### PR TITLE
Improve input types

### DIFF
--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -14,7 +14,7 @@ export interface IteratorSize extends Size {
     offsetLeft: number;
 }
 
-export type InputValue = InputSchemaValue | { id: string };
+export type InputValue = InputSchemaValue | { id: string } | undefined;
 export type InputSchemaValue = string | number;
 export interface InputOption {
     option: string;
@@ -33,7 +33,7 @@ export interface Output {
     readonly label: string;
 }
 
-export type InputData = Readonly<Record<number, InputValue | undefined>>;
+export type InputData = Readonly<Record<number, InputValue>>;
 
 export interface NodeSchema {
     readonly name: string;
@@ -82,7 +82,7 @@ export interface UsableData {
     category: string;
     node: string;
     id: string;
-    inputs: Record<number, InputValue | null | undefined>;
+    inputs: Record<number, InputValue | null>;
     outputs: Record<number, InputValue>;
     child: boolean;
     children?: string[];

--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -15,7 +15,7 @@ export interface IteratorSize extends Size {
 }
 
 export type InputValue = InputSchemaValue | { id: string };
-export type InputSchemaValue = string | number | undefined;
+export type InputSchemaValue = string | number;
 export interface InputOption {
     option: string;
     value: InputSchemaValue;
@@ -33,7 +33,7 @@ export interface Output {
     readonly label: string;
 }
 
-export type InputData = Readonly<Record<number, InputValue>>;
+export type InputData = Readonly<Record<number, InputValue | undefined>>;
 
 export interface NodeSchema {
     readonly name: string;

--- a/src/helpers/SchemaMap.ts
+++ b/src/helpers/SchemaMap.ts
@@ -41,7 +41,7 @@ export class SchemaMap {
     }
 
     getDefaultInput(category: string, name: string): InputData {
-        const defaultData: Record<number, InputValue | undefined> = {};
+        const defaultData: Record<number, InputValue> = {};
         const { inputs } = this.get(category, name);
         if (inputs) {
             inputs.forEach((input, i) => {

--- a/src/helpers/SchemaMap.ts
+++ b/src/helpers/SchemaMap.ts
@@ -41,7 +41,7 @@ export class SchemaMap {
     }
 
     getDefaultInput(category: string, name: string): InputData {
-        const defaultData: Record<number, InputValue> = {};
+        const defaultData: Record<number, InputValue | undefined> = {};
         const { inputs } = this.get(category, name);
         if (inputs) {
             inputs.forEach((input, i) => {

--- a/src/helpers/contexts/GlobalNodeState.tsx
+++ b/src/helpers/contexts/GlobalNodeState.tsx
@@ -483,7 +483,7 @@ export const GlobalProvider = ({
                 inputData = schemata.getDefaultInput(nodeData.category, nodeData.type);
             }
 
-            const inputDataByIndex = inputData[index] as T;
+            const inputDataByIndex = inputData[index] as T | undefined;
             const setInputData = (data: T) => {
                 const nodeCopy: Node<Mutable<NodeData>> = copyNode(nodeById);
                 if (nodeCopy && nodeCopy.data) {

--- a/src/helpers/contexts/GlobalNodeState.tsx
+++ b/src/helpers/contexts/GlobalNodeState.tsx
@@ -49,7 +49,7 @@ interface Global {
     setReactFlowInstance: SetState<ReactFlowInstance<NodeData, EdgeData> | null>;
     reactFlowWrapper: React.RefObject<Element>;
     isValidConnection: (connection: Readonly<Connection>) => boolean;
-    useInputData: <T extends InputValue>(
+    useInputData: <T extends NonNullable<InputValue>>(
         id: string,
         index: number
     ) => readonly [T | undefined, (data: T) => void];
@@ -467,7 +467,7 @@ export const GlobalProvider = ({
 
     const useInputData = useCallback(
         // eslint-disable-next-line prefer-arrow-functions/prefer-arrow-functions, func-names
-        function <T extends InputValue>(
+        function <T extends NonNullable<InputValue>>(
             id: string,
             index: number
         ): readonly [T | undefined, (data: T) => void] {


### PR DESCRIPTION
InputSchemaValue should not be undefined because that's not a valid value of node schemas. Instead, InputValue should be nullable.