### PR TITLE
Remove ESLint from pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,13 @@
     "make-win-zip": "cross-env NODE_ENV=production electron-forge make --targets @electron-forge/maker-zip --platform win32",
     "make-mac-zip": "cross-env NODE_ENV=production electron-forge make --targets @electron-forge/maker-zip --platform darwin",
     "publish": "cross-env NODE_ENV=production electron-forge publish",
-    "lint": "npm run lint-js && black --check ./backend",
+    "lint": "npm run lint-js && npm run lint-py",
     "lint-js": "eslint . --ext \".js,.jsx,.ts,.tsx\"",
+    "lint-py": "black --check ./backend",
     "lint-fix": "eslint . --fix --ext \".js,.jsx,.ts,.tsx\" && black ./backend"
   },
   "pre-commit": [
-    "lint"
+    "lint-py"
   ],
   "keywords": [],
   "author": {


### PR DESCRIPTION
With typescript now fully integrated into ESLint, ESLint will do a full project type check. This is quite slow, and the other type-related rules aren't cheap either.

The effect is that I have to wait like ~20sec per commit, which is REALLY annoying. So I just removed ESLint from he pre-commit hook. ESLint is still checked by our CI, so with a PR based-workflow that shouldn't be an issue.