### PR TITLE
Fuzzy search query

### DIFF
--- a/src/components/NodeSelectorPanel.jsx
+++ b/src/components/NodeSelectorPanel.jsx
@@ -5,9 +5,7 @@ import {
   InputGroup, InputLeftElement, Tab, TabList, TabPanel,
   TabPanels, Tabs, Text, Tooltip, useColorModeValue, useDisclosure, Wrap, WrapItem,
 } from '@chakra-ui/react';
-import {
-  memo, useContext, useEffect, useState,
-} from 'react';
+import { memo, useContext, useState } from 'react';
 import { GlobalContext } from '../helpers/contexts/GlobalNodeState.jsx';
 import getNodeAccentColor from '../helpers/getNodeAccentColors.js';
 import { IconFactory } from './CustomIcons.jsx';
@@ -28,13 +26,49 @@ const onDragStart = (event, nodeCategory, node) => {
   event.dataTransfer.effectAllowed = 'move';
 };
 
+/**
+ * @param {string} query
+ * @returns {(name: string) => boolean}
+ */
+function createSearchPredicate(query) {
+  const pattern = new RegExp(`^${[...query].map((char) => {
+    const hex = `\\u{${char.codePointAt(0).toString(16)}}`;
+    return `[^${hex}]*${hex}`;
+  }).join('')}`, 'iu');
+  return (name) => pattern.test(name);
+}
+
+/**
+ * Returns a map that maps for sub category name to all nodes of that sub category.
+ *
+ * The nodes per namespace are sorted by name.
+ * @param {any[]} nodes
+ * @returns {Map<string, any[]>}
+ */
+function getNamespaces(nodes) {
+  const map = new Map();
+  nodes
+    .sort((a, b) => {
+      let keyA = a.subcategory.toUpperCase();
+      let keyB = b.subcategory.toUpperCase();
+      if (keyA !== keyB) return keyA.localeCompare(keyB);
+      keyA = a.name.toUpperCase();
+      keyB = b.name.toUpperCase();
+      return keyA.localeCompare(keyB);
+    })
+    .forEach((n) => {
+      const list = map.get(n.subcategory) ?? [];
+      map.set(n.subcategory, list);
+      list.push(n);
+    });
+  return map;
+}
+
 // eslint-disable-next-line react/prop-types
 const NodeSelector = ({ data, height }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const handleChange = (event) => setSearchQuery(event.target.value);
   const { isOpen, onOpen, onClose } = useDisclosure();
-
-  const [namespaces, setNamespaces] = useState([]);
 
   const {
     createNode, reactFlowInstance, reactFlowWrapper, useHoveredNode,
@@ -42,27 +76,7 @@ const NodeSelector = ({ data, height }) => {
 
   const [, setHoveredNode] = useHoveredNode;
 
-  useEffect(() => {
-    const set = {};
-    data?.forEach(({ category, nodes }) => {
-      nodes
-        .sort(
-          (a, b) => (a.subcategory + a.name)
-            .toUpperCase()
-            .localeCompare((b.subcategory + b.name).toUpperCase()),
-        )
-        .forEach((node) => {
-          const namespace = node.subcategory;
-          if (!set[category]) {
-            set[category] = [];
-          }
-          if (!set[category].includes(namespace)) {
-            set[category].push(namespace);
-          }
-        });
-    });
-    setNamespaces(set);
-  }, [data]);
+  const matchesSearchQuery = createSearchPredicate(searchQuery);
 
   return (
     <Box
@@ -128,126 +142,122 @@ const NodeSelector = ({ data, height }) => {
                 allowMultiple
                 defaultIndex={data.map((item, index) => index)}
               >
-                {data.map(({ category, nodes }) => (
-                  <AccordionItem key={category}>
-                    <AccordionButton>
-                      <HStack
-                        flex="1"
-                        textAlign="left"
-                      >
-                        {IconFactory(category, getNodeAccentColor(category))}
-                        <Heading size="5xl">{category}</Heading>
-                      </HStack>
-                      <AccordionIcon />
-                    </AccordionButton>
-                    <AccordionPanel>
-                      {namespaces[category] && namespaces[category]
-                      // eslint-disable-next-line max-len
-                      // This is super terrible but I have no better way of filtering for these at the moment
-                      // I could probably cache this in the namespace object but w/e
-                        .filter(
-                          (namespace) => `${category} ${namespace} ${nodes.filter((e) => e.subcategory === namespace).map((e) => e.name).join(' ')}`.toLowerCase().includes(searchQuery.toLowerCase()),
-                        )
-                        .map((namespace) => (
-                          <Box key={namespace}>
-                            <Center w="full">
-                              <HStack w="full">
-                                <Divider orientation="horizontal" />
-                                <Text
-                                  casing="uppercase"
-                                  color="#71809699"
-                                  fontSize="sm"
-                                  w="auto"
-                                  whiteSpace="nowrap"
-                                >
-                                  {namespace}
-                                </Text>
-                                <Divider orientation="horizontal" />
-                              </HStack>
-                            </Center>
-                            <Wrap>
-                              {nodes
-                                .filter(
-                                  (e) => `${category} ${namespace} ${e.name}`.toLowerCase().includes(searchQuery.toLowerCase()),
-                                )
-                                .filter(
-                                  (e) => e.subcategory
-                                    .toUpperCase()
-                                    .includes(namespace.toUpperCase()),
-                                )
-                                .filter((e) => e.nodeType !== 'iteratorHelper')
-                                .sort(
-                                  (a, b) => a.name.toUpperCase()
-                                    .localeCompare(b.name.toUpperCase()),
-                                )
-                                .map((node) => (
-                                  <WrapItem
-                                    key={node.name}
-                                    p={1}
-                                    w="full"
+                {data.map(({ category, nodes: categoryNodes }) => {
+                  const matchingNodes = matchesSearchQuery(category)
+                    ? categoryNodes
+                    : categoryNodes.filter((n) => (
+                      matchesSearchQuery(`${category} ${n.name}`)
+                      || matchesSearchQuery(`${n.subcategory} ${n.name}`)
+                    ));
+
+                  // don't show categories without nodes
+                  if (matchingNodes.length === 0) return null;
+
+                  const namespaceMap = getNamespaces(matchingNodes);
+
+                  return (
+                    <AccordionItem key={category}>
+                      <AccordionButton>
+                        <HStack
+                          flex="1"
+                          textAlign="left"
+                        >
+                          {IconFactory(category, getNodeAccentColor(category))}
+                          <Heading size="5xl">{category}</Heading>
+                        </HStack>
+                        <AccordionIcon />
+                      </AccordionButton>
+                      <AccordionPanel>
+                        {[...namespaceMap]
+                          .map(([namespace, nodes]) => (
+                            <Box key={namespace}>
+                              <Center w="full">
+                                <HStack w="full">
+                                  <Divider orientation="horizontal" />
+                                  <Text
+                                    casing="uppercase"
+                                    color="#71809699"
+                                    fontSize="sm"
+                                    w="auto"
+                                    whiteSpace="nowrap"
                                   >
-                                    <Tooltip
-                                      closeOnMouseDown
-                                      hasArrow
-                                      borderRadius={8}
-                                      label={node.description}
-                                      px={2}
-                                      py={1}
+                                    {namespace}
+                                  </Text>
+                                  <Divider orientation="horizontal" />
+                                </HStack>
+                              </Center>
+                              <Wrap>
+                                {nodes
+                                  .filter((e) => e.nodeType !== 'iteratorHelper')
+                                  .map((node) => (
+                                    <WrapItem
+                                      key={node.name}
+                                      p={1}
+                                      w="full"
                                     >
-                                      <Center
-                                        draggable
-                                        boxSizing="content-box"
-                                        display="block"
-                                        w="100%"
-                                        onDoubleClick={() => {
-                                          const {
-                                            height: wHeight, width,
-                                          } = reactFlowWrapper.current.getBoundingClientRect();
-
-                                          const position = reactFlowInstance.project({
-                                            x: width / 2,
-                                            y: wHeight / 2,
-                                          });
-
-                                          const nodeData = {
-                                            category,
-                                            type: node.name,
-                                          };
-
-                                          createNode({
-                                            nodeType: node.nodeType,
-                                            position,
-                                            data: nodeData,
-                                            defaultNodes: node.defaultNodes,
-                                          });
-                                        }}
-                                        onDragEnd={() => {
-                                          setHoveredNode(null);
-                                        }}
-                                        onDragStart={
-                                            (event) => {
-                                              onDragStart(event, category, node);
-                                              setHoveredNode(null);
-                                            }
-                                          }
+                                      <Tooltip
+                                        closeOnMouseDown
+                                        hasArrow
+                                        borderRadius={8}
+                                        label={node.description}
+                                        px={2}
+                                        py={1}
                                       >
-                                        <RepresentativeNode
-                                          category={category}
-                                          icon={node.icon}
-                                          subcategory={node.subcategory}
-                                          type={node.name}
-                                        />
-                                      </Center>
-                                    </Tooltip>
-                                  </WrapItem>
-                                ))}
-                            </Wrap>
-                          </Box>
-                        ))}
+                                        <Center
+                                          draggable
+                                          boxSizing="content-box"
+                                          display="block"
+                                          w="100%"
+                                          onDoubleClick={() => {
+                                            const {
+                                              height: wHeight, width,
+                                            } = reactFlowWrapper.current.getBoundingClientRect();
 
-                    </AccordionPanel>
-                  </AccordionItem>
-                ))}
+                                            const position = reactFlowInstance.project({
+                                              x: width / 2,
+                                              y: wHeight / 2,
+                                            });
+
+                                            const nodeData = {
+                                              category,
+                                              type: node.name,
+                                            };
+
+                                            createNode({
+                                              nodeType: node.nodeType,
+                                              position,
+                                              data: nodeData,
+                                              defaultNodes: node.defaultNodes,
+                                            });
+                                          }}
+                                          onDragEnd={() => {
+                                            setHoveredNode(null);
+                                          }}
+                                          onDragStart={
+                                              (event) => {
+                                                onDragStart(event, category, node);
+                                                setHoveredNode(null);
+                                              }
+                                            }
+                                        >
+                                          <RepresentativeNode
+                                            category={category}
+                                            icon={node.icon}
+                                            subcategory={node.subcategory}
+                                            type={node.name}
+                                          />
+                                        </Center>
+                                      </Tooltip>
+                                    </WrapItem>
+                                  ))}
+                              </Wrap>
+                            </Box>
+                          ))}
+
+                      </AccordionPanel>
+                    </AccordionItem>
+                  );
+                })}
                 <AccordionItem>
                   <Center
                     p={10}


### PR DESCRIPTION
This implements a fuzzy search. Basically, as long as a sequence of character (with any number of characters in between these characters) matches the search string, the node matches. Or in other words, the search `foo` will be interpreted as the regex `f.*o.*o`.

I also refactored the "super terrible" code around namespaces and filtering matches. Categories with no nodes will no longer be displayed.

Exampe: Matches for `pylo`

![image](https://user-images.githubusercontent.com/20878432/165631493-6a123b85-cfa6-441a-b8fc-1437de11225c.png)
(Sorry for the blurry screenshot, see #52)