### PR TITLE
Use `npm ci`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,6 @@ jobs:
               with:
                   node-version: 14
             - name: install dependencies
-              run: npm install
+              run: npm ci
             - name: build
               run: npm run make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
               with:
                   node-version: 14
             - name: install dependencies
-              run: npm install
+              run: npm ci
             - name: publish
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`npm ci` should be used in the workflows instead of `npm install`. These commands are mostly the same, with the major difference being that `npm ci` is faster and errors out if `package.json` and `package-lock.json` are inconsistent.