### PR TITLE
Fixed NumberInput returning strings

### DIFF
--- a/backend/nodes/image_nodes.py
+++ b/backend/nodes/image_nodes.py
@@ -258,7 +258,7 @@ class ImResizeByFactorNode(NodeBase):
         interpolation = int(interpolation)
 
         h, w = img.shape[:2]
-        out_dims = (math.ceil(w * float(scale)), math.ceil(h * float(scale)))
+        out_dims = (math.ceil(w * scale), math.ceil(h * scale))
 
         # Try PIL first, otherwise fall back to cv2
         if pil is Image:
@@ -865,14 +865,12 @@ class GaussianBlurNode(NodeBase):
     def run(
         self,
         img: np.ndarray,
-        amount_x: str,
-        amount_y: str,
+        amount_x: float,
+        amount_y: float,
     ) -> np.ndarray:
         """Adjusts the sharpening of an image"""
 
-        blurred = cv2.GaussianBlur(
-            img, (0, 0), sigmaX=float(amount_x), sigmaY=float(amount_y)
-        )
+        blurred = cv2.GaussianBlur(img, (0, 0), sigmaX=amount_x, sigmaY=amount_y)
 
         return blurred
 
@@ -896,11 +894,11 @@ class SharpenNode(NodeBase):
     def run(
         self,
         img: np.ndarray,
-        amount: int,
+        amount: float,
     ) -> np.ndarray:
         """Adjusts the sharpening of an image"""
 
-        blurred = cv2.GaussianBlur(img, (0, 0), float(amount))
+        blurred = cv2.GaussianBlur(img, (0, 0), amount)
         img = cv2.addWeighted(img, 2.0, blurred, -1.0, 0)
 
         return img
@@ -1438,8 +1436,6 @@ class AverageColorFixNode(NodeBase):
         self, input_img: np.ndarray, ref_img: np.ndarray, scale_factor: float
     ) -> np.ndarray:
         """Fixes the average color of the input image"""
-
-        scale_factor = float(scale_factor)
 
         input_img = normalize(input_img)
         ref_img = normalize(ref_img)

--- a/src/components/inputs/NumberInput.tsx
+++ b/src/components/inputs/NumberInput.tsx
@@ -5,7 +5,7 @@ import {
     NumberInputField,
     NumberInputStepper,
 } from '@chakra-ui/react';
-import { memo, useContext } from 'react';
+import { memo, useContext, useState } from 'react';
 import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 
 interface NumericalInputProps {
@@ -25,15 +25,21 @@ const NumericalInput = memo(
     ({ label, id, index, def, min, max, precision, step, type, isLocked }: NumericalInputProps) => {
         const { useInputData, useNodeLock } = useContext(GlobalContext);
         // TODO: make sure this is always a number
-        const [input, setInput] = useInputData<string | number>(id, index);
+        const [input, setInput] = useInputData<number>(id, index);
+        const [inputString, setInputString] = useState(String(input));
         const [, , isInputLocked] = useNodeLock(id, index);
 
         const handleChange = (numberAsString: string, numberAsNumber: number) => {
-            if (type.includes('odd')) {
-                // Make the number odd if need be
-                setInput(String(numberAsNumber + (1 - (numberAsNumber % 2))));
-            } else {
-                setInput(numberAsString);
+            setInputString(numberAsString);
+
+            if (!Number.isNaN(numberAsNumber)) {
+                if (type.includes('odd')) {
+                    // Make the number odd if need be
+                    // round up the nearest odd number
+                    // eslint-disable-next-line no-param-reassign
+                    numberAsNumber += 1 - (numberAsNumber % 2);
+                }
+                setInput(numberAsNumber);
             }
         };
 
@@ -48,7 +54,7 @@ const NumericalInput = memo(
                 placeholder={label}
                 precision={precision}
                 step={step ?? 1}
-                value={String(input)}
+                value={inputString}
                 onChange={handleChange}
             >
                 <NumberInputField />


### PR DESCRIPTION
fixes #58

On the python side, I only removed float casts. From what I see, the integer inputs don't actually guarantee integers rn, so int casting is still a good idea.