### PR TITLE
v0.5.2

### DIFF
--- a/backend/nodes/properties/inputs/file_inputs.py
+++ b/backend/nodes/properties/inputs/file_inputs.py
@@ -42,9 +42,9 @@ def TorchFileInput() -> Dict:
     return FileInput("pth", "Pretrained Model", None, ["pth", "pt"])
 
 
-def DirectoryInput() -> Dict:
+def DirectoryInput(hasHandle: bool = False) -> Dict:
     """Input for submitting a local directory"""
-    return FileInput("directory", "Directory", None, ["directory"])
+    return FileInput("directory", "Base Directory", None, ["directory"], hasHandle)
 
 
 def ImageExtensionDropdown() -> Dict:

--- a/backend/nodes/properties/outputs/file_outputs.py
+++ b/backend/nodes/properties/outputs/file_outputs.py
@@ -17,6 +17,13 @@ def ImageFileOutput(label: str = "image") -> Dict:
     )
 
 
+def DirectoryOutput(label: str = "directory") -> Dict:
+    """Output for saving to a directory"""
+    return FileOutput(
+        label, "Image Directory", ["directory"]
+    )
+
+
 def OnnxFileOutput() -> Dict:
     """Output for saving a .onnx file"""
     return FileOutput("onnx", "ONNX Model", ["onnx"])

--- a/backend/nodes/utility_nodes.py
+++ b/backend/nodes/utility_nodes.py
@@ -85,6 +85,6 @@ class TextAppendNode(NodeBase):
         str2: str,
         str3: str = None,
         str4: str = None,
-    ) -> int:
+    ) -> str:
         strings = [x for x in [str1, str2, str3, str4] if x != "" and x is not None]
         return separator.join(strings)

--- a/backend/run.py
+++ b/backend/run.py
@@ -152,7 +152,7 @@ async def run(request: Request):
 def get_extra_data(category, node, node_output):
     if category == "Image":
         if node == "Load Image":
-            img, name = node_output
+            img, name, dirname = node_output
 
             if img.ndim == 2:
                 h, w, c = img.shape[:2], 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chainner",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chainner",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "GPLv3",
       "dependencies": {
         "@chakra-ui/icons": "^1.0.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chainner",
   "productName": "chaiNNer",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A flowchart based image processing GUI",
   "main": ".webpack/main",
   "scripts": {

--- a/src/components/inputs/DirectoryInput.jsx
+++ b/src/components/inputs/DirectoryInput.jsx
@@ -9,8 +9,9 @@ import { GlobalContext } from '../../helpers/GlobalNodeState.jsx';
 const DirectoryInput = memo(({
   label, id, index, isLocked,
 }) => {
-  const { useInputData } = useContext(GlobalContext);
+  const { useInputData, useNodeLock } = useContext(GlobalContext);
   const [directory, setDirectory] = useInputData(id, index);
+  const [, , isInputLocked] = useNodeLock(id, index);
 
   const onButtonClick = async () => {
     const { canceled, filePaths } = await ipcRenderer.invoke('dir-select', directory ?? '');
@@ -36,7 +37,7 @@ const DirectoryInput = memo(({
         draggable={false}
         cursor="pointer"
         className="nodrag"
-        disabled={isLocked}
+        disabled={isLocked || isInputLocked}
       />
     </InputGroup>
   );

--- a/src/helpers/checkNodeValidity.js
+++ b/src/helpers/checkNodeValidity.js
@@ -16,7 +16,7 @@ const checkNodeValidity = ({
   // Finds all empty inputs
   const emptyInputs = Object.entries(inputData)
     .filter(
-      ([key, value]) => Object.keys(nonOptionalInputs).includes(String(key))
+      ([key, value]) => !inputs[key].optional
     && (value === '' || value === undefined || value === null)
     && !edgeTargetIndexes.includes(String(key)),
     )

--- a/src/helpers/dependencies.js
+++ b/src/helpers/dependencies.js
@@ -4,11 +4,11 @@ export default (isNvidiaAvailable) => [
   {
     name: 'OpenCV',
     packageName: 'opencv-python',
-    version: '4.5.5.62',
+    version: '4.5.5.64',
   }, {
     name: 'NumPy',
     packageName: 'numpy',
-    version: '1.22.1',
+    version: '1.22.3',
   }, {
     name: 'PyTorch',
     packageName: 'torch',
@@ -18,10 +18,9 @@ export default (isNvidiaAvailable) => [
     name: 'NCNN',
     packageName: 'ncnn-vulkan',
     version: '2022.4.1',
-  },
-  {
+  }, {
     name: 'Pillow (PIL)',
     packageName: 'Pillow',
-    version: '9.0.1',
+    version: '9.1.0',
   },
 ];

--- a/src/helpers/migrations.js
+++ b/src/helpers/migrations.js
@@ -143,6 +143,43 @@ const toV05 = (data) => {
 };
 
 // ==============
+//    v0.5.2
+// ==============
+const toV052 = (data) => {
+  const newData = { ...data };
+  newData.nodes.forEach((node) => {
+    // Update any connections coming out of a Load Image or Load Image (Iterator)
+    if (['Load Image', 'Load Image (Iterator)'].includes(node.data.type)) {
+      const edges = newData.edges.filter((e) => e.source === node.id);
+      edges.forEach((edge) => {
+        const edgeIndex = edge.sourceHandle.slice(-2);
+        // Image Name node moves different amounts in different Load Image types
+        const newEdgeIndex = (node.data.type === 'Load Image') ? '2' : '3';
+        if (edgeIndex === '-1') {
+          edge.sourceHandle = edge.source.concat('-', newEdgeIndex);
+        }
+      });
+    }
+
+    // Update any connections and inputs to Save Image Node
+    if (node.data.type === 'Save Image') {
+      // Shift text input values >=2 down one place and set Relative Path to empty string
+      node.data.inputData[4] = node.data.inputData[3];
+      node.data.inputData[3] = node.data.inputData[2];
+      node.data.inputData[2] = '';
+      // Move Image Name connection if it exists
+      const edges = newData.edges.filter((e) => e.target === node.id);
+      edges.forEach((edge) => {
+        const edgeIndex = edge.targetHandle.slice(-2);
+        if (edgeIndex === '-2')
+          edge.targetHandle = edge.target.concat('-', '3');
+      });
+    }
+  });
+  return newData;
+};
+
+// ==============
 
 export const migrate = (_version, data) => {
   let convertedData = data;
@@ -162,6 +199,11 @@ export const migrate = (_version, data) => {
   // v0.3.x & v0.4.x to v0.5.0
   if (semver.lt(version, '0.5.0')) {
     convertedData = toV05(convertedData);
+  }
+
+  // v0.5.0 & v0.5.1 to v0.5.2
+  if (semver.lt(version, '0.5.2')) {
+    convertedData = toV052(convertedData);
   }
 
   return convertedData;


### PR DESCRIPTION
-Added Image Directory to Load Image and Load Image (Iterator)
-Added Relative Path to Load Image (Iterator) and Save Image
-Added DirectoryOutput
-Added handle and locking to DirectoryInput
-Fixed validation bug that could result in optional inputs being incorrectly checked for input
-Added 0.5.2 migration to update Load (both) and Save Image nodes
-Updated OpenCV, numpy, and Pillow dependency requirements
-Incremented version number