### PR TITLE
Fixed pil check

### DIFF
--- a/backend/nodes/image_nodes.py
+++ b/backend/nodes/image_nodes.py
@@ -256,7 +256,7 @@ class ImResizeByFactorNode(NodeBase):
         out_dims = (math.ceil(w * scale), math.ceil(h * scale))
 
         # Try PIL first, otherwise fall back to cv2
-        if pil is Image:
+        if pil is not None:
             pimg = pil.fromarray((img * 255).astype("uint8"))
             pimg = pimg.resize(out_dims, resample=interpolation)
             result = np.array(pimg).astype("float32") / 255
@@ -297,7 +297,7 @@ class ImResizeToResolutionNode(NodeBase):
         out_dims = (int(width), int(height))
 
         # Try PIL first, otherwise fall back to cv2
-        if pil is Image:
+        if pil is not None:
             pimg = pil.fromarray((img * 255).astype("uint8"))
             pimg = pimg.resize(out_dims, resample=interpolation)
             result = np.array(pimg).astype("float32") / 255


### PR DESCRIPTION
The pil check was not implemented correctly.

```py
try:
    from PIL import Image
    pil = Image
except ImportError:
    pil = Image = None
```

So if pil is not available, `pil` and `Image` will be none, so of course `pil is Image` is true.