### PR TITLE
Added useAsyncEffect

### DIFF
--- a/src/components/inputs/previews/ImagePreview.tsx
+++ b/src/components/inputs/previews/ImagePreview.tsx
@@ -1,8 +1,8 @@
 import { Center, HStack, Image, Spinner, Tag, VStack } from '@chakra-ui/react';
-import log from 'electron-log';
-import { memo, useContext, useEffect, useState } from 'react';
+import { memo, useContext, useState } from 'react';
 import { getBackend } from '../../../helpers/Backend';
 import { SettingsContext } from '../../../helpers/contexts/SettingsContext';
+import { useAsyncEffect } from '../../../helpers/hooks/useAsyncEffect';
 import { checkFileExists } from '../../../helpers/util';
 
 interface ImageObject {
@@ -45,14 +45,15 @@ export default memo(({ path, category, nodeType, id }: ImagePreviewProps) => {
   const [isCpu] = useIsCpu;
   const [isFp16] = useIsFp16;
 
-  useEffect(() => {
-    (async () => {
-      if (path) {
-        setIsLoading(true);
-        const fileExists = await checkFileExists(path);
-        if (fileExists) {
-          try {
-            const result = await backend.runIndividual<ImageObject | null>({
+  useAsyncEffect(
+    {
+      supplier: async (token) => {
+        token.causeEffect(() => setIsLoading(true));
+
+        if (path) {
+          const fileExists = await checkFileExists(path);
+          if (fileExists) {
+            return backend.runIndividual<ImageObject | null>({
               category,
               node: nodeType,
               id,
@@ -60,18 +61,15 @@ export default memo(({ path, category, nodeType, id }: ImagePreviewProps) => {
               isCpu,
               isFp16,
             });
-
-            if (result) {
-              setImg(result);
-            }
-          } catch (err) {
-            log.error(err);
           }
         }
-        setIsLoading(false);
-      }
-    })();
-  }, [path]);
+        return null;
+      },
+      successEffect: setImg,
+      finallyEffect: () => setIsLoading(false),
+    },
+    [path]
+  );
 
   return (
     <Center w="full">

--- a/src/helpers/hooks/useAsyncEffect.ts
+++ b/src/helpers/hooks/useAsyncEffect.ts
@@ -1,0 +1,137 @@
+// eslint-disable-next-line max-classes-per-file
+import { useEffect } from 'react';
+import log from 'electron-log';
+
+/**
+ * An object that can tell whether the current operation has been canceled.
+ */
+export interface CancellationToken {
+  /**
+   * Whether the operation has been canceled.
+   *
+   * Once an operation has been canceled, it can **never** be un-canceled again.
+   */
+  readonly isCanceled: boolean;
+  /**
+   * A simply utility function that will throw a {@link CancellationError} if the operation has
+   * been canceled.
+   *
+   * @throws {CancellationError}
+   */
+  readonly checkCanceled: () => void;
+  /**
+   * Causes an effect.
+   *
+   * The given function is allowed to have side effects, but it MUST be synchronous.
+   * Asynchronous effects are not supported.
+   *
+   * This utility function is equivalent to:
+   *
+   * ```
+   * checkCanceled();
+   * fn();
+   * ```
+   *
+   * @throws {CancellationError}
+   */
+  readonly causeEffect: (fn: () => void) => void;
+}
+
+export class CancellationError extends Error {}
+
+/**
+ * An object that controls and holds whether an operation has been changed.
+ *
+ * The controller also implements the {@link CancellationToken} interface. You can pass the controller directly into
+ * function that need a token. TypeScript will ensure that the token is used correctly.
+ */
+export class CancellationController implements CancellationToken {
+  isCanceled = false;
+
+  readonly checkCanceled = (): void => {
+    if (this.isCanceled) {
+      throw new CancellationError();
+    }
+  };
+
+  readonly causeEffect = (fn: () => void) => {
+    this.checkCanceled();
+    fn();
+  };
+
+  /**
+   * A simply utility function that will set `isCanceled` to `true`.
+   */
+  readonly cancel = (): void => {
+    this.isCanceled = true;
+  };
+}
+
+interface UseAsyncEffectOptions<T> {
+  supplier: (token: CancellationToken) => Promise<T>;
+  successEffect: (value: T) => void;
+  catchEffect?: (error: unknown) => void;
+  finallyEffect?: () => void;
+}
+
+/**
+ * This is an async replacement for `useEffect`.
+ *
+ * The supplier must not cause effects, except as a callback in `token.effect`.
+ * The `successEffect`, `catchEffect`, and `finallyEffect` functions are allowed to cause effects
+ * and must be executing synchronously.
+ *
+ * THis whole operation is roughly equivalent to:
+ *
+ * ```
+ * supplier().then(successEffect).catch(catchEffect ?? log.error).finally(finallyEffect)
+ * ```
+ */
+export const useAsyncEffect = <T>(
+  { supplier, successEffect, catchEffect, finallyEffect }: UseAsyncEffectOptions<T>,
+  dependencies?: readonly unknown[]
+) => {
+  useEffect(() => {
+    const controller = new CancellationController();
+
+    const cEffect = (reason: unknown) => {
+      if (catchEffect) {
+        try {
+          catchEffect?.(reason);
+        } catch (error) {
+          log.error('catchEffect unexpectedly threw an error:', error);
+        }
+      } else {
+        log.error(reason);
+      }
+    };
+    const fEffect = () => {
+      if (finallyEffect) {
+        try {
+          finallyEffect?.();
+        } catch (error) {
+          log.error('finallyEffect unexpectedly threw an error:', error);
+        }
+      }
+    };
+
+    supplier(controller).then(
+      (result) => {
+        if (controller.isCanceled) return;
+        try {
+          successEffect(result);
+        } catch (error) {
+          cEffect(error);
+        }
+        fEffect?.();
+      },
+      (reason) => {
+        if (controller.isCanceled) return;
+        cEffect(reason);
+        fEffect?.();
+      }
+    );
+
+    return controller.cancel;
+  }, dependencies);
+};


### PR DESCRIPTION
`useAsyncEffect` effect is the async equivalent of `useEffect`. The function guarantees that (if used correctly) no race conditions will occur.

Right now, all the async function all over the React code likely cause many subtle race conditions. `useAsyncEffect` is my attempt at eliminating those. However, it not nearly enough and I will refactor a few other components in the next few days as well.