### PR TITLE
Faster image preview

### DIFF
--- a/src/components/inputs/previews/ImagePreview.tsx
+++ b/src/components/inputs/previews/ImagePreview.tsx
@@ -91,7 +91,7 @@ export default memo(({ path, category, nodeType, id }: ImagePreviewProps) => {
             maxH="200px"
             // fallbackSrc="https://via.placeholder.com/200"
             maxW="200px"
-            src={(img?.image ? `data:image/png;base64,${img.image}` : undefined) || path || ''}
+            src={img?.image || path}
           />
           {img && path && (
             <HStack>


### PR DESCRIPTION
I changed the backend implementation of the image preview to downscale images that are too large. This makes the Load Image preview **a lot** faster and doesn't cause lag for large images anymore. It also saves quite a bit of RAM since the frontend only has a small PNG in memory.

The only downside is that the preview will be slightly blurry if you zoom in. And I mean really zoom in. You'll only notice that the image is smaller than the original once you hit max zoom level. People with DPI scaling will notice this sooner of course.