### PR TITLE
Added checksums to save files

### DIFF
--- a/src/helpers/SaveFile.ts
+++ b/src/helpers/SaveFile.ts
@@ -1,5 +1,7 @@
 import { readFile, writeFile } from 'fs/promises';
 import { Edge, Node, Viewport } from 'react-flow-renderer';
+import { createHash } from 'crypto';
+import semver from 'semver';
 import { EdgeData, NodeData } from '../common-types';
 import { migrate } from './migrations';
 
@@ -9,36 +11,68 @@ export interface SaveData {
     viewport: Viewport;
 }
 
-interface ParsedSaveFile {
-    version: string;
-    timestamp: string;
-    content: SaveData;
+export interface ParsedSaveData extends SaveData {
+    tamperedWith: boolean;
 }
 
+interface RawSaveFile {
+    version: string;
+    content: SaveData;
+    timestamp?: string;
+    checksum?: string;
+}
+
+const hash = (value: string): string => {
+    return createHash('md5').update(value).digest('hex');
+};
+
 export class SaveFile {
-    static parse(content: string): SaveData {
-        if (!/^\s*\{/.test(content)) {
+    static parse(value: string): ParsedSaveData {
+        if (!/^\s*\{/.test(value)) {
             // base64 decode
             // eslint-disable-next-line no-param-reassign
-            content = Buffer.from(content, 'base64').toString('utf-8');
+            value = Buffer.from(value, 'base64').toString('utf-8');
         }
 
-        const data = JSON.parse(content) as ParsedSaveFile | { version: undefined };
+        const rawData = JSON.parse(value) as RawSaveFile | (SaveData & { version?: never });
 
-        if (data.version) {
-            return migrate(data.version, data.content) as SaveData;
+        let data: SaveData;
+        let tamperedWith = false;
+        if (rawData.version) {
+            const { version, content, checksum } = rawData;
+            if (checksum !== undefined) {
+                // checksum is present
+                tamperedWith = checksum !== hash(JSON.stringify(content));
+            } else {
+                // checksum was added after v0.6.1, so any saves >0.6.1 without a checksum have
+                // been tampered with
+                tamperedWith = semver.gt(version, '0.6.1');
+            }
+
+            data = migrate(version, content) as SaveData;
+        } else {
+            // Legacy files
+            data = migrate(null, rawData) as SaveData;
         }
-        // Legacy files
-        return migrate(null, data) as SaveData;
+
+        return {
+            ...data,
+            tamperedWith,
+        };
     }
 
-    static async read(path: string): Promise<SaveData> {
+    static async read(path: string): Promise<ParsedSaveData> {
         return SaveFile.parse(await readFile(path, { encoding: 'utf-8' }));
     }
 
     static stringify(content: SaveData, version: string): string {
-        const json = JSON.stringify({ version, content, timestamp: new Date() });
-        return Buffer.from(json).toString('base64');
+        const data: RawSaveFile = {
+            version,
+            content,
+            timestamp: new Date().toISOString(),
+            checksum: hash(JSON.stringify(content)),
+        };
+        return JSON.stringify(data);
     }
 
     static async write(path: string, saveData: SaveData, version: string): Promise<void> {

--- a/src/helpers/safeIpc.ts
+++ b/src/helpers/safeIpc.ts
@@ -10,7 +10,7 @@ import {
 } from 'electron';
 import { Systeminformation } from 'systeminformation';
 import { PythonKeys } from '../common-types';
-import { SaveData } from './SaveFile';
+import { ParsedSaveData, SaveData } from './SaveFile';
 
 interface ChannelInfo<ReturnType, Args extends unknown[] = []> {
     returnType: ReturnType;
@@ -41,7 +41,7 @@ interface Channels {
         string | undefined,
         [saveData: SaveData, savePath: string | undefined]
     >;
-    'get-cli-open': ChannelInfo<SaveData | undefined>;
+    'get-cli-open': ChannelInfo<ParsedSaveData | undefined>;
     'kill-backend': ChannelInfo<void>;
     'restart-backend': ChannelInfo<void>;
     'relaunch-application': ChannelInfo<void>;
@@ -56,7 +56,7 @@ interface Channels {
     'downloading-python': ChannelInfo<never>;
     'extracting-python': ChannelInfo<never>;
     'file-new': ChannelInfo<never>;
-    'file-open': ChannelInfo<never, [saveData: SaveData, openedFilePath: string]>;
+    'file-open': ChannelInfo<never, [saveData: ParsedSaveData, openedFilePath: string]>;
     'file-save-as': ChannelInfo<never>;
     'file-save': ChannelInfo<never>;
     'finish-loading': ChannelInfo<never>;


### PR DESCRIPTION
This PR implements the idea of [this comment](https://github.com/joeyballentine/chaiNNer/issues/56#issuecomment-1111322718). Save files now have a checksum to detect tampering and are no longer base64 encoded. While tampering is currently detected, the UI doesn't show a warning yet.