### PR TITLE
Added missing key in NodeSelector

### DIFF
--- a/src/components/NodeSelectorPanel/NodeSelectorPanel.tsx
+++ b/src/components/NodeSelectorPanel/NodeSelectorPanel.tsx
@@ -194,6 +194,7 @@ const NodeSelector = ({ schemata, height }: NodeSelectorProps) => {
                                                                 )
                                                                 .map((node) => (
                                                                     <RepresentativeNodeWrapper
+                                                                        key={node.name}
                                                                         node={node}
                                                                     />
                                                                 ))}


### PR DESCRIPTION
React was throwing a little hissy fit over a missing `key`.