### PR TITLE
Require at least npm7

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To batch upscale, create an Image Iterator node and drag the nodes you want to u
 
 ## Building chaiNNer Yourself
 
-I provide pre-built versions of chaiNNer here on GitHub. However, if you would like to build chaiNNer yourself, simply run `npm install` to install all the nodejs dependencies, and `npm run make` to build the application.
+I provide pre-built versions of chaiNNer here on GitHub. However, if you would like to build chaiNNer yourself, simply run `npm install` (make sure that you have at least npm v7 installed) to install all the nodejs dependencies, and `npm run make` to build the application.
 
 ## GPU Support
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "name": "Joey Ballentine",
     "email": "joeyjballentine@gmail.com"
   },
+  "engines": {
+    "npm": ">=7.0.0"
+  },
   "license": "GPLv3",
   "config": {
     "forge": {


### PR DESCRIPTION
After #63, I added the >=npm@7 requirement to the README + `package.json`.

However, npm@6 doesn't respect the `engines` field, so it doesn't do much in terms of protection.