### PR TITLE
Minor improvements to alert box

### DIFF
--- a/src/helpers/contexts/AlertBoxContext.tsx
+++ b/src/helpers/contexts/AlertBoxContext.tsx
@@ -27,7 +27,8 @@ export enum AlertType {
 
 export const AlertBoxContext = createContext<Readonly<AlertBox>>({} as AlertBox);
 
-export const AlertBoxProvider = ({ children }: React.PropsWithChildren<Record<string, never>>) => {
+// eslint-disable-next-line @typescript-eslint/ban-types
+export const AlertBoxProvider = ({ children }: React.PropsWithChildren<{}>) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [alertType, setAlertType] = useState<AlertType>(AlertType.INFO);
   const [title, setTitle] = useState<string | null>(null);

--- a/src/helpers/contexts/AlertBoxContext.tsx
+++ b/src/helpers/contexts/AlertBoxContext.tsx
@@ -11,7 +11,8 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import { app, clipboard } from 'electron';
-import React, { createContext, useEffect, useRef, useState } from 'react';
+import React, { createContext, useRef, useState, useMemo } from 'react';
+import { assertNever } from '../util';
 
 interface AlertBox {
   showMessageBox: (_alertType: AlertType, _title: string | null, _message: string) => void;
@@ -24,16 +25,12 @@ export enum AlertType {
   CRIT_ERROR = 'Critical Error',
 }
 
-type Props = {
-  children: JSX.Element;
-};
-
 export const AlertBoxContext = createContext<Readonly<AlertBox>>({} as AlertBox);
 
-export const AlertBoxProvider = ({ children }: Props) => {
+export const AlertBoxProvider = ({ children }: React.PropsWithChildren<Record<string, never>>) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [alertType, setAlertType] = useState<AlertType>(AlertType.INFO);
-  const [title, setTitle] = useState<string | null>();
+  const [title, setTitle] = useState<string | null>(null);
   const [message, setMessage] = useState<string>('');
   const cancelRef = useRef<HTMLButtonElement>(null);
 
@@ -96,14 +93,11 @@ export const AlertBoxProvider = ({ children }: Props) => {
           </Button>
         );
       default:
-        return <></>;
+        return assertNever(type);
     }
   };
 
-  const [buttons, setButtons] = useState<JSX.Element>(<></>);
-  useEffect(() => {
-    setButtons(getButtons(alertType));
-  }, [alertType]);
+  const buttons = useMemo(() => getButtons(alertType), [alertType, cancelRef, message, onClose]);
 
   return (
     <AlertBoxContext.Provider value={{ showMessageBox }}>

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,9 +1,12 @@
 import { constants } from 'fs';
 import fs from 'fs/promises';
 
-// eslint-disable-next-line import/prefer-default-export
 export const checkFileExists = (file: string): Promise<boolean> =>
   fs.access(file, constants.F_OK).then(
     () => true,
     () => false
   );
+
+export const assertNever = (value: never): never => {
+  throw new Error(`Unreachable code path. The value ${String(value)} is invalid.`);
+};


### PR DESCRIPTION
Hey @joeyballentine, I saw your commits in the GH feed channel and wanted to give you some feedback.

- `type Props = { children: JSX.Element; };`: React actually has a helper type for that: `React.PropsWithChildren<T>`. Given some props type, this type will add the `children` property to it.
   This helper type also uses the correct type for `children`. React actually might pass a string, number, null or even array as children.
- `const [title, setTitle] = useState<string | null>();`. If you don't provide a default, `useState` will default to undefined, so `title` will actually have the type `string | null | undefined`.
- `default: return <></>;`: We can use a pretty cool pattern here. You do an exhaustive match of all possible enum variants here, so we know that the `default` case is unreachable. We can actually let TS verify that we do exhaustive matching correctly. By adding a little helper function [`assertNever`](https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#union-exhaustiveness-checking), TS will now yell at us if we ever forget one enum variant.
- `const [buttons, setButtons] = useState<JSX.Element>(<></>);` This has nothing to do with TS: I'm pretty sure `useMemo` is more idiomatic here.