### PR TITLE
Split global state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,8 +36,10 @@
         "react-hotkeys-hook": "^3.4.4",
         "react-icons": "^4.2.0",
         "react-markdown": "^8.0.3",
+        "scheduler": "^0.22.0",
         "semver": "^7.3.5",
         "systeminformation": "^5.9.15",
+        "use-context-selector": "^1.3.10",
         "use-debounce": "^7.0.1",
         "use-http": "^1.0.26",
         "uuid": "^8.3.2"
@@ -16869,6 +16871,15 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
     "node_modules/react-draggable": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.4.tgz",
@@ -17666,12 +17677,11 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
+      "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/schema-utils": {
@@ -19834,6 +19844,25 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-context-selector": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/use-context-selector/-/use-context-selector-1.3.10.tgz",
+      "integrity": "sha512-xprS9YQ0F56IPTOjev+Lm+TWZD7Pa20+slBeaClt4YtOOoHKFOF3A9Cfr7LDcX2QIZ9VTyxXCnA6/WhL4Cm47g==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": "*",
+        "react-native": "*",
+        "scheduler": ">=0.19.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
           "optional": true
         }
       }
@@ -33723,6 +33752,17 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-draggable": {
@@ -34329,12 +34369,11 @@
       }
     },
     "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
+      "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "schema-utils": {
@@ -36039,6 +36078,12 @@
       "requires": {
         "tslib": "^2.0.0"
       }
+    },
+    "use-context-selector": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/use-context-selector/-/use-context-selector-1.3.10.tgz",
+      "integrity": "sha512-xprS9YQ0F56IPTOjev+Lm+TWZD7Pa20+slBeaClt4YtOOoHKFOF3A9Cfr7LDcX2QIZ9VTyxXCnA6/WhL4Cm47g==",
+      "requires": {}
     },
     "use-debounce": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -191,8 +191,10 @@
     "react-hotkeys-hook": "^3.4.4",
     "react-icons": "^4.2.0",
     "react-markdown": "^8.0.3",
+    "scheduler": "^0.22.0",
     "semver": "^7.3.5",
     "systeminformation": "^5.9.15",
+    "use-context-selector": "^1.3.10",
     "use-debounce": "^7.0.1",
     "use-http": "^1.0.26",
     "uuid": "^8.3.2"

--- a/src/components/CustomEdge.tsx
+++ b/src/components/CustomEdge.tsx
@@ -4,7 +4,11 @@ import { memo, useContext, useMemo, useState } from 'react';
 import { EdgeProps, getBezierPath, getEdgeCenter } from 'react-flow-renderer';
 import { useDebouncedCallback } from 'use-debounce';
 import { EdgeData } from '../common-types';
-import { GlobalContext } from '../helpers/contexts/GlobalNodeState';
+import {
+    GlobalConstantsContext,
+    GlobalContext,
+    GlobalSettersContext,
+} from '../helpers/contexts/GlobalNodeState';
 import getNodeAccentColors from '../helpers/getNodeAccentColors';
 import shadeColor from '../helpers/shadeColor';
 
@@ -33,7 +37,9 @@ const CustomEdge = ({
         [sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition]
     );
 
-    const { removeEdgeById, nodes, useHoveredNode, schemata } = useContext(GlobalContext);
+    const { nodes } = useContext(GlobalContext);
+    const { schemata } = useContext(GlobalConstantsContext);
+    const { removeEdgeById, setHoveredNode } = useContext(GlobalSettersContext);
 
     const parentNode = useMemo(() => nodes.find((n) => source === n.id), [source]);
 
@@ -55,8 +61,6 @@ const CustomEdge = ({
     const hoverTimeout = useDebouncedCallback(() => {
         setIsHovered(false);
     }, 7500);
-
-    const [, setHoveredNode] = useHoveredNode;
 
     return (
         <g

--- a/src/components/CustomEdge.tsx
+++ b/src/components/CustomEdge.tsx
@@ -5,7 +5,7 @@ import { EdgeProps, getBezierPath, getEdgeCenter } from 'react-flow-renderer';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { useDebouncedCallback } from 'use-debounce';
 import { EdgeData } from '../common-types';
-import { GlobalChainContext, GlobalContext } from '../helpers/contexts/GlobalNodeState';
+import { GlobalVolatileContext, GlobalContext } from '../helpers/contexts/GlobalNodeState';
 import getNodeAccentColors from '../helpers/getNodeAccentColors';
 import shadeColor from '../helpers/shadeColor';
 
@@ -34,7 +34,7 @@ const CustomEdge = ({
         [sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition]
     );
 
-    const parentNode = useContextSelector(GlobalChainContext, (c) =>
+    const parentNode = useContextSelector(GlobalVolatileContext, (c) =>
         c.nodes.find((n) => source === n.id)
     );
 

--- a/src/components/CustomEdge.tsx
+++ b/src/components/CustomEdge.tsx
@@ -2,7 +2,7 @@ import { DeleteIcon } from '@chakra-ui/icons';
 import { Center, IconButton, useColorModeValue } from '@chakra-ui/react';
 import { memo, useMemo, useState } from 'react';
 import { EdgeProps, getBezierPath, getEdgeCenter } from 'react-flow-renderer';
-import { useContext } from 'use-context-selector';
+import { useContext, useContextSelector } from 'use-context-selector';
 import { useDebouncedCallback } from 'use-debounce';
 import { EdgeData } from '../common-types';
 import { GlobalChainContext, GlobalContext } from '../helpers/contexts/GlobalNodeState';
@@ -34,7 +34,7 @@ const CustomEdge = ({
         [sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition]
     );
 
-    const { nodes } = useContext(GlobalChainContext);
+    const nodes = useContextSelector(GlobalChainContext, (c) => c.nodes);
     const { schemata, removeEdgeById, setHoveredNode } = useContext(GlobalContext);
 
     const parentNode = useMemo(() => nodes.find((n) => source === n.id), [source]);

--- a/src/components/CustomEdge.tsx
+++ b/src/components/CustomEdge.tsx
@@ -1,7 +1,8 @@
 import { DeleteIcon } from '@chakra-ui/icons';
 import { Center, IconButton, useColorModeValue } from '@chakra-ui/react';
-import { memo, useContext, useMemo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { EdgeProps, getBezierPath, getEdgeCenter } from 'react-flow-renderer';
+import { useContext } from 'use-context-selector';
 import { useDebouncedCallback } from 'use-debounce';
 import { EdgeData } from '../common-types';
 import { GlobalChainContext, GlobalContext } from '../helpers/contexts/GlobalNodeState';

--- a/src/components/CustomEdge.tsx
+++ b/src/components/CustomEdge.tsx
@@ -4,11 +4,7 @@ import { memo, useContext, useMemo, useState } from 'react';
 import { EdgeProps, getBezierPath, getEdgeCenter } from 'react-flow-renderer';
 import { useDebouncedCallback } from 'use-debounce';
 import { EdgeData } from '../common-types';
-import {
-    GlobalConstantsContext,
-    GlobalContext,
-    GlobalSettersContext,
-} from '../helpers/contexts/GlobalNodeState';
+import { GlobalChainContext, GlobalContext } from '../helpers/contexts/GlobalNodeState';
 import getNodeAccentColors from '../helpers/getNodeAccentColors';
 import shadeColor from '../helpers/shadeColor';
 
@@ -37,9 +33,8 @@ const CustomEdge = ({
         [sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition]
     );
 
-    const { nodes } = useContext(GlobalContext);
-    const { schemata } = useContext(GlobalConstantsContext);
-    const { removeEdgeById, setHoveredNode } = useContext(GlobalSettersContext);
+    const { nodes } = useContext(GlobalChainContext);
+    const { schemata, removeEdgeById, setHoveredNode } = useContext(GlobalContext);
 
     const parentNode = useMemo(() => nodes.find((n) => source === n.id), [source]);
 

--- a/src/components/CustomEdge.tsx
+++ b/src/components/CustomEdge.tsx
@@ -34,10 +34,11 @@ const CustomEdge = ({
         [sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition]
     );
 
-    const nodes = useContextSelector(GlobalChainContext, (c) => c.nodes);
-    const { schemata, removeEdgeById, setHoveredNode } = useContext(GlobalContext);
+    const parentNode = useContextSelector(GlobalChainContext, (c) =>
+        c.nodes.find((n) => source === n.id)
+    );
 
-    const parentNode = useMemo(() => nodes.find((n) => source === n.id), [source]);
+    const { schemata, removeEdgeById, setHoveredNode } = useContext(GlobalContext);
 
     const [isHovered, setIsHovered] = useState(false);
 

--- a/src/components/DependencyManager.tsx
+++ b/src/components/DependencyManager.tsx
@@ -38,8 +38,9 @@ import {
 } from '@chakra-ui/react';
 import { exec as _exec, spawn } from 'child_process';
 import log from 'electron-log';
-import { memo, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import semver from 'semver';
+import { useContext } from 'use-context-selector';
 import util from 'util';
 import { PythonKeys } from '../common-types';
 import { SettingsContext } from '../helpers/contexts/SettingsContext';

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,7 +17,11 @@ import { EdgeData, NodeData, UsableData } from '../common-types';
 import { getBackend } from '../helpers/Backend';
 import checkNodeValidity from '../helpers/checkNodeValidity';
 import { AlertBoxContext, AlertType } from '../helpers/contexts/AlertBoxContext';
-import { GlobalContext } from '../helpers/contexts/GlobalNodeState';
+import {
+    GlobalConstantsContext,
+    GlobalContext,
+    GlobalSettersContext,
+} from '../helpers/contexts/GlobalNodeState';
 import { SettingsContext } from '../helpers/contexts/SettingsContext';
 import { useAsyncEffect } from '../helpers/hooks/useAsyncEffect';
 import {
@@ -96,8 +100,9 @@ interface HeaderProps {
 }
 
 const Header = ({ port }: HeaderProps) => {
-    const { useAnimateEdges, nodes, edges, schemata, setIteratorPercent } =
-        useContext(GlobalContext);
+    const { nodes, edges } = useContext(GlobalContext);
+    const { schemata } = useContext(GlobalConstantsContext);
+    const { useAnimateEdges, setIteratorPercent } = useContext(GlobalSettersContext);
 
     const { useIsCpu, useIsFp16 } = useContext(SettingsContext);
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,8 +9,9 @@ import {
     Tag,
     useColorModeValue,
 } from '@chakra-ui/react';
-import { memo, useContext, useState } from 'react';
+import { memo, useState } from 'react';
 import { IoPause, IoPlay, IoStop } from 'react-icons/io5';
+import { useContext } from 'use-context-selector';
 import { ExecutionContext } from '../helpers/contexts/ExecutionContext';
 import { useAsyncEffect } from '../helpers/hooks/useAsyncEffect';
 import { ipcRenderer } from '../helpers/safeIpc';

--- a/src/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -1,7 +1,7 @@
 import { Box, Center, Tooltip } from '@chakra-ui/react';
 import { DragEvent, memo } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { useContext } from 'use-context-selector';
+import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeSchema } from '../../common-types';
 import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import RepresentativeNode from '../node/RepresentativeNode';
@@ -19,7 +19,8 @@ interface RepresentativeNodeWrapperProps {
 }
 
 const RepresentativeNodeWrapper = ({ node }: RepresentativeNodeWrapperProps) => {
-    const { createNode, reactFlowInstance } = useContext(GlobalChainContext);
+    const createNode = useContextSelector(GlobalChainContext, (c) => c.createNode);
+    const reactFlowInstance = useContextSelector(GlobalChainContext, (c) => c.reactFlowInstance);
     const { reactFlowWrapper, setHoveredNode } = useContext(GlobalContext);
 
     return (

--- a/src/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -3,7 +3,7 @@ import { DragEvent, memo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeSchema } from '../../common-types';
-import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalVolatileContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import RepresentativeNode from '../node/RepresentativeNode';
 
 const onDragStart = (event: DragEvent<HTMLDivElement>, node: NodeSchema) => {
@@ -19,8 +19,8 @@ interface RepresentativeNodeWrapperProps {
 }
 
 const RepresentativeNodeWrapper = ({ node }: RepresentativeNodeWrapperProps) => {
-    const createNode = useContextSelector(GlobalChainContext, (c) => c.createNode);
-    const reactFlowInstance = useContextSelector(GlobalChainContext, (c) => c.reactFlowInstance);
+    const createNode = useContextSelector(GlobalVolatileContext, (c) => c.createNode);
+    const reactFlowInstance = useContextSelector(GlobalVolatileContext, (c) => c.reactFlowInstance);
     const { reactFlowWrapper, setHoveredNode } = useContext(GlobalContext);
 
     return (

--- a/src/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -1,5 +1,6 @@
 import { Box, Center, Tooltip } from '@chakra-ui/react';
 import { DragEvent, memo } from 'react';
+import { useReactFlow } from 'react-flow-renderer';
 import ReactMarkdown from 'react-markdown';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeSchema } from '../../common-types';
@@ -20,8 +21,8 @@ interface RepresentativeNodeWrapperProps {
 
 const RepresentativeNodeWrapper = ({ node }: RepresentativeNodeWrapperProps) => {
     const createNode = useContextSelector(GlobalVolatileContext, (c) => c.createNode);
-    const reactFlowInstance = useContextSelector(GlobalVolatileContext, (c) => c.reactFlowInstance);
     const { reactFlowWrapper, setHoveredNode } = useContext(GlobalContext);
+    const reactFlowInstance = useReactFlow();
 
     return (
         <Box
@@ -43,7 +44,7 @@ const RepresentativeNodeWrapper = ({ node }: RepresentativeNodeWrapperProps) => 
                     display="block"
                     w="100%"
                     onDoubleClick={() => {
-                        if (!reactFlowInstance || !reactFlowWrapper.current) return;
+                        if (!reactFlowWrapper.current) return;
 
                         const { height: wHeight, width } =
                             reactFlowWrapper.current.getBoundingClientRect();

--- a/src/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -2,7 +2,11 @@ import { Box, Center, Tooltip } from '@chakra-ui/react';
 import { DragEvent, memo, useContext } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { NodeSchema } from '../../common-types';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import {
+    GlobalConstantsContext,
+    GlobalContext,
+    GlobalSettersContext,
+} from '../../helpers/contexts/GlobalNodeState';
 import RepresentativeNode from '../node/RepresentativeNode';
 
 const onDragStart = (event: DragEvent<HTMLDivElement>, node: NodeSchema) => {
@@ -18,10 +22,9 @@ interface RepresentativeNodeWrapperProps {
 }
 
 const RepresentativeNodeWrapper = ({ node }: RepresentativeNodeWrapperProps) => {
-    const { createNode, reactFlowInstance, reactFlowWrapper, useHoveredNode } =
-        useContext(GlobalContext);
-
-    const [, setHoveredNode] = useHoveredNode;
+    const { createNode, reactFlowInstance } = useContext(GlobalContext);
+    const { reactFlowWrapper } = useContext(GlobalConstantsContext);
+    const { setHoveredNode } = useContext(GlobalSettersContext);
 
     return (
         <Box

--- a/src/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -2,11 +2,7 @@ import { Box, Center, Tooltip } from '@chakra-ui/react';
 import { DragEvent, memo, useContext } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { NodeSchema } from '../../common-types';
-import {
-    GlobalConstantsContext,
-    GlobalContext,
-    GlobalSettersContext,
-} from '../../helpers/contexts/GlobalNodeState';
+import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import RepresentativeNode from '../node/RepresentativeNode';
 
 const onDragStart = (event: DragEvent<HTMLDivElement>, node: NodeSchema) => {
@@ -22,9 +18,8 @@ interface RepresentativeNodeWrapperProps {
 }
 
 const RepresentativeNodeWrapper = ({ node }: RepresentativeNodeWrapperProps) => {
-    const { createNode, reactFlowInstance } = useContext(GlobalContext);
-    const { reactFlowWrapper } = useContext(GlobalConstantsContext);
-    const { setHoveredNode } = useContext(GlobalSettersContext);
+    const { createNode, reactFlowInstance } = useContext(GlobalChainContext);
+    const { reactFlowWrapper, setHoveredNode } = useContext(GlobalContext);
 
     return (
         <Box

--- a/src/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -1,6 +1,7 @@
 import { Box, Center, Tooltip } from '@chakra-ui/react';
-import { DragEvent, memo, useContext } from 'react';
+import { DragEvent, memo } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { useContext } from 'use-context-selector';
 import { NodeSchema } from '../../common-types';
 import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import RepresentativeNode from '../node/RepresentativeNode';

--- a/src/components/ReactFlowBox.tsx
+++ b/src/components/ReactFlowBox.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Box, useColorModeValue } from '@chakra-ui/react';
 import log from 'electron-log';
-import { DragEvent, memo, useCallback, useContext, useEffect, useMemo } from 'react';
+import { DragEvent, memo, useCallback, useEffect, useMemo } from 'react';
 import ReactFlow, {
     Background,
     BackgroundVariant,
@@ -14,6 +14,7 @@ import ReactFlow, {
     useEdgesState,
     useNodesState,
 } from 'react-flow-renderer';
+import { useContext } from 'use-context-selector';
 import { EdgeData, NodeData, NodeSchema } from '../common-types';
 import { GlobalChainContext, GlobalContext } from '../helpers/contexts/GlobalNodeState';
 import { MenuFunctionsContext } from '../helpers/contexts/MenuFunctions';

--- a/src/components/ReactFlowBox.tsx
+++ b/src/components/ReactFlowBox.tsx
@@ -15,7 +15,8 @@ import ReactFlow, {
     useNodesState,
 } from 'react-flow-renderer';
 import { EdgeData, NodeData, NodeSchema } from '../common-types';
-import { GlobalContext } from '../helpers/contexts/GlobalNodeState';
+import { GlobalContext, GlobalSettersContext } from '../helpers/contexts/GlobalNodeState';
+import { MenuFunctionsContext } from '../helpers/contexts/MenuFunctions';
 import { SettingsContext } from '../helpers/contexts/SettingsContext';
 import { snapToGrid } from '../helpers/reactFlowUtil';
 
@@ -29,20 +30,11 @@ interface ReactFlowBoxProps {
     wrapperRef: React.RefObject<HTMLDivElement>;
 }
 const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) => {
-    const {
-        nodes,
-        edges,
-        createNode,
-        createConnection,
-        reactFlowInstance,
-        setReactFlowInstance,
-        setNodes,
-        setEdges,
-        onMoveEnd,
-        zoom,
-        useMenuCloseFunctions,
-        useHoveredNode,
-    } = useContext(GlobalContext);
+    const { nodes, edges, createNode, createConnection, reactFlowInstance, zoom } =
+        useContext(GlobalContext);
+    const { setReactFlowInstance, setNodes, setEdges, onMoveEnd, setHoveredNode } =
+        useContext(GlobalSettersContext);
+    const { closeAllMenus } = useContext(MenuFunctionsContext);
 
     const { useSnapToGrid } = useContext(SettingsContext);
 
@@ -162,8 +154,6 @@ const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) =
         event.dataTransfer.dropEffect = 'move';
     }, []);
 
-    const [, setHoveredNode] = useHoveredNode;
-
     const onDragStart = useCallback(() => {
         setHoveredNode(null);
     }, []);
@@ -213,8 +203,6 @@ const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) =
     const onNodeContextMenu = useCallback((event, node) => {
         // TODO implement this
     }, []);
-
-    const [closeAllMenus] = useMenuCloseFunctions;
 
     return (
         <Box

--- a/src/components/ReactFlowBox.tsx
+++ b/src/components/ReactFlowBox.tsx
@@ -15,7 +15,7 @@ import ReactFlow, {
     useNodesState,
 } from 'react-flow-renderer';
 import { EdgeData, NodeData, NodeSchema } from '../common-types';
-import { GlobalContext, GlobalSettersContext } from '../helpers/contexts/GlobalNodeState';
+import { GlobalChainContext, GlobalContext } from '../helpers/contexts/GlobalNodeState';
 import { MenuFunctionsContext } from '../helpers/contexts/MenuFunctions';
 import { SettingsContext } from '../helpers/contexts/SettingsContext';
 import { snapToGrid } from '../helpers/reactFlowUtil';
@@ -31,9 +31,9 @@ interface ReactFlowBoxProps {
 }
 const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) => {
     const { nodes, edges, createNode, createConnection, reactFlowInstance, zoom } =
-        useContext(GlobalContext);
+        useContext(GlobalChainContext);
     const { setReactFlowInstance, setNodes, setEdges, onMoveEnd, setHoveredNode } =
-        useContext(GlobalSettersContext);
+        useContext(GlobalContext);
     const { closeAllMenus } = useContext(MenuFunctionsContext);
 
     const { useSnapToGrid } = useContext(SettingsContext);

--- a/src/components/ReactFlowBox.tsx
+++ b/src/components/ReactFlowBox.tsx
@@ -16,7 +16,7 @@ import ReactFlow, {
 } from 'react-flow-renderer';
 import { useContext } from 'use-context-selector';
 import { EdgeData, NodeData, NodeSchema } from '../common-types';
-import { GlobalChainContext, GlobalContext } from '../helpers/contexts/GlobalNodeState';
+import { GlobalVolatileContext, GlobalContext } from '../helpers/contexts/GlobalNodeState';
 import { MenuFunctionsContext } from '../helpers/contexts/MenuFunctions';
 import { SettingsContext } from '../helpers/contexts/SettingsContext';
 import { snapToGrid } from '../helpers/reactFlowUtil';
@@ -30,7 +30,7 @@ interface ReactFlowBoxProps {
 }
 const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) => {
     const { nodes, edges, createNode, createConnection, reactFlowInstance, zoom } =
-        useContext(GlobalChainContext);
+        useContext(GlobalVolatileContext);
     const { setReactFlowInstance, setNodes, setEdges, onMoveEnd, setHoveredNode } =
         useContext(GlobalContext);
     const { closeAllMenus } = useContext(MenuFunctionsContext);

--- a/src/components/ReactFlowBox.tsx
+++ b/src/components/ReactFlowBox.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Box, useColorModeValue } from '@chakra-ui/react';
 import log from 'electron-log';
-import { createContext, DragEvent, memo, useCallback, useContext, useEffect, useMemo } from 'react';
+import { DragEvent, memo, useCallback, useContext, useEffect, useMemo } from 'react';
 import ReactFlow, {
     Background,
     BackgroundVariant,
@@ -19,8 +19,6 @@ import { GlobalChainContext, GlobalContext } from '../helpers/contexts/GlobalNod
 import { MenuFunctionsContext } from '../helpers/contexts/MenuFunctions';
 import { SettingsContext } from '../helpers/contexts/SettingsContext';
 import { snapToGrid } from '../helpers/reactFlowUtil';
-
-export const NodeDataContext = createContext({});
 
 const STARTING_Z_INDEX = 50;
 

--- a/src/components/ReactFlowBox.tsx
+++ b/src/components/ReactFlowBox.tsx
@@ -10,11 +10,11 @@ import ReactFlow, {
     EdgeTypes,
     Node,
     NodeTypes,
-    ReactFlowInstance,
     useEdgesState,
     useNodesState,
+    useReactFlow,
 } from 'react-flow-renderer';
-import { useContext } from 'use-context-selector';
+import { useContext, useContextSelector } from 'use-context-selector';
 import { EdgeData, NodeData, NodeSchema } from '../common-types';
 import { GlobalVolatileContext, GlobalContext } from '../helpers/contexts/GlobalNodeState';
 import { MenuFunctionsContext } from '../helpers/contexts/MenuFunctions';
@@ -29,13 +29,12 @@ interface ReactFlowBoxProps {
     wrapperRef: React.RefObject<HTMLDivElement>;
 }
 const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) => {
-    const { nodes, edges, createNode, createConnection, reactFlowInstance, zoom } =
-        useContext(GlobalVolatileContext);
-    const { setReactFlowInstance, setNodes, setEdges, onMoveEnd, setHoveredNode } =
-        useContext(GlobalContext);
+    const { nodes, edges, createNode, createConnection, zoom } = useContext(GlobalVolatileContext);
+    const { setNodes, setEdges, onMoveEnd, setHoveredNode } = useContext(GlobalContext);
     const { closeAllMenus } = useContext(MenuFunctionsContext);
 
-    const { useSnapToGrid } = useContext(SettingsContext);
+    const useSnapToGrid = useContextSelector(SettingsContext, (c) => c.useSnapToGrid);
+    const reactFlowInstance = useReactFlow();
 
     const [_nodes, _setNodes, onNodesChange] = useNodesState<NodeData>([]);
     const [_edges, _setEdges, onEdgesChange] = useEdgesState<EdgeData>([]);
@@ -138,15 +137,6 @@ const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) =
         }
     }, [snapToGridAmount, nodes]);
 
-    const onInit = useCallback(
-        (rfi: ReactFlowInstance<NodeData, EdgeData>) => {
-            if (!reactFlowInstance) {
-                setReactFlowInstance(rfi);
-            }
-        },
-        [reactFlowInstance]
-    );
-
     const onDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
         event.preventDefault();
         // eslint-disable-next-line no-param-reassign
@@ -162,7 +152,7 @@ const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) =
             // log.info('dropped');
             event.preventDefault();
 
-            if (!reactFlowInstance || !wrapperRef.current) return;
+            if (!wrapperRef.current) return;
 
             const reactFlowBounds = wrapperRef.current.getBoundingClientRect();
 
@@ -233,7 +223,6 @@ const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) =
                 onEdgesChange={onEdgesChange}
                 onEdgesDelete={onEdgesDelete}
                 // onSelectionChange={setSelectedElements}
-                onInit={onInit}
                 onMoveEnd={onMoveEnd}
                 onNodeContextMenu={onNodeContextMenu}
                 onNodeDragStop={onNodeDragStop}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -29,7 +29,8 @@ import {
     useDisclosure,
     VStack,
 } from '@chakra-ui/react';
-import { memo, useContext, useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
+import { useContext } from 'use-context-selector';
 import { SettingsContext } from '../helpers/contexts/SettingsContext';
 import { useAsyncEffect } from '../helpers/hooks/useAsyncEffect';
 import { ipcRenderer } from '../helpers/safeIpc';

--- a/src/components/inputs/DirectoryInput.tsx
+++ b/src/components/inputs/DirectoryInput.tsx
@@ -11,9 +11,9 @@ interface DirectoryInputProps {
 }
 
 const DirectoryInput = memo(({ id, index, isLocked }: DirectoryInputProps) => {
-    const { useInputData, useNodeLock } = useContext(GlobalContext);
+    const { useInputData, isNodeInputLocked } = useContext(GlobalContext);
     const [directory, setDirectory] = useInputData<string>(id, index);
-    const [, , isInputLocked] = useNodeLock(id, index);
+    const isInputLocked = isNodeInputLocked(id, index);
 
     const onButtonClick = async () => {
         const { canceled, filePaths } = await ipcRenderer.invoke('dir-select', directory ?? '');

--- a/src/components/inputs/DirectoryInput.tsx
+++ b/src/components/inputs/DirectoryInput.tsx
@@ -3,13 +3,13 @@ import { memo } from 'react';
 import { BsFolderPlus } from 'react-icons/bs';
 import { useContextSelector } from 'use-context-selector';
 import { ipcRenderer } from '../../helpers/safeIpc';
-import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalVolatileContext } from '../../helpers/contexts/GlobalNodeState';
 import { InputProps } from './props';
 
 type DirectoryInputProps = InputProps;
 
 const DirectoryInput = memo(({ id, index, isLocked, useInputData }: DirectoryInputProps) => {
-    const isInputLocked = useContextSelector(GlobalChainContext, (c) =>
+    const isInputLocked = useContextSelector(GlobalVolatileContext, (c) =>
         c.isNodeInputLocked(id, index)
     );
 

--- a/src/components/inputs/DirectoryInput.tsx
+++ b/src/components/inputs/DirectoryInput.tsx
@@ -2,13 +2,13 @@ import { Input, InputGroup, InputLeftElement } from '@chakra-ui/react';
 import { memo, useContext } from 'react';
 import { BsFolderPlus } from 'react-icons/bs';
 import { ipcRenderer } from '../../helpers/safeIpc';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 import { InputProps } from './props';
 
 type DirectoryInputProps = InputProps;
 
 const DirectoryInput = memo(({ id, index, isLocked, useInputData }: DirectoryInputProps) => {
-    const { isNodeInputLocked } = useContext(GlobalContext);
+    const { isNodeInputLocked } = useContext(GlobalChainContext);
 
     const [directory, setDirectory] = useInputData<string>(index);
     const isInputLocked = isNodeInputLocked(id, index);

--- a/src/components/inputs/DirectoryInput.tsx
+++ b/src/components/inputs/DirectoryInput.tsx
@@ -1,7 +1,7 @@
 import { Input, InputGroup, InputLeftElement } from '@chakra-ui/react';
 import { memo } from 'react';
 import { BsFolderPlus } from 'react-icons/bs';
-import { useContext } from 'use-context-selector';
+import { useContextSelector } from 'use-context-selector';
 import { ipcRenderer } from '../../helpers/safeIpc';
 import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 import { InputProps } from './props';
@@ -9,7 +9,7 @@ import { InputProps } from './props';
 type DirectoryInputProps = InputProps;
 
 const DirectoryInput = memo(({ id, index, isLocked, useInputData }: DirectoryInputProps) => {
-    const { isNodeInputLocked } = useContext(GlobalChainContext);
+    const isNodeInputLocked = useContextSelector(GlobalChainContext, (c) => c.isNodeInputLocked);
 
     const [directory, setDirectory] = useInputData<string>(index);
     const isInputLocked = isNodeInputLocked(id, index);

--- a/src/components/inputs/DirectoryInput.tsx
+++ b/src/components/inputs/DirectoryInput.tsx
@@ -9,10 +9,11 @@ import { InputProps } from './props';
 type DirectoryInputProps = InputProps;
 
 const DirectoryInput = memo(({ id, index, isLocked, useInputData }: DirectoryInputProps) => {
-    const isNodeInputLocked = useContextSelector(GlobalChainContext, (c) => c.isNodeInputLocked);
+    const isInputLocked = useContextSelector(GlobalChainContext, (c) =>
+        c.isNodeInputLocked(id, index)
+    );
 
     const [directory, setDirectory] = useInputData<string>(index);
-    const isInputLocked = isNodeInputLocked(id, index);
 
     const onButtonClick = async () => {
         const { canceled, filePaths } = await ipcRenderer.invoke('dir-select', directory ?? '');

--- a/src/components/inputs/DirectoryInput.tsx
+++ b/src/components/inputs/DirectoryInput.tsx
@@ -1,6 +1,7 @@
 import { Input, InputGroup, InputLeftElement } from '@chakra-ui/react';
-import { memo, useContext } from 'react';
+import { memo } from 'react';
 import { BsFolderPlus } from 'react-icons/bs';
+import { useContext } from 'use-context-selector';
 import { ipcRenderer } from '../../helpers/safeIpc';
 import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 import { InputProps } from './props';

--- a/src/components/inputs/DirectoryInput.tsx
+++ b/src/components/inputs/DirectoryInput.tsx
@@ -3,16 +3,14 @@ import { memo, useContext } from 'react';
 import { BsFolderPlus } from 'react-icons/bs';
 import { ipcRenderer } from '../../helpers/safeIpc';
 import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { InputProps } from './props';
 
-interface DirectoryInputProps {
-    id: string;
-    index: number;
-    isLocked?: boolean;
-}
+type DirectoryInputProps = InputProps;
 
-const DirectoryInput = memo(({ id, index, isLocked }: DirectoryInputProps) => {
-    const { useInputData, isNodeInputLocked } = useContext(GlobalContext);
-    const [directory, setDirectory] = useInputData<string>(id, index);
+const DirectoryInput = memo(({ id, index, isLocked, useInputData }: DirectoryInputProps) => {
+    const { isNodeInputLocked } = useContext(GlobalContext);
+
+    const [directory, setDirectory] = useInputData<string>(index);
     const isInputLocked = isNodeInputLocked(id, index);
 
     const onButtonClick = async () => {

--- a/src/components/inputs/DropDownInput.tsx
+++ b/src/components/inputs/DropDownInput.tsx
@@ -1,18 +1,14 @@
 import { Select } from '@chakra-ui/react';
-import { ChangeEvent, memo, useContext, useEffect } from 'react';
+import { ChangeEvent, memo, useEffect } from 'react';
 import { InputOption } from '../../common-types';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { InputProps } from './props';
 
-interface DropDownInputProps {
-    id: string;
-    index: number;
-    isLocked?: boolean;
+interface DropDownInputProps extends InputProps {
     options: readonly InputOption[];
 }
 
-const DropDownInput = memo(({ options, id, index, isLocked }: DropDownInputProps) => {
-    const { useInputData } = useContext(GlobalContext);
-    const [selection, setSelection] = useInputData<string | number>(id, index);
+const DropDownInput = memo(({ options, index, useInputData, isLocked }: DropDownInputProps) => {
+    const [selection, setSelection] = useInputData<string | number>(index);
 
     const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
         const { value } = event.target;

--- a/src/components/inputs/FileInput.tsx
+++ b/src/components/inputs/FileInput.tsx
@@ -3,7 +3,7 @@ import path from 'path';
 import { memo, useEffect } from 'react';
 import { BsFileEarmarkPlus } from 'react-icons/bs';
 import { useContextSelector } from 'use-context-selector';
-import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalVolatileContext } from '../../helpers/contexts/GlobalNodeState';
 import { ipcRenderer } from '../../helpers/safeIpc';
 import { checkFileExists } from '../../helpers/util';
 import ImagePreview from './previews/ImagePreview';
@@ -18,7 +18,7 @@ interface FileInputProps extends InputProps {
 
 const FileInput = memo(
     ({ filetypes, id, index, useInputData, label, type, isLocked, schemaId }: FileInputProps) => {
-        const isInputLocked = useContextSelector(GlobalChainContext, (c) =>
+        const isInputLocked = useContextSelector(GlobalVolatileContext, (c) =>
             c.isNodeInputLocked(id, index)
         );
 

--- a/src/components/inputs/FileInput.tsx
+++ b/src/components/inputs/FileInput.tsx
@@ -2,7 +2,7 @@ import { Box, Input, InputGroup, InputLeftElement, Tooltip, VStack } from '@chak
 import path from 'path';
 import { memo, useEffect } from 'react';
 import { BsFileEarmarkPlus } from 'react-icons/bs';
-import { useContext } from 'use-context-selector';
+import { useContextSelector } from 'use-context-selector';
 import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 import { ipcRenderer } from '../../helpers/safeIpc';
 import { checkFileExists } from '../../helpers/util';
@@ -18,7 +18,10 @@ interface FileInputProps extends InputProps {
 
 const FileInput = memo(
     ({ filetypes, id, index, useInputData, label, type, isLocked, schemaId }: FileInputProps) => {
-        const { isNodeInputLocked } = useContext(GlobalChainContext);
+        const isNodeInputLocked = useContextSelector(
+            GlobalChainContext,
+            (c) => c.isNodeInputLocked
+        );
 
         const [filePath, setFilePath] = useInputData<string>(index);
 

--- a/src/components/inputs/FileInput.tsx
+++ b/src/components/inputs/FileInput.tsx
@@ -22,7 +22,7 @@ interface FileInputProps {
 
 const FileInput = memo(
     ({ filetypes, id, index, label, type, isLocked, category, name, schemaId }: FileInputProps) => {
-        const { useInputData, useNodeLock } = useContext(GlobalContext);
+        const { useInputData, isNodeInputLocked } = useContext(GlobalContext);
         const [filePath, setFilePath] = useInputData<string>(id, index);
 
         // Handle case of NCNN model selection where param and bin files are named in pairs
@@ -57,7 +57,7 @@ const FileInput = memo(
             }, [binFilePath]);
         }
 
-        const [, , isInputLocked] = useNodeLock(id, index);
+        const isInputLocked = isNodeInputLocked(id, index);
 
         const onButtonClick = async () => {
             const fileDir = filePath ? path.dirname(filePath) : undefined;

--- a/src/components/inputs/FileInput.tsx
+++ b/src/components/inputs/FileInput.tsx
@@ -1,7 +1,8 @@
 import { Box, Input, InputGroup, InputLeftElement, Tooltip, VStack } from '@chakra-ui/react';
 import path from 'path';
-import { memo, useContext, useEffect } from 'react';
+import { memo, useEffect } from 'react';
 import { BsFileEarmarkPlus } from 'react-icons/bs';
+import { useContext } from 'use-context-selector';
 import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 import { ipcRenderer } from '../../helpers/safeIpc';
 import { checkFileExists } from '../../helpers/util';

--- a/src/components/inputs/FileInput.tsx
+++ b/src/components/inputs/FileInput.tsx
@@ -18,9 +18,8 @@ interface FileInputProps extends InputProps {
 
 const FileInput = memo(
     ({ filetypes, id, index, useInputData, label, type, isLocked, schemaId }: FileInputProps) => {
-        const isNodeInputLocked = useContextSelector(
-            GlobalChainContext,
-            (c) => c.isNodeInputLocked
+        const isInputLocked = useContextSelector(GlobalChainContext, (c) =>
+            c.isNodeInputLocked(id, index)
         );
 
         const [filePath, setFilePath] = useInputData<string>(index);
@@ -56,8 +55,6 @@ const FileInput = memo(
                 })();
             }, [binFilePath]);
         }
-
-        const isInputLocked = isNodeInputLocked(id, index);
 
         const onButtonClick = async () => {
             const fileDir = filePath ? path.dirname(filePath) : undefined;

--- a/src/components/inputs/FileInput.tsx
+++ b/src/components/inputs/FileInput.tsx
@@ -7,29 +7,25 @@ import { ipcRenderer } from '../../helpers/safeIpc';
 import { checkFileExists } from '../../helpers/util';
 import ImagePreview from './previews/ImagePreview';
 import TorchModelPreview from './previews/TorchModelPreview';
+import { InputProps } from './props';
 
-interface FileInputProps {
-    id: string;
-    index: number;
-    isLocked?: boolean;
-    label: string;
-    category: string;
-    name: string;
+interface FileInputProps extends InputProps {
     filetypes: readonly string[];
     type: string;
     schemaId: string;
 }
 
 const FileInput = memo(
-    ({ filetypes, id, index, label, type, isLocked, category, name, schemaId }: FileInputProps) => {
-        const { useInputData, isNodeInputLocked } = useContext(GlobalContext);
-        const [filePath, setFilePath] = useInputData<string>(id, index);
+    ({ filetypes, id, index, useInputData, label, type, isLocked, schemaId }: FileInputProps) => {
+        const { isNodeInputLocked } = useContext(GlobalContext);
+
+        const [filePath, setFilePath] = useInputData<string>(index);
 
         // Handle case of NCNN model selection where param and bin files are named in pairs
         // Eventually, these should be combined into a single input type instead of using
         // the file inputs directly
         if (label.toUpperCase().includes('NCNN') && label.toLowerCase().includes('bin')) {
-            const [paramFilePath] = useInputData<string>(id, index - 1);
+            const [paramFilePath] = useInputData<string>(index - 1);
             useEffect(() => {
                 (async () => {
                     if (paramFilePath) {
@@ -43,7 +39,7 @@ const FileInput = memo(
             }, [paramFilePath]);
         }
         if (label.toUpperCase().includes('NCNN') && label.toLowerCase().includes('param')) {
-            const [binFilePath] = useInputData<string>(id, index + 1);
+            const [binFilePath] = useInputData<string>(index + 1);
             useEffect(() => {
                 (async () => {
                     if (binFilePath) {

--- a/src/components/inputs/FileInput.tsx
+++ b/src/components/inputs/FileInput.tsx
@@ -2,7 +2,7 @@ import { Box, Input, InputGroup, InputLeftElement, Tooltip, VStack } from '@chak
 import path from 'path';
 import { memo, useContext, useEffect } from 'react';
 import { BsFileEarmarkPlus } from 'react-icons/bs';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 import { ipcRenderer } from '../../helpers/safeIpc';
 import { checkFileExists } from '../../helpers/util';
 import ImagePreview from './previews/ImagePreview';
@@ -17,7 +17,7 @@ interface FileInputProps extends InputProps {
 
 const FileInput = memo(
     ({ filetypes, id, index, useInputData, label, type, isLocked, schemaId }: FileInputProps) => {
-        const { isNodeInputLocked } = useContext(GlobalContext);
+        const { isNodeInputLocked } = useContext(GlobalChainContext);
 
         const [filePath, setFilePath] = useInputData<string>(index);
 

--- a/src/components/inputs/GenericInput.tsx
+++ b/src/components/inputs/GenericInput.tsx
@@ -1,9 +1,8 @@
 import { Box, Text } from '@chakra-ui/react';
 import { memo } from 'react';
+import { InputProps } from './props';
 
-interface GenericInputProps {
-    label: string;
-}
+type GenericInputProps = InputProps;
 
 const GenericInput = memo(({ label }: GenericInputProps) => (
     // These both need to have -1 margins to thin it out... I don't know why

--- a/src/components/inputs/InputContainer.tsx
+++ b/src/components/inputs/InputContainer.tsx
@@ -1,7 +1,7 @@
 import { Box, HStack, Text, useColorModeValue } from '@chakra-ui/react';
 import React, { memo, useContext } from 'react';
 import { Handle, Position } from 'react-flow-renderer';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 
 interface InputContainerProps {
     id: string;
@@ -12,7 +12,7 @@ interface InputContainerProps {
 
 const InputContainer = memo(
     ({ children, hasHandle, id, index, label }: React.PropsWithChildren<InputContainerProps>) => {
-        const { isValidConnection } = useContext(GlobalContext);
+        const { isValidConnection } = useContext(GlobalChainContext);
 
         let contents = children;
         if (hasHandle) {

--- a/src/components/inputs/InputContainer.tsx
+++ b/src/components/inputs/InputContainer.tsx
@@ -1,7 +1,7 @@
 import { Box, HStack, Text, useColorModeValue } from '@chakra-ui/react';
 import React, { memo } from 'react';
 import { Handle, Position } from 'react-flow-renderer';
-import { useContext } from 'use-context-selector';
+import { useContextSelector } from 'use-context-selector';
 import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 
 interface InputContainerProps {
@@ -13,7 +13,10 @@ interface InputContainerProps {
 
 const InputContainer = memo(
     ({ children, hasHandle, id, index, label }: React.PropsWithChildren<InputContainerProps>) => {
-        const { isValidConnection } = useContext(GlobalChainContext);
+        const isValidConnection = useContextSelector(
+            GlobalChainContext,
+            (c) => c.isValidConnection
+        );
 
         let contents = children;
         if (hasHandle) {

--- a/src/components/inputs/InputContainer.tsx
+++ b/src/components/inputs/InputContainer.tsx
@@ -1,6 +1,7 @@
 import { Box, HStack, Text, useColorModeValue } from '@chakra-ui/react';
-import React, { memo, useContext } from 'react';
+import React, { memo } from 'react';
 import { Handle, Position } from 'react-flow-renderer';
+import { useContext } from 'use-context-selector';
 import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 
 interface InputContainerProps {

--- a/src/components/inputs/InputContainer.tsx
+++ b/src/components/inputs/InputContainer.tsx
@@ -2,7 +2,7 @@ import { Box, HStack, Text, useColorModeValue } from '@chakra-ui/react';
 import React, { memo } from 'react';
 import { Handle, Position } from 'react-flow-renderer';
 import { useContextSelector } from 'use-context-selector';
-import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalVolatileContext } from '../../helpers/contexts/GlobalNodeState';
 
 interface InputContainerProps {
     id: string;
@@ -14,7 +14,7 @@ interface InputContainerProps {
 const InputContainer = memo(
     ({ children, hasHandle, id, index, label }: React.PropsWithChildren<InputContainerProps>) => {
         const isValidConnection = useContextSelector(
-            GlobalChainContext,
+            GlobalVolatileContext,
             (c) => c.isValidConnection
         );
 

--- a/src/components/inputs/NumberInput.tsx
+++ b/src/components/inputs/NumberInput.tsx
@@ -6,7 +6,7 @@ import {
     NumberInputStepper,
 } from '@chakra-ui/react';
 import { memo, useState } from 'react';
-import { useContext } from 'use-context-selector';
+import { useContextSelector } from 'use-context-selector';
 import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 import { InputProps } from './props';
 
@@ -33,7 +33,10 @@ const NumericalInput = memo(
         type,
         isLocked,
     }: NumericalInputProps) => {
-        const { isNodeInputLocked } = useContext(GlobalChainContext);
+        const isNodeInputLocked = useContextSelector(
+            GlobalChainContext,
+            (c) => c.isNodeInputLocked
+        );
 
         // TODO: make sure this is always a number
         const [input, setInput] = useInputData<number>(index);

--- a/src/components/inputs/NumberInput.tsx
+++ b/src/components/inputs/NumberInput.tsx
@@ -23,11 +23,11 @@ interface NumericalInputProps {
 
 const NumericalInput = memo(
     ({ label, id, index, def, min, max, precision, step, type, isLocked }: NumericalInputProps) => {
-        const { useInputData, useNodeLock } = useContext(GlobalContext);
+        const { useInputData, isNodeInputLocked } = useContext(GlobalContext);
         // TODO: make sure this is always a number
         const [input, setInput] = useInputData<number>(id, index);
         const [inputString, setInputString] = useState(String(input));
-        const [, , isInputLocked] = useNodeLock(id, index);
+        const isInputLocked = isNodeInputLocked(id, index);
 
         const handleChange = (numberAsString: string, numberAsNumber: number) => {
             setInputString(numberAsString);

--- a/src/components/inputs/NumberInput.tsx
+++ b/src/components/inputs/NumberInput.tsx
@@ -6,7 +6,7 @@ import {
     NumberInputStepper,
 } from '@chakra-ui/react';
 import { memo, useContext, useState } from 'react';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 import { InputProps } from './props';
 
 interface NumericalInputProps extends InputProps {
@@ -32,7 +32,7 @@ const NumericalInput = memo(
         type,
         isLocked,
     }: NumericalInputProps) => {
-        const { isNodeInputLocked } = useContext(GlobalContext);
+        const { isNodeInputLocked } = useContext(GlobalChainContext);
 
         // TODO: make sure this is always a number
         const [input, setInput] = useInputData<number>(index);

--- a/src/components/inputs/NumberInput.tsx
+++ b/src/components/inputs/NumberInput.tsx
@@ -7,7 +7,7 @@ import {
 } from '@chakra-ui/react';
 import { memo, useState } from 'react';
 import { useContextSelector } from 'use-context-selector';
-import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalVolatileContext } from '../../helpers/contexts/GlobalNodeState';
 import { InputProps } from './props';
 
 interface NumericalInputProps extends InputProps {
@@ -33,7 +33,7 @@ const NumericalInput = memo(
         type,
         isLocked,
     }: NumericalInputProps) => {
-        const isInputLocked = useContextSelector(GlobalChainContext, (c) =>
+        const isInputLocked = useContextSelector(GlobalVolatileContext, (c) =>
             c.isNodeInputLocked(id, index)
         );
 

--- a/src/components/inputs/NumberInput.tsx
+++ b/src/components/inputs/NumberInput.tsx
@@ -33,15 +33,13 @@ const NumericalInput = memo(
         type,
         isLocked,
     }: NumericalInputProps) => {
-        const isNodeInputLocked = useContextSelector(
-            GlobalChainContext,
-            (c) => c.isNodeInputLocked
+        const isInputLocked = useContextSelector(GlobalChainContext, (c) =>
+            c.isNodeInputLocked(id, index)
         );
 
         // TODO: make sure this is always a number
         const [input, setInput] = useInputData<number>(index);
         const [inputString, setInputString] = useState(String(input));
-        const isInputLocked = isNodeInputLocked(id, index);
 
         const handleChange = (numberAsString: string, numberAsNumber: number) => {
             setInputString(numberAsString);

--- a/src/components/inputs/NumberInput.tsx
+++ b/src/components/inputs/NumberInput.tsx
@@ -5,7 +5,8 @@ import {
     NumberInputField,
     NumberInputStepper,
 } from '@chakra-ui/react';
-import { memo, useContext, useState } from 'react';
+import { memo, useState } from 'react';
+import { useContext } from 'use-context-selector';
 import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 import { InputProps } from './props';
 

--- a/src/components/inputs/NumberInput.tsx
+++ b/src/components/inputs/NumberInput.tsx
@@ -7,12 +7,9 @@ import {
 } from '@chakra-ui/react';
 import { memo, useContext, useState } from 'react';
 import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { InputProps } from './props';
 
-interface NumericalInputProps {
-    id: string;
-    index: number;
-    isLocked?: boolean;
-    label: string;
+interface NumericalInputProps extends InputProps {
     type: string;
     min?: number;
     max?: number;
@@ -22,10 +19,23 @@ interface NumericalInputProps {
 }
 
 const NumericalInput = memo(
-    ({ label, id, index, def, min, max, precision, step, type, isLocked }: NumericalInputProps) => {
-        const { useInputData, isNodeInputLocked } = useContext(GlobalContext);
+    ({
+        label,
+        id,
+        index,
+        useInputData,
+        def,
+        min,
+        max,
+        precision,
+        step,
+        type,
+        isLocked,
+    }: NumericalInputProps) => {
+        const { isNodeInputLocked } = useContext(GlobalContext);
+
         // TODO: make sure this is always a number
-        const [input, setInput] = useInputData<number>(id, index);
+        const [input, setInput] = useInputData<number>(index);
         const [inputString, setInputString] = useState(String(input));
         const isInputLocked = isNodeInputLocked(id, index);
 

--- a/src/components/inputs/SliderInput.tsx
+++ b/src/components/inputs/SliderInput.tsx
@@ -12,13 +12,10 @@ import {
     Text,
     Tooltip,
 } from '@chakra-ui/react';
-import { memo, useContext, useEffect, useState } from 'react';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { memo, useEffect, useState } from 'react';
+import { InputProps } from './props';
 
-interface SliderInputProps {
-    id: string;
-    index: number;
-    isLocked?: boolean;
+interface SliderInputProps extends InputProps {
     min: number;
     max: number;
     def?: number;
@@ -26,9 +23,8 @@ interface SliderInputProps {
 }
 
 const SliderInput = memo(
-    ({ index, def, min, max, id, accentColor, isLocked }: SliderInputProps) => {
-        const { useInputData } = useContext(GlobalContext);
-        const [input, setInput] = useInputData<number>(id, index);
+    ({ index, useInputData, def, min, max, accentColor, isLocked }: SliderInputProps) => {
+        const [input, setInput] = useInputData<number>(index);
         const [sliderValue, setSliderValue] = useState(input ?? def);
         const [showTooltip, setShowTooltip] = useState(false);
 
@@ -47,10 +43,8 @@ const SliderInput = memo(
                     min={min}
                     step={1}
                     value={sliderValue ?? def}
-                    onChange={(v) => setSliderValue(v)}
-                    onChangeEnd={(v) => {
-                        setInput(v);
-                    }}
+                    onChange={setSliderValue}
+                    onChangeEnd={setInput}
                     onMouseEnter={() => setShowTooltip(true)}
                     onMouseLeave={() => setShowTooltip(false)}
                 >

--- a/src/components/inputs/TextAreaInput.tsx
+++ b/src/components/inputs/TextAreaInput.tsx
@@ -1,42 +1,39 @@
 import { Textarea } from '@chakra-ui/react';
-import { ChangeEvent, memo, useContext, useEffect } from 'react';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { ChangeEvent, memo, useEffect } from 'react';
+import { InputProps } from './props';
 
-interface TextAreaInputProps {
-    id: string;
-    index: number;
-    isLocked?: boolean;
-    label: string;
+interface TextAreaInputProps extends InputProps {
     resizable: boolean;
 }
 
-const TextAreaInput = memo(({ label, id, index, isLocked, resizable }: TextAreaInputProps) => {
-    const { useInputData } = useContext(GlobalContext);
-    const [input, setInput] = useInputData<string>(id, index);
+const TextAreaInput = memo(
+    ({ label, index, useInputData, isLocked, resizable }: TextAreaInputProps) => {
+        const [input, setInput] = useInputData<string>(index);
 
-    useEffect(() => {
-        if (!input) {
-            setInput('');
-        }
-    }, []);
+        useEffect(() => {
+            if (!input) {
+                setInput('');
+            }
+        }, []);
 
-    const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-        const text = event.target.value;
-        setInput(text);
-    };
+        const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+            const text = event.target.value;
+            setInput(text);
+        };
 
-    return (
-        <Textarea
-            className="nodrag"
-            disabled={isLocked}
-            draggable={false}
-            minW={240}
-            placeholder={label}
-            resize={resizable ? 'both' : 'none'}
-            value={input ?? ''}
-            onChange={handleChange}
-        />
-    );
-});
+        return (
+            <Textarea
+                className="nodrag"
+                disabled={isLocked}
+                draggable={false}
+                minW={240}
+                placeholder={label}
+                resize={resizable ? 'both' : 'none'}
+                value={input ?? ''}
+                onChange={handleChange}
+            />
+        );
+    }
+);
 
 export default TextAreaInput;

--- a/src/components/inputs/TextInput.tsx
+++ b/src/components/inputs/TextInput.tsx
@@ -1,6 +1,6 @@
 import { Input } from '@chakra-ui/react';
 import { ChangeEvent, memo, useEffect, useState } from 'react';
-import { useContext } from 'use-context-selector';
+import { useContextSelector } from 'use-context-selector';
 import { useDebouncedCallback } from 'use-debounce';
 import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 import { InputProps } from './props';
@@ -11,7 +11,10 @@ interface TextInputProps extends InputProps {
 
 const TextInput = memo(
     ({ label, id, index, useInputData, isLocked, maxLength }: TextInputProps) => {
-        const { isNodeInputLocked } = useContext(GlobalChainContext);
+        const isNodeInputLocked = useContextSelector(
+            GlobalChainContext,
+            (c) => c.isNodeInputLocked
+        );
 
         const [input, setInput] = useInputData<string>(index);
         const [tempText, setTempText] = useState('');

--- a/src/components/inputs/TextInput.tsx
+++ b/src/components/inputs/TextInput.tsx
@@ -2,7 +2,7 @@ import { Input } from '@chakra-ui/react';
 import { ChangeEvent, memo, useEffect, useState } from 'react';
 import { useContextSelector } from 'use-context-selector';
 import { useDebouncedCallback } from 'use-debounce';
-import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalVolatileContext } from '../../helpers/contexts/GlobalNodeState';
 import { InputProps } from './props';
 
 interface TextInputProps extends InputProps {
@@ -11,7 +11,7 @@ interface TextInputProps extends InputProps {
 
 const TextInput = memo(
     ({ label, id, index, useInputData, isLocked, maxLength }: TextInputProps) => {
-        const isInputLocked = useContextSelector(GlobalChainContext, (c) =>
+        const isInputLocked = useContextSelector(GlobalVolatileContext, (c) =>
             c.isNodeInputLocked(id, index)
         );
 

--- a/src/components/inputs/TextInput.tsx
+++ b/src/components/inputs/TextInput.tsx
@@ -1,5 +1,6 @@
 import { Input } from '@chakra-ui/react';
-import { ChangeEvent, memo, useContext, useEffect, useState } from 'react';
+import { ChangeEvent, memo, useEffect, useState } from 'react';
+import { useContext } from 'use-context-selector';
 import { useDebouncedCallback } from 'use-debounce';
 import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 import { InputProps } from './props';

--- a/src/components/inputs/TextInput.tsx
+++ b/src/components/inputs/TextInput.tsx
@@ -1,7 +1,7 @@
 import { Input } from '@chakra-ui/react';
 import { ChangeEvent, memo, useContext, useEffect, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 import { InputProps } from './props';
 
 interface TextInputProps extends InputProps {
@@ -10,7 +10,7 @@ interface TextInputProps extends InputProps {
 
 const TextInput = memo(
     ({ label, id, index, useInputData, isLocked, maxLength }: TextInputProps) => {
-        const { isNodeInputLocked } = useContext(GlobalContext);
+        const { isNodeInputLocked } = useContext(GlobalChainContext);
 
         const [input, setInput] = useInputData<string>(index);
         const [tempText, setTempText] = useState('');

--- a/src/components/inputs/TextInput.tsx
+++ b/src/components/inputs/TextInput.tsx
@@ -11,14 +11,12 @@ interface TextInputProps extends InputProps {
 
 const TextInput = memo(
     ({ label, id, index, useInputData, isLocked, maxLength }: TextInputProps) => {
-        const isNodeInputLocked = useContextSelector(
-            GlobalChainContext,
-            (c) => c.isNodeInputLocked
+        const isInputLocked = useContextSelector(GlobalChainContext, (c) =>
+            c.isNodeInputLocked(id, index)
         );
 
         const [input, setInput] = useInputData<string>(index);
         const [tempText, setTempText] = useState('');
-        const isInputLocked = isNodeInputLocked(id, index);
 
         useEffect(() => {
             if (!input) {

--- a/src/components/inputs/TextInput.tsx
+++ b/src/components/inputs/TextInput.tsx
@@ -12,10 +12,10 @@ interface TextInputProps {
 }
 
 const TextInput = memo(({ label, id, index, isLocked, maxLength }: TextInputProps) => {
-    const { useInputData, useNodeLock } = useContext(GlobalContext);
+    const { useInputData, isNodeInputLocked } = useContext(GlobalContext);
     const [input, setInput] = useInputData<string>(id, index);
     const [tempText, setTempText] = useState('');
-    const [, , isInputLocked] = useNodeLock(id, index);
+    const isInputLocked = isNodeInputLocked(id, index);
 
     useEffect(() => {
         if (!input) {

--- a/src/components/inputs/TextInput.tsx
+++ b/src/components/inputs/TextInput.tsx
@@ -2,49 +2,49 @@ import { Input } from '@chakra-ui/react';
 import { ChangeEvent, memo, useContext, useEffect, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { InputProps } from './props';
 
-interface TextInputProps {
-    id: string;
-    index: number;
-    isLocked?: boolean;
-    label: string;
+interface TextInputProps extends InputProps {
     maxLength?: number;
 }
 
-const TextInput = memo(({ label, id, index, isLocked, maxLength }: TextInputProps) => {
-    const { useInputData, isNodeInputLocked } = useContext(GlobalContext);
-    const [input, setInput] = useInputData<string>(id, index);
-    const [tempText, setTempText] = useState('');
-    const isInputLocked = isNodeInputLocked(id, index);
+const TextInput = memo(
+    ({ label, id, index, useInputData, isLocked, maxLength }: TextInputProps) => {
+        const { isNodeInputLocked } = useContext(GlobalContext);
 
-    useEffect(() => {
-        if (!input) {
-            setInput('');
-        } else {
-            setTempText(input);
-        }
-    }, []);
+        const [input, setInput] = useInputData<string>(index);
+        const [tempText, setTempText] = useState('');
+        const isInputLocked = isNodeInputLocked(id, index);
 
-    const handleChange = useDebouncedCallback((event: ChangeEvent<HTMLInputElement>) => {
-        let text = event.target.value;
-        text = maxLength ? text.slice(0, maxLength) : text;
-        setInput(text);
-    }, 500);
+        useEffect(() => {
+            if (!input) {
+                setInput('');
+            } else {
+                setTempText(input);
+            }
+        }, []);
 
-    return (
-        <Input
-            className="nodrag"
-            disabled={isLocked || isInputLocked}
-            draggable={false}
-            maxLength={maxLength}
-            placeholder={label}
-            value={tempText}
-            onChange={(event) => {
-                setTempText(event.target.value);
-                handleChange(event);
-            }}
-        />
-    );
-});
+        const handleChange = useDebouncedCallback((event: ChangeEvent<HTMLInputElement>) => {
+            let text = event.target.value;
+            text = maxLength ? text.slice(0, maxLength) : text;
+            setInput(text);
+        }, 500);
+
+        return (
+            <Input
+                className="nodrag"
+                disabled={isLocked || isInputLocked}
+                draggable={false}
+                maxLength={maxLength}
+                placeholder={label}
+                value={tempText}
+                onChange={(event) => {
+                    setTempText(event.target.value);
+                    handleChange(event);
+                }}
+            />
+        );
+    }
+);
 
 export default TextInput;

--- a/src/components/inputs/previews/ImagePreview.tsx
+++ b/src/components/inputs/previews/ImagePreview.tsx
@@ -1,5 +1,6 @@
 import { Center, HStack, Image, Spinner, Tag, VStack } from '@chakra-ui/react';
-import { memo, useContext, useState } from 'react';
+import { memo, useState } from 'react';
+import { useContext } from 'use-context-selector';
 import { getBackend } from '../../../helpers/Backend';
 import { SettingsContext } from '../../../helpers/contexts/SettingsContext';
 import { useAsyncEffect } from '../../../helpers/hooks/useAsyncEffect';

--- a/src/components/inputs/previews/TorchModelPreview.tsx
+++ b/src/components/inputs/previews/TorchModelPreview.tsx
@@ -1,5 +1,6 @@
 import { Center, Spinner, Tag, Wrap, WrapItem } from '@chakra-ui/react';
-import { memo, useContext, useState } from 'react';
+import { memo, useState } from 'react';
+import { useContext } from 'use-context-selector';
 import { getBackend } from '../../../helpers/Backend';
 import { SettingsContext } from '../../../helpers/contexts/SettingsContext';
 import { useAsyncEffect } from '../../../helpers/hooks/useAsyncEffect';

--- a/src/components/inputs/props.ts
+++ b/src/components/inputs/props.ts
@@ -1,0 +1,12 @@
+import { InputData, InputSchemaValue } from '../../common-types';
+
+export interface InputProps {
+    readonly id: string;
+    readonly index: number;
+    readonly inputData: InputData;
+    readonly isLocked: boolean;
+    readonly label: string;
+    readonly useInputData: <T extends InputSchemaValue>(
+        index: number
+    ) => readonly [T | undefined, (value: T) => void];
+}

--- a/src/components/node/IteratorHelperNode.tsx
+++ b/src/components/node/IteratorHelperNode.tsx
@@ -1,5 +1,6 @@
 import { Center, useColorModeValue, VStack } from '@chakra-ui/react';
-import { memo, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useContext } from 'use-context-selector';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
 import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';

--- a/src/components/node/IteratorHelperNode.tsx
+++ b/src/components/node/IteratorHelperNode.tsx
@@ -1,6 +1,6 @@
 import { Center, useColorModeValue, VStack } from '@chakra-ui/react';
 import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { useContext } from 'use-context-selector';
+import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
 import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
@@ -16,7 +16,7 @@ interface IteratorHelperNodeProps {
 }
 
 const IteratorHelperNode = ({ data, selected }: IteratorHelperNodeProps) => {
-    const { edges } = useContext(GlobalChainContext);
+    const edges = useContextSelector(GlobalChainContext, (c) => c.edges);
     const { schemata, updateIteratorBounds, setHoveredNode } = useContext(GlobalContext);
 
     const { id, inputData, isLocked, parentNode, schemaId } = data;

--- a/src/components/node/IteratorHelperNode.tsx
+++ b/src/components/node/IteratorHelperNode.tsx
@@ -2,7 +2,11 @@ import { Center, useColorModeValue, VStack } from '@chakra-ui/react';
 import { memo, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import {
+    GlobalConstantsContext,
+    GlobalContext,
+    GlobalSettersContext,
+} from '../../helpers/contexts/GlobalNodeState';
 import getAccentColor from '../../helpers/getNodeAccentColors';
 import shadeColor from '../../helpers/shadeColor';
 import IteratorHelperNodeFooter from './IteratorHelperNodeFooter';
@@ -15,7 +19,9 @@ interface IteratorHelperNodeProps {
 }
 
 const IteratorHelperNode = ({ data, selected }: IteratorHelperNodeProps) => {
-    const { edges, schemata, updateIteratorBounds, useHoveredNode } = useContext(GlobalContext);
+    const { edges } = useContext(GlobalContext);
+    const { schemata } = useContext(GlobalConstantsContext);
+    const { updateIteratorBounds, setHoveredNode } = useContext(GlobalSettersContext);
 
     const { id, inputData, isLocked, parentNode, schemaId } = data;
 
@@ -51,8 +57,6 @@ const IteratorHelperNode = ({ data, selected }: IteratorHelperNodeProps) => {
             setCheckedSize(true);
         }
     }, [checkedSize]);
-
-    const [, setHoveredNode] = useHoveredNode;
 
     return (
         <Center

--- a/src/components/node/IteratorHelperNode.tsx
+++ b/src/components/node/IteratorHelperNode.tsx
@@ -86,11 +86,10 @@ const IteratorHelperNode = ({ data, selected }: IteratorHelperNodeProps) => {
                 />
                 <NodeBody
                     accentColor={accentColor}
-                    category={category}
                     id={id}
+                    inputData={inputData}
                     inputs={inputs}
                     isLocked={isLocked}
-                    name={name}
                     outputs={outputs}
                     schemaId={schemaId}
                 />

--- a/src/components/node/IteratorHelperNode.tsx
+++ b/src/components/node/IteratorHelperNode.tsx
@@ -2,11 +2,7 @@ import { Center, useColorModeValue, VStack } from '@chakra-ui/react';
 import { memo, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
-import {
-    GlobalConstantsContext,
-    GlobalContext,
-    GlobalSettersContext,
-} from '../../helpers/contexts/GlobalNodeState';
+import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import getAccentColor from '../../helpers/getNodeAccentColors';
 import shadeColor from '../../helpers/shadeColor';
 import IteratorHelperNodeFooter from './IteratorHelperNodeFooter';
@@ -19,9 +15,8 @@ interface IteratorHelperNodeProps {
 }
 
 const IteratorHelperNode = ({ data, selected }: IteratorHelperNodeProps) => {
-    const { edges } = useContext(GlobalContext);
-    const { schemata } = useContext(GlobalConstantsContext);
-    const { updateIteratorBounds, setHoveredNode } = useContext(GlobalSettersContext);
+    const { edges } = useContext(GlobalChainContext);
+    const { schemata, updateIteratorBounds, setHoveredNode } = useContext(GlobalContext);
 
     const { id, inputData, isLocked, parentNode, schemaId } = data;
 

--- a/src/components/node/IteratorHelperNode.tsx
+++ b/src/components/node/IteratorHelperNode.tsx
@@ -3,7 +3,7 @@ import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'rea
 import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
-import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalVolatileContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import getAccentColor from '../../helpers/getNodeAccentColors';
 import shadeColor from '../../helpers/shadeColor';
 import IteratorHelperNodeFooter from './IteratorHelperNodeFooter';
@@ -16,7 +16,7 @@ interface IteratorHelperNodeProps {
 }
 
 const IteratorHelperNode = ({ data, selected }: IteratorHelperNodeProps) => {
-    const edges = useContextSelector(GlobalChainContext, (c) => c.edges);
+    const edges = useContextSelector(GlobalVolatileContext, (c) => c.edges);
     const { schemata, updateIteratorBounds, setHoveredNode } = useContext(GlobalContext);
 
     const { id, inputData, isLocked, parentNode, schemaId } = data;

--- a/src/components/node/IteratorNode.tsx
+++ b/src/components/node/IteratorNode.tsx
@@ -1,5 +1,6 @@
 import { Center, Text, useColorModeValue, VStack } from '@chakra-ui/react';
-import { memo, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { useContext } from 'use-context-selector';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
 import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';

--- a/src/components/node/IteratorNode.tsx
+++ b/src/components/node/IteratorNode.tsx
@@ -103,11 +103,10 @@ const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => {
                     )}
                     <NodeInputs
                         accentColor={accentColor}
-                        category={category}
                         id={id}
+                        inputData={inputData}
                         inputs={inputs}
                         isLocked={isLocked}
-                        name={name}
                         schemaId={schemaId}
                     />
                     <Center>

--- a/src/components/node/IteratorNode.tsx
+++ b/src/components/node/IteratorNode.tsx
@@ -3,7 +3,7 @@ import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
-import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalVolatileContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import getAccentColor from '../../helpers/getNodeAccentColors';
 import shadeColor from '../../helpers/shadeColor';
 import IteratorNodeBody from './IteratorNodeBody';
@@ -26,7 +26,7 @@ const IteratorNodeWrapper = memo(({ data, selected }: IteratorNodeProps) => (
 ));
 
 const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => {
-    const edges = useContextSelector(GlobalChainContext, (c) => c.edges);
+    const edges = useContextSelector(GlobalVolatileContext, (c) => c.edges);
     const { schemata } = useContext(GlobalContext);
 
     const {

--- a/src/components/node/IteratorNode.tsx
+++ b/src/components/node/IteratorNode.tsx
@@ -2,7 +2,7 @@ import { Center, Text, useColorModeValue, VStack } from '@chakra-ui/react';
 import { memo, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalConstantsContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import getAccentColor from '../../helpers/getNodeAccentColors';
 import shadeColor from '../../helpers/shadeColor';
 import IteratorNodeBody from './IteratorNodeBody';
@@ -25,7 +25,8 @@ const IteratorNodeWrapper = memo(({ data, selected }: IteratorNodeProps) => (
 ));
 
 const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => {
-    const { edges, schemata } = useContext(GlobalContext);
+    const { edges } = useContext(GlobalContext);
+    const { schemata } = useContext(GlobalConstantsContext);
 
     const {
         id,

--- a/src/components/node/IteratorNode.tsx
+++ b/src/components/node/IteratorNode.tsx
@@ -2,7 +2,7 @@ import { Center, Text, useColorModeValue, VStack } from '@chakra-ui/react';
 import { memo, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
-import { GlobalConstantsContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import getAccentColor from '../../helpers/getNodeAccentColors';
 import shadeColor from '../../helpers/shadeColor';
 import IteratorNodeBody from './IteratorNodeBody';
@@ -25,8 +25,8 @@ const IteratorNodeWrapper = memo(({ data, selected }: IteratorNodeProps) => (
 ));
 
 const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => {
-    const { edges } = useContext(GlobalContext);
-    const { schemata } = useContext(GlobalConstantsContext);
+    const { edges } = useContext(GlobalChainContext);
+    const { schemata } = useContext(GlobalContext);
 
     const {
         id,

--- a/src/components/node/IteratorNode.tsx
+++ b/src/components/node/IteratorNode.tsx
@@ -1,6 +1,6 @@
 import { Center, Text, useColorModeValue, VStack } from '@chakra-ui/react';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
-import { useContext } from 'use-context-selector';
+import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
 import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
@@ -26,7 +26,7 @@ const IteratorNodeWrapper = memo(({ data, selected }: IteratorNodeProps) => (
 ));
 
 const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => {
-    const { edges } = useContext(GlobalChainContext);
+    const edges = useContextSelector(GlobalChainContext, (c) => c.edges);
     const { schemata } = useContext(GlobalContext);
 
     const {

--- a/src/components/node/IteratorNodeBody.tsx
+++ b/src/components/node/IteratorNodeBody.tsx
@@ -2,7 +2,7 @@ import { Box, useColorModeValue } from '@chakra-ui/react';
 import { Resizable } from 're-resizable';
 import { memo, useContext, useLayoutEffect, useMemo, useState } from 'react';
 import { IteratorSize } from '../../common-types';
-import { GlobalContext, GlobalSettersContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import { SettingsContext } from '../../helpers/contexts/SettingsContext';
 
 const createGridDotsPath = (size: number, fill: string) => (
@@ -65,9 +65,9 @@ const IteratorNodeBody = ({
     maxWidth = 256,
     maxHeight = 256,
 }: IteratorNodeBodyProps) => {
-    const { zoom, hoveredNode } = useContext(GlobalContext);
+    const { zoom, hoveredNode } = useContext(GlobalChainContext);
     const { useIteratorSize, setHoveredNode, updateIteratorBounds } =
-        useContext(GlobalSettersContext);
+        useContext(GlobalContext);
 
     const { useSnapToGrid } = useContext(SettingsContext);
     const [isSnapToGrid, , snapToGridAmount] = useSnapToGrid;

--- a/src/components/node/IteratorNodeBody.tsx
+++ b/src/components/node/IteratorNodeBody.tsx
@@ -2,7 +2,7 @@ import { Box, useColorModeValue } from '@chakra-ui/react';
 import { Resizable } from 're-resizable';
 import { memo, useContext, useLayoutEffect, useMemo, useState } from 'react';
 import { IteratorSize } from '../../common-types';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalContext, GlobalSettersContext } from '../../helpers/contexts/GlobalNodeState';
 import { SettingsContext } from '../../helpers/contexts/SettingsContext';
 
 const createGridDotsPath = (size: number, fill: string) => (
@@ -65,13 +65,13 @@ const IteratorNodeBody = ({
     maxWidth = 256,
     maxHeight = 256,
 }: IteratorNodeBodyProps) => {
-    const { zoom, useIteratorSize, useHoveredNode, updateIteratorBounds } =
-        useContext(GlobalContext);
+    const { zoom, hoveredNode } = useContext(GlobalContext);
+    const { useIteratorSize, setHoveredNode, updateIteratorBounds } =
+        useContext(GlobalSettersContext);
 
     const { useSnapToGrid } = useContext(SettingsContext);
     const [isSnapToGrid, , snapToGridAmount] = useSnapToGrid;
 
-    const [hoveredNode, setHoveredNode] = useHoveredNode;
     const [setIteratorSize, defaultSize] = useIteratorSize(id);
     const { width, height } = iteratorSize ?? defaultSize;
 

--- a/src/components/node/IteratorNodeBody.tsx
+++ b/src/components/node/IteratorNodeBody.tsx
@@ -3,7 +3,7 @@ import { Resizable } from 're-resizable';
 import { memo, useLayoutEffect, useMemo, useState } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { IteratorSize } from '../../common-types';
-import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalVolatileContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import { SettingsContext } from '../../helpers/contexts/SettingsContext';
 
 const createGridDotsPath = (size: number, fill: string) => (
@@ -66,8 +66,8 @@ const IteratorNodeBody = ({
     maxWidth = 256,
     maxHeight = 256,
 }: IteratorNodeBodyProps) => {
-    const zoom = useContextSelector(GlobalChainContext, (c) => c.zoom);
-    const hoveredNode = useContextSelector(GlobalChainContext, (c) => c.hoveredNode);
+    const zoom = useContextSelector(GlobalVolatileContext, (c) => c.zoom);
+    const hoveredNode = useContextSelector(GlobalVolatileContext, (c) => c.hoveredNode);
     const { useIteratorSize, setHoveredNode, updateIteratorBounds } = useContext(GlobalContext);
 
     const { useSnapToGrid } = useContext(SettingsContext);

--- a/src/components/node/IteratorNodeBody.tsx
+++ b/src/components/node/IteratorNodeBody.tsx
@@ -1,6 +1,7 @@
 import { Box, useColorModeValue } from '@chakra-ui/react';
 import { Resizable } from 're-resizable';
-import { memo, useContext, useLayoutEffect, useMemo, useState } from 'react';
+import { memo, useLayoutEffect, useMemo, useState } from 'react';
+import { useContext } from 'use-context-selector';
 import { IteratorSize } from '../../common-types';
 import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import { SettingsContext } from '../../helpers/contexts/SettingsContext';
@@ -66,8 +67,7 @@ const IteratorNodeBody = ({
     maxHeight = 256,
 }: IteratorNodeBodyProps) => {
     const { zoom, hoveredNode } = useContext(GlobalChainContext);
-    const { useIteratorSize, setHoveredNode, updateIteratorBounds } =
-        useContext(GlobalContext);
+    const { useIteratorSize, setHoveredNode, updateIteratorBounds } = useContext(GlobalContext);
 
     const { useSnapToGrid } = useContext(SettingsContext);
     const [isSnapToGrid, , snapToGridAmount] = useSnapToGrid;

--- a/src/components/node/IteratorNodeBody.tsx
+++ b/src/components/node/IteratorNodeBody.tsx
@@ -1,7 +1,7 @@
 import { Box, useColorModeValue } from '@chakra-ui/react';
 import { Resizable } from 're-resizable';
 import { memo, useLayoutEffect, useMemo, useState } from 'react';
-import { useContext } from 'use-context-selector';
+import { useContext, useContextSelector } from 'use-context-selector';
 import { IteratorSize } from '../../common-types';
 import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import { SettingsContext } from '../../helpers/contexts/SettingsContext';
@@ -66,7 +66,8 @@ const IteratorNodeBody = ({
     maxWidth = 256,
     maxHeight = 256,
 }: IteratorNodeBodyProps) => {
-    const { zoom, hoveredNode } = useContext(GlobalChainContext);
+    const zoom = useContextSelector(GlobalChainContext, (c) => c.zoom);
+    const hoveredNode = useContextSelector(GlobalChainContext, (c) => c.hoveredNode);
     const { useIteratorSize, setHoveredNode, updateIteratorBounds } = useContext(GlobalContext);
 
     const { useSnapToGrid } = useContext(SettingsContext);

--- a/src/components/node/Node.tsx
+++ b/src/components/node/Node.tsx
@@ -12,7 +12,7 @@ import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'rea
 import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
-import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalVolatileContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import getAccentColor from '../../helpers/getNodeAccentColors';
 import shadeColor from '../../helpers/shadeColor';
 import NodeBody from './NodeBody';
@@ -33,8 +33,8 @@ interface NodeProps {
 }
 
 const Node = memo(({ data, selected }: NodeProps) => {
-    const nodes = useContextSelector(GlobalChainContext, (c) => c.nodes);
-    const edges = useContextSelector(GlobalChainContext, (c) => c.edges);
+    const nodes = useContextSelector(GlobalVolatileContext, (c) => c.nodes);
+    const edges = useContextSelector(GlobalVolatileContext, (c) => c.edges);
     const { schemata, updateIteratorBounds, setHoveredNode } = useContext(GlobalContext);
 
     const { id, inputData, isLocked, parentNode, schemaId } = data;

--- a/src/components/node/Node.tsx
+++ b/src/components/node/Node.tsx
@@ -11,7 +11,11 @@ import {
 import { memo, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import {
+    GlobalConstantsContext,
+    GlobalContext,
+    GlobalSettersContext,
+} from '../../helpers/contexts/GlobalNodeState';
 import getAccentColor from '../../helpers/getNodeAccentColors';
 import shadeColor from '../../helpers/shadeColor';
 import NodeBody from './NodeBody';
@@ -32,8 +36,9 @@ interface NodeProps {
 }
 
 const Node = memo(({ data, selected }: NodeProps) => {
-    const { nodes, edges, schemata, updateIteratorBounds, useHoveredNode } =
-        useContext(GlobalContext);
+    const { nodes, edges } = useContext(GlobalContext);
+    const { schemata } = useContext(GlobalConstantsContext);
+    const { updateIteratorBounds, setHoveredNode } = useContext(GlobalSettersContext);
 
     const { id, inputData, isLocked, parentNode, schemaId } = data;
 
@@ -79,8 +84,6 @@ const Node = memo(({ data, selected }: NodeProps) => {
     //     setShowMenu(false);
     //   }
     // }, [selected]);
-
-    const [, setHoveredNode] = useHoveredNode;
 
     return (
         <>

--- a/src/components/node/Node.tsx
+++ b/src/components/node/Node.tsx
@@ -8,7 +8,8 @@ import {
     useColorModeValue,
     VStack,
 } from '@chakra-ui/react';
-import { memo, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useContext } from 'use-context-selector';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
 import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';

--- a/src/components/node/Node.tsx
+++ b/src/components/node/Node.tsx
@@ -11,11 +11,7 @@ import {
 import { memo, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
-import {
-    GlobalConstantsContext,
-    GlobalContext,
-    GlobalSettersContext,
-} from '../../helpers/contexts/GlobalNodeState';
+import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import getAccentColor from '../../helpers/getNodeAccentColors';
 import shadeColor from '../../helpers/shadeColor';
 import NodeBody from './NodeBody';
@@ -36,9 +32,8 @@ interface NodeProps {
 }
 
 const Node = memo(({ data, selected }: NodeProps) => {
-    const { nodes, edges } = useContext(GlobalContext);
-    const { schemata } = useContext(GlobalConstantsContext);
-    const { updateIteratorBounds, setHoveredNode } = useContext(GlobalSettersContext);
+    const { nodes, edges } = useContext(GlobalChainContext);
+    const { schemata, updateIteratorBounds, setHoveredNode } = useContext(GlobalContext);
 
     const { id, inputData, isLocked, parentNode, schemaId } = data;
 

--- a/src/components/node/Node.tsx
+++ b/src/components/node/Node.tsx
@@ -127,11 +127,10 @@ const Node = memo(({ data, selected }: NodeProps) => {
                         />
                         <NodeBody
                             accentColor={accentColor}
-                            category={category}
                             id={id}
+                            inputData={inputData}
                             inputs={inputs}
                             isLocked={isLocked}
-                            name={name}
                             outputs={outputs}
                             schemaId={schemaId}
                         />

--- a/src/components/node/Node.tsx
+++ b/src/components/node/Node.tsx
@@ -9,7 +9,7 @@ import {
     VStack,
 } from '@chakra-ui/react';
 import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { useContext } from 'use-context-selector';
+import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
 import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
@@ -33,7 +33,8 @@ interface NodeProps {
 }
 
 const Node = memo(({ data, selected }: NodeProps) => {
-    const { nodes, edges } = useContext(GlobalChainContext);
+    const nodes = useContextSelector(GlobalChainContext, (c) => c.nodes);
+    const edges = useContextSelector(GlobalChainContext, (c) => c.edges);
     const { schemata, updateIteratorBounds, setHoveredNode } = useContext(GlobalContext);
 
     const { id, inputData, isLocked, parentNode, schemaId } = data;

--- a/src/components/node/NodeBody.tsx
+++ b/src/components/node/NodeBody.tsx
@@ -1,6 +1,6 @@
 import { Center, Text } from '@chakra-ui/react';
 import { memo } from 'react';
-import { Input, Output } from '../../common-types';
+import { Input, InputData, Output } from '../../common-types';
 import NodeInputs from './NodeInputs';
 import NodeOutputs from './NodeOutputs';
 // useContext, useEffect, useMemo,
@@ -8,9 +8,8 @@ import NodeOutputs from './NodeOutputs';
 interface NodeBodyProps {
     accentColor: string;
     id: string;
+    inputData: InputData;
     isLocked?: boolean;
-    category: string;
-    name: string;
     inputs: readonly Input[];
     outputs: readonly Output[];
     schemaId: string;
@@ -21,9 +20,8 @@ const NodeBody = ({
     inputs,
     outputs,
     id,
+    inputData,
     isLocked,
-    category,
-    name,
     schemaId,
 }: NodeBodyProps) => (
     <>
@@ -44,11 +42,10 @@ const NodeBody = ({
         )}
         <NodeInputs
             accentColor={accentColor}
-            category={category}
             id={id}
+            inputData={inputData}
             inputs={inputs}
             isLocked={isLocked}
-            name={name}
             schemaId={schemaId}
         />
 

--- a/src/components/node/NodeFooter.tsx
+++ b/src/components/node/NodeFooter.tsx
@@ -23,7 +23,7 @@ import {
 import { memo, useEffect, useState } from 'react';
 import { MdMoreHoriz } from 'react-icons/md';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalVolatileContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import { MenuFunctionsContext } from '../../helpers/contexts/MenuFunctions';
 
 interface NodeFooterProps {
@@ -34,7 +34,7 @@ interface NodeFooterProps {
 }
 
 const NodeFooter = ({ id, isValid = false, invalidReason = '', isLocked }: NodeFooterProps) => {
-    const duplicateNode = useContextSelector(GlobalChainContext, (c) => c.duplicateNode);
+    const duplicateNode = useContextSelector(GlobalVolatileContext, (c) => c.duplicateNode);
     const { removeNodeById, clearNode, toggleNodeLock } = useContext(GlobalContext);
     const { addMenuCloseFunction } = useContext(MenuFunctionsContext);
 

--- a/src/components/node/NodeFooter.tsx
+++ b/src/components/node/NodeFooter.tsx
@@ -22,7 +22,8 @@ import {
 } from '@chakra-ui/react';
 import { memo, useContext, useEffect, useState } from 'react';
 import { MdMoreHoriz } from 'react-icons/md';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalContext, GlobalSettersContext } from '../../helpers/contexts/GlobalNodeState';
+import { MenuFunctionsContext } from '../../helpers/contexts/MenuFunctions';
 
 interface NodeFooterProps {
     id: string;
@@ -32,10 +33,9 @@ interface NodeFooterProps {
 }
 
 const NodeFooter = ({ id, isValid = false, invalidReason = '', isLocked }: NodeFooterProps) => {
-    const { removeNodeById, duplicateNode, clearNode, useNodeLock, useMenuCloseFunctions } =
-        useContext(GlobalContext);
-
-    const [, toggleLock] = useNodeLock(id);
+    const { duplicateNode } = useContext(GlobalContext);
+    const { removeNodeById, clearNode, toggleNodeLock } = useContext(GlobalSettersContext);
+    const { addMenuCloseFunction } = useContext(MenuFunctionsContext);
 
     const iconShade = useColorModeValue('gray.400', 'gray.800');
     const validShade = useColorModeValue('gray.900', 'gray.100');
@@ -44,7 +44,6 @@ const NodeFooter = ({ id, isValid = false, invalidReason = '', isLocked }: NodeF
     // const iconShade = useColorModeValue('gray.400', 'gray.800');
 
     const [isOpen, setIsOpen] = useState(false);
-    const [, addMenuCloseFunction] = useMenuCloseFunctions;
     useEffect(() => {
         addMenuCloseFunction(() => {
             setIsOpen(false);
@@ -69,7 +68,7 @@ const NodeFooter = ({ id, isValid = false, invalidReason = '', isLocked }: NodeF
                     cursor="pointer"
                     mb={-1}
                     mt={-1}
-                    onClick={() => toggleLock?.()}
+                    onClick={() => toggleNodeLock(id)}
                 />
             </Center>
             <Spacer />

--- a/src/components/node/NodeFooter.tsx
+++ b/src/components/node/NodeFooter.tsx
@@ -20,8 +20,9 @@ import {
     Tooltip,
     useColorModeValue,
 } from '@chakra-ui/react';
-import { memo, useContext, useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { MdMoreHoriz } from 'react-icons/md';
+import { useContext } from 'use-context-selector';
 import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import { MenuFunctionsContext } from '../../helpers/contexts/MenuFunctions';
 

--- a/src/components/node/NodeFooter.tsx
+++ b/src/components/node/NodeFooter.tsx
@@ -22,7 +22,7 @@ import {
 } from '@chakra-ui/react';
 import { memo, useContext, useEffect, useState } from 'react';
 import { MdMoreHoriz } from 'react-icons/md';
-import { GlobalContext, GlobalSettersContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import { MenuFunctionsContext } from '../../helpers/contexts/MenuFunctions';
 
 interface NodeFooterProps {
@@ -33,8 +33,8 @@ interface NodeFooterProps {
 }
 
 const NodeFooter = ({ id, isValid = false, invalidReason = '', isLocked }: NodeFooterProps) => {
-    const { duplicateNode } = useContext(GlobalContext);
-    const { removeNodeById, clearNode, toggleNodeLock } = useContext(GlobalSettersContext);
+    const { duplicateNode } = useContext(GlobalChainContext);
+    const { removeNodeById, clearNode, toggleNodeLock } = useContext(GlobalContext);
     const { addMenuCloseFunction } = useContext(MenuFunctionsContext);
 
     const iconShade = useColorModeValue('gray.400', 'gray.800');

--- a/src/components/node/NodeFooter.tsx
+++ b/src/components/node/NodeFooter.tsx
@@ -22,7 +22,7 @@ import {
 } from '@chakra-ui/react';
 import { memo, useEffect, useState } from 'react';
 import { MdMoreHoriz } from 'react-icons/md';
-import { useContext } from 'use-context-selector';
+import { useContext, useContextSelector } from 'use-context-selector';
 import { GlobalChainContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import { MenuFunctionsContext } from '../../helpers/contexts/MenuFunctions';
 
@@ -34,7 +34,7 @@ interface NodeFooterProps {
 }
 
 const NodeFooter = ({ id, isValid = false, invalidReason = '', isLocked }: NodeFooterProps) => {
-    const { duplicateNode } = useContext(GlobalChainContext);
+    const duplicateNode = useContextSelector(GlobalChainContext, (c) => c.duplicateNode);
     const { removeNodeById, clearNode, toggleNodeLock } = useContext(GlobalContext);
     const { addMenuCloseFunction } = useContext(MenuFunctionsContext);
 

--- a/src/components/node/NodeInputs.tsx
+++ b/src/components/node/NodeInputs.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import { memo, useCallback, useContext } from 'react';
+import { memo, useCallback } from 'react';
+import { useContext } from 'use-context-selector';
 import { Input, InputData, InputSchemaValue } from '../../common-types';
 import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import DirectoryInput from '../inputs/DirectoryInput';

--- a/src/components/node/NodeInputs.tsx
+++ b/src/components/node/NodeInputs.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useCallback, useContext } from 'react';
 import { Input, InputData, InputSchemaValue } from '../../common-types';
-import { GlobalSettersContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import DirectoryInput from '../inputs/DirectoryInput';
 import DropDownInput from '../inputs/DropDownInput';
 import FileInput from '../inputs/FileInput';
@@ -115,7 +115,7 @@ const NodeInputs = ({
     isLocked,
     schemaId,
 }: NodeInputsProps) => {
-    const { useInputData: useInputDataContext } = useContext(GlobalSettersContext);
+    const { useInputData: useInputDataContext } = useContext(GlobalContext);
 
     const useInputData = useCallback(
         <T extends InputSchemaValue>(index: number) => useInputDataContext<T>(id, index, inputData),

--- a/src/components/node/NodeInputs.tsx
+++ b/src/components/node/NodeInputs.tsx
@@ -1,31 +1,28 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import { memo } from 'react';
-import { Input } from '../../common-types';
+import { memo, useCallback, useContext } from 'react';
+import { Input, InputData, InputSchemaValue } from '../../common-types';
+import { GlobalSettersContext } from '../../helpers/contexts/GlobalNodeState';
 import DirectoryInput from '../inputs/DirectoryInput';
 import DropDownInput from '../inputs/DropDownInput';
 import FileInput from '../inputs/FileInput';
 import GenericInput from '../inputs/GenericInput';
 import InputContainer from '../inputs/InputContainer';
 import NumberInput from '../inputs/NumberInput';
+import { InputProps } from '../inputs/props';
 import SliderInput from '../inputs/SliderInput';
 import TextAreaInput from '../inputs/TextAreaInput';
 import TextInput from '../inputs/TextInput';
 
-interface InputProps extends Input {
-    id: string;
-    index: number;
+interface FullInputProps extends Input, InputProps {
     type: string;
     accentColor: string;
-    isLocked?: boolean;
-    category: string;
-    name: string;
     hasHandle?: boolean;
     schemaId: string;
 }
 
 // TODO: perhaps make this an object instead of a switch statement
-const pickInput = (type: string, props: InputProps) => {
+const pickInput = (type: string, props: FullInputProps) => {
     let InputType: React.MemoExoticComponent<(props: any) => JSX.Element> = GenericInput;
     switch (type) {
         case 'file::image':
@@ -84,7 +81,7 @@ const pickInput = (type: string, props: InputProps) => {
                     index={props.index}
                     key={`${props.id}-${props.index}`}
                 >
-                    <GenericInput label={props.label} />
+                    <GenericInput {...props} />
                 </InputContainer>
             );
     }
@@ -104,37 +101,44 @@ const pickInput = (type: string, props: InputProps) => {
 interface NodeInputsProps {
     inputs: readonly Input[];
     id: string;
+    inputData: InputData;
     accentColor: string;
     isLocked?: boolean;
-    category: string;
-    name: string;
     schemaId: string;
 }
 
 const NodeInputs = ({
     inputs,
     id,
+    inputData,
     accentColor,
     isLocked,
-    category,
-    name,
     schemaId,
-}: NodeInputsProps) => (
-    <>
-        {inputs.map((input, i) => {
-            const props: InputProps = {
-                ...input,
-                id,
-                index: i,
-                type: input.type,
-                accentColor,
-                isLocked,
-                category,
-                name,
-                schemaId,
-            };
-            return pickInput(input.type, props);
-        })}
-    </>
-);
+}: NodeInputsProps) => {
+    const { useInputData: useInputDataContext } = useContext(GlobalSettersContext);
+
+    const useInputData = useCallback(
+        <T extends InputSchemaValue>(index: number) => useInputDataContext<T>(id, index, inputData),
+        [useInputDataContext, id, inputData]
+    );
+
+    return (
+        <>
+            {inputs.map((input, i) => {
+                const props: FullInputProps = {
+                    ...input,
+                    id,
+                    index: i,
+                    inputData,
+                    useInputData,
+                    type: input.type,
+                    accentColor,
+                    isLocked: isLocked ?? false,
+                    schemaId,
+                };
+                return pickInput(input.type, props);
+            })}
+        </>
+    );
+};
 export default memo(NodeInputs);

--- a/src/components/outputs/OutputContainer.tsx
+++ b/src/components/outputs/OutputContainer.tsx
@@ -1,7 +1,7 @@
 import { Box, HStack, useColorModeValue } from '@chakra-ui/react';
 import React, { memo } from 'react';
 import { Handle, Position } from 'react-flow-renderer';
-import { useContext } from 'use-context-selector';
+import { useContextSelector } from 'use-context-selector';
 import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 
 interface OutputContainerProps {
@@ -12,7 +12,10 @@ interface OutputContainerProps {
 
 const OutputContainer = memo(
     ({ children, hasHandle, index, id }: React.PropsWithChildren<OutputContainerProps>) => {
-        const { isValidConnection } = useContext(GlobalChainContext);
+        const isValidConnection = useContextSelector(
+            GlobalChainContext,
+            (c) => c.isValidConnection
+        );
 
         let contents = children;
         if (hasHandle) {

--- a/src/components/outputs/OutputContainer.tsx
+++ b/src/components/outputs/OutputContainer.tsx
@@ -1,6 +1,7 @@
 import { Box, HStack, useColorModeValue } from '@chakra-ui/react';
-import React, { memo, useContext } from 'react';
+import React, { memo } from 'react';
 import { Handle, Position } from 'react-flow-renderer';
+import { useContext } from 'use-context-selector';
 import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 
 interface OutputContainerProps {

--- a/src/components/outputs/OutputContainer.tsx
+++ b/src/components/outputs/OutputContainer.tsx
@@ -2,7 +2,7 @@ import { Box, HStack, useColorModeValue } from '@chakra-ui/react';
 import React, { memo } from 'react';
 import { Handle, Position } from 'react-flow-renderer';
 import { useContextSelector } from 'use-context-selector';
-import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalVolatileContext } from '../../helpers/contexts/GlobalNodeState';
 
 interface OutputContainerProps {
     hasHandle: boolean;
@@ -13,7 +13,7 @@ interface OutputContainerProps {
 const OutputContainer = memo(
     ({ children, hasHandle, index, id }: React.PropsWithChildren<OutputContainerProps>) => {
         const isValidConnection = useContextSelector(
-            GlobalChainContext,
+            GlobalVolatileContext,
             (c) => c.isValidConnection
         );
 

--- a/src/components/outputs/OutputContainer.tsx
+++ b/src/components/outputs/OutputContainer.tsx
@@ -1,7 +1,7 @@
 import { Box, HStack, useColorModeValue } from '@chakra-ui/react';
 import React, { memo, useContext } from 'react';
 import { Handle, Position } from 'react-flow-renderer';
-import { GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { GlobalChainContext } from '../../helpers/contexts/GlobalNodeState';
 
 interface OutputContainerProps {
     hasHandle: boolean;
@@ -11,7 +11,7 @@ interface OutputContainerProps {
 
 const OutputContainer = memo(
     ({ children, hasHandle, index, id }: React.PropsWithChildren<OutputContainerProps>) => {
-        const { isValidConnection } = useContext(GlobalContext);
+        const { isValidConnection } = useContext(GlobalChainContext);
 
         let contents = children;
         if (hasHandle) {

--- a/src/helpers/contexts/AlertBoxContext.tsx
+++ b/src/helpers/contexts/AlertBoxContext.tsx
@@ -11,7 +11,8 @@ import {
     useDisclosure,
 } from '@chakra-ui/react';
 import { app, clipboard } from 'electron';
-import React, { createContext, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
+import { createContext } from 'use-context-selector';
 import { assertNever } from '../util';
 
 interface AlertBox {

--- a/src/helpers/contexts/ExecutionContext.tsx
+++ b/src/helpers/contexts/ExecutionContext.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Edge, Node } from 'react-flow-renderer';
+import { createContext, useContext } from 'use-context-selector';
 import { useThrottledCallback } from 'use-debounce';
 import { EdgeData, NodeData, UsableData } from '../../common-types';
 import { getBackend } from '../Backend';

--- a/src/helpers/contexts/ExecutionContext.tsx
+++ b/src/helpers/contexts/ExecutionContext.tsx
@@ -12,7 +12,7 @@ import {
 } from '../hooks/useBackendEventSource';
 import { parseHandle } from '../util';
 import { AlertBoxContext, AlertType } from './AlertBoxContext';
-import { GlobalChainContext, GlobalContext } from './GlobalNodeState';
+import { GlobalVolatileContext, GlobalContext } from './GlobalNodeState';
 import { SettingsContext } from './SettingsContext';
 
 interface ExecutionContextProps {
@@ -88,8 +88,8 @@ export const ExecutionContext = createContext<Readonly<ExecutionContextProps>>(
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const ExecutionProvider = ({ children }: React.PropsWithChildren<{}>) => {
-    const nodes = useContextSelector(GlobalChainContext, (c) => c.nodes);
-    const edges = useContextSelector(GlobalChainContext, (c) => c.edges);
+    const nodes = useContextSelector(GlobalVolatileContext, (c) => c.nodes);
+    const edges = useContextSelector(GlobalVolatileContext, (c) => c.edges);
     const { schemata, useAnimateEdges, setIteratorPercent } = useContext(GlobalContext);
 
     const { useIsCpu, useIsFp16, port } = useContext(SettingsContext);

--- a/src/helpers/contexts/ExecutionContext.tsx
+++ b/src/helpers/contexts/ExecutionContext.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Edge, Node } from 'react-flow-renderer';
-import { createContext, useContext } from 'use-context-selector';
+import { createContext, useContext, useContextSelector } from 'use-context-selector';
 import { useThrottledCallback } from 'use-debounce';
 import { EdgeData, NodeData, UsableData } from '../../common-types';
 import { getBackend } from '../Backend';
@@ -88,7 +88,8 @@ export const ExecutionContext = createContext<Readonly<ExecutionContextProps>>(
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const ExecutionProvider = ({ children }: React.PropsWithChildren<{}>) => {
-    const { nodes, edges } = useContext(GlobalChainContext);
+    const nodes = useContextSelector(GlobalChainContext, (c) => c.nodes);
+    const edges = useContextSelector(GlobalChainContext, (c) => c.edges);
     const { schemata, useAnimateEdges, setIteratorPercent } = useContext(GlobalContext);
 
     const { useIsCpu, useIsFp16, port } = useContext(SettingsContext);

--- a/src/helpers/contexts/ExecutionContext.tsx
+++ b/src/helpers/contexts/ExecutionContext.tsx
@@ -11,7 +11,7 @@ import {
 } from '../hooks/useBackendEventSource';
 import { parseHandle } from '../util';
 import { AlertBoxContext, AlertType } from './AlertBoxContext';
-import { GlobalContext } from './GlobalNodeState';
+import { GlobalConstantsContext, GlobalContext, GlobalSettersContext } from './GlobalNodeState';
 import { SettingsContext } from './SettingsContext';
 
 interface ExecutionContextProps {
@@ -87,8 +87,9 @@ export const ExecutionContext = createContext<Readonly<ExecutionContextProps>>(
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const ExecutionProvider = ({ children }: React.PropsWithChildren<{}>) => {
-    const { useAnimateEdges, nodes, edges, schemata, setIteratorPercent } =
-        useContext(GlobalContext);
+    const { nodes, edges } = useContext(GlobalContext);
+    const { schemata } = useContext(GlobalConstantsContext);
+    const { useAnimateEdges, setIteratorPercent } = useContext(GlobalSettersContext);
 
     const { useIsCpu, useIsFp16, port } = useContext(SettingsContext);
 

--- a/src/helpers/contexts/ExecutionContext.tsx
+++ b/src/helpers/contexts/ExecutionContext.tsx
@@ -11,7 +11,7 @@ import {
 } from '../hooks/useBackendEventSource';
 import { parseHandle } from '../util';
 import { AlertBoxContext, AlertType } from './AlertBoxContext';
-import { GlobalConstantsContext, GlobalContext, GlobalSettersContext } from './GlobalNodeState';
+import { GlobalChainContext, GlobalContext } from './GlobalNodeState';
 import { SettingsContext } from './SettingsContext';
 
 interface ExecutionContextProps {
@@ -87,9 +87,8 @@ export const ExecutionContext = createContext<Readonly<ExecutionContextProps>>(
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const ExecutionProvider = ({ children }: React.PropsWithChildren<{}>) => {
-    const { nodes, edges } = useContext(GlobalContext);
-    const { schemata } = useContext(GlobalConstantsContext);
-    const { useAnimateEdges, setIteratorPercent } = useContext(GlobalSettersContext);
+    const { nodes, edges } = useContext(GlobalChainContext);
+    const { schemata, useAnimateEdges, setIteratorPercent } = useContext(GlobalContext);
 
     const { useIsCpu, useIsFp16, port } = useContext(SettingsContext);
 

--- a/src/helpers/contexts/GlobalNodeState.tsx
+++ b/src/helpers/contexts/GlobalNodeState.tsx
@@ -6,13 +6,12 @@ import {
     Edge,
     getOutgoers,
     Node,
-    ReactFlowInstance,
     useKeyPress,
     useReactFlow,
     Viewport,
     XYPosition,
 } from 'react-flow-renderer';
-import { createContext, useContext, useContextSelector } from 'use-context-selector';
+import { createContext, useContextSelector } from 'use-context-selector';
 import { v4 as uuidv4 } from 'uuid';
 import {
     EdgeData,
@@ -39,7 +38,6 @@ interface GlobalVolatile {
     edges: readonly Edge<EdgeData>[];
     createNode: (proto: NodeProto) => void;
     createConnection: (connection: Connection) => void;
-    reactFlowInstance: ReactFlowInstance<NodeData, EdgeData> | null;
     isValidConnection: (connection: Readonly<Connection>) => boolean;
     isNodeInputLocked: (id: string, index: number) => boolean;
     duplicateNode: (id: string) => void;
@@ -51,7 +49,6 @@ interface Global {
     reactFlowWrapper: React.RefObject<Element>;
     setNodes: SetState<Node<NodeData>[]>;
     setEdges: SetState<Edge<EdgeData>[]>;
-    setReactFlowInstance: SetState<ReactFlowInstance<NodeData, EdgeData> | null>;
     useAnimateEdges: () => readonly [
         (nodeIdsToAnimate?: readonly string[] | undefined) => void,
         (nodeIdsToUnAnimate?: readonly string[] | undefined) => void,
@@ -192,10 +189,6 @@ export const GlobalProvider = ({
         if (cachedViewport) setViewport(cachedViewport);
     }, []);
 
-    const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance<
-        NodeData,
-        EdgeData
-    > | null>(null);
     const [savePath, setSavePath] = useState<string | undefined>();
 
     const [loadedFromCli] = useSessionStorage('loaded-from-cli', false);
@@ -722,7 +715,6 @@ export const GlobalProvider = ({
         edges,
         createNode,
         createConnection,
-        reactFlowInstance,
         isValidConnection,
         isNodeInputLocked,
         duplicateNode,
@@ -736,7 +728,6 @@ export const GlobalProvider = ({
         reactFlowWrapper,
         setNodes,
         setEdges,
-        setReactFlowInstance,
         useAnimateEdges,
         useInputData,
         toggleNodeLock,

--- a/src/helpers/contexts/GlobalNodeState.tsx
+++ b/src/helpers/contexts/GlobalNodeState.tsx
@@ -34,7 +34,7 @@ import { SettingsContext } from './SettingsContext';
 
 type SetState<T> = React.Dispatch<React.SetStateAction<T>>;
 
-interface Global {
+interface GlobalVolatile {
     nodes: readonly Node<NodeData>[];
     edges: readonly Edge<EdgeData>[];
     createNode: (proto: NodeProto) => void;
@@ -46,7 +46,7 @@ interface Global {
     zoom: number;
     hoveredNode: string | null | undefined;
 }
-interface GlobalSetters {
+interface Global {
     schemata: SchemaMap;
     reactFlowWrapper: React.RefObject<Element>;
     setNodes: SetState<Node<NodeData>[]>;
@@ -87,8 +87,8 @@ interface NodeProto {
 }
 
 // TODO: Find default
-export const GlobalChainContext = createContext<Readonly<Global>>({} as Global);
-export const GlobalContext = createContext<Readonly<GlobalSetters>>({} as GlobalSetters);
+export const GlobalVolatileContext = createContext<Readonly<GlobalVolatile>>({} as GlobalVolatile);
+export const GlobalContext = createContext<Readonly<Global>>({} as Global);
 
 const createUniqueId = () => uuidv4();
 
@@ -717,7 +717,7 @@ export const GlobalProvider = ({
         [setZoom]
     );
 
-    let globalChainValue: Global = {
+    let globalChainValue: GlobalVolatile = {
         nodes,
         edges,
         createNode,
@@ -731,7 +731,7 @@ export const GlobalProvider = ({
     };
     globalChainValue = useMemo(() => globalChainValue, Object.values(globalChainValue));
 
-    let globalValue: GlobalSetters = {
+    let globalValue: Global = {
         schemata,
         reactFlowWrapper,
         setNodes,
@@ -752,8 +752,8 @@ export const GlobalProvider = ({
     globalValue = useMemo(() => globalValue, Object.values(globalValue));
 
     return (
-        <GlobalChainContext.Provider value={globalChainValue}>
+        <GlobalVolatileContext.Provider value={globalChainValue}>
             <GlobalContext.Provider value={globalValue}>{children}</GlobalContext.Provider>
-        </GlobalChainContext.Provider>
+        </GlobalVolatileContext.Provider>
     );
 };

--- a/src/helpers/contexts/GlobalNodeState.tsx
+++ b/src/helpers/contexts/GlobalNodeState.tsx
@@ -182,8 +182,6 @@ export const GlobalProvider = ({
     const [edges, setEdges] = useState<Edge<EdgeData>[]>(cachedEdges);
     const { setViewport, getViewport } = useReactFlow();
 
-    console.log('here');
-
     // Cache node state to avoid clearing state when refreshing
     useEffect(() => {
         const timerId = setTimeout(() => {

--- a/src/helpers/contexts/GlobalNodeState.tsx
+++ b/src/helpers/contexts/GlobalNodeState.tsx
@@ -12,7 +12,7 @@ import {
     Viewport,
     XYPosition,
 } from 'react-flow-renderer';
-import { createContext, useContext } from 'use-context-selector';
+import { createContext, useContext, useContextSelector } from 'use-context-selector';
 import { v4 as uuidv4 } from 'uuid';
 import {
     EdgeData,
@@ -173,7 +173,7 @@ export const GlobalProvider = ({
     schemata,
     reactFlowWrapper,
 }: React.PropsWithChildren<GlobalProviderProps>) => {
-    const { useSnapToGrid } = useContext(SettingsContext);
+    const useSnapToGrid = useContextSelector(SettingsContext, (c) => c.useSnapToGrid);
 
     const [nodes, setNodes] = useState<Node<NodeData>[]>(cachedNodes);
     const [edges, setEdges] = useState<Edge<EdgeData>[]>(cachedEdges);

--- a/src/helpers/contexts/GlobalNodeState.tsx
+++ b/src/helpers/contexts/GlobalNodeState.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import log from 'electron-log';
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
     Connection,
     Edge,
@@ -12,6 +12,7 @@ import {
     Viewport,
     XYPosition,
 } from 'react-flow-renderer';
+import { createContext, useContext } from 'use-context-selector';
 import { v4 as uuidv4 } from 'uuid';
 import {
     EdgeData,

--- a/src/helpers/contexts/GlobalNodeState.tsx
+++ b/src/helpers/contexts/GlobalNodeState.tsx
@@ -567,7 +567,7 @@ export const GlobalProvider = ({
                     parseHandle(e.targetHandle).index === index
             );
         },
-        [modifyNode]
+        [edges]
     );
 
     const useIteratorSize = useCallback(

--- a/src/helpers/contexts/GlobalNodeState.tsx
+++ b/src/helpers/contexts/GlobalNodeState.tsx
@@ -45,11 +45,9 @@ interface Global {
     zoom: number;
     hoveredNode: string | null | undefined;
 }
-interface GlobalConstants {
+interface GlobalSetters {
     schemata: SchemaMap;
     reactFlowWrapper: React.RefObject<Element>;
-}
-interface GlobalSetters {
     setNodes: SetState<Node<NodeData>[]>;
     setEdges: SetState<Edge<EdgeData>[]>;
     setReactFlowInstance: SetState<ReactFlowInstance<NodeData, EdgeData> | null>;
@@ -88,11 +86,8 @@ interface NodeProto {
 }
 
 // TODO: Find default
-export const GlobalContext = createContext<Readonly<Global>>({} as Global);
-export const GlobalConstantsContext = createContext<Readonly<GlobalConstants>>(
-    {} as GlobalConstants
-);
-export const GlobalSettersContext = createContext<Readonly<GlobalSetters>>({} as GlobalSetters);
+export const GlobalChainContext = createContext<Readonly<Global>>({} as Global);
+export const GlobalContext = createContext<Readonly<GlobalSetters>>({} as GlobalSetters);
 
 const createUniqueId = () => uuidv4();
 
@@ -721,7 +716,7 @@ export const GlobalProvider = ({
         [setZoom]
     );
 
-    let globalValue: Global = {
+    let globalChainValue: Global = {
         nodes,
         edges,
         createNode,
@@ -733,15 +728,11 @@ export const GlobalProvider = ({
         zoom,
         hoveredNode,
     };
-    globalValue = useMemo(() => globalValue, Object.values(globalValue));
+    globalChainValue = useMemo(() => globalChainValue, Object.values(globalChainValue));
 
-    let globalConstantsValue: GlobalConstants = {
+    let globalValue: GlobalSetters = {
         schemata,
         reactFlowWrapper,
-    };
-    globalConstantsValue = useMemo(() => globalConstantsValue, Object.values(globalConstantsValue));
-
-    let globalSettersValue: GlobalSetters = {
         setNodes,
         setEdges,
         setReactFlowInstance,
@@ -757,15 +748,11 @@ export const GlobalProvider = ({
         setHoveredNode,
         onMoveEnd,
     };
-    globalSettersValue = useMemo(() => globalSettersValue, Object.values(globalSettersValue));
+    globalValue = useMemo(() => globalValue, Object.values(globalValue));
 
     return (
-        <GlobalContext.Provider value={globalValue}>
-            <GlobalConstantsContext.Provider value={globalConstantsValue}>
-                <GlobalSettersContext.Provider value={globalSettersValue}>
-                    {children}
-                </GlobalSettersContext.Provider>
-            </GlobalConstantsContext.Provider>
-        </GlobalContext.Provider>
+        <GlobalChainContext.Provider value={globalChainValue}>
+            <GlobalContext.Provider value={globalValue}>{children}</GlobalContext.Provider>
+        </GlobalChainContext.Provider>
     );
 };

--- a/src/helpers/contexts/MenuFunctions.tsx
+++ b/src/helpers/contexts/MenuFunctions.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-import React, { createContext, useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
+import { createContext } from 'use-context-selector';
 import { noop } from '../util';
 
 interface MenuFunctions {

--- a/src/helpers/contexts/MenuFunctions.tsx
+++ b/src/helpers/contexts/MenuFunctions.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-shadow */
+import React, { createContext, useCallback, useMemo, useState } from 'react';
+import { noop } from '../util';
+
+interface MenuFunctions {
+    closeAllMenus: () => void;
+    addMenuCloseFunction: (func: () => void, id: string) => void;
+}
+
+export const MenuFunctionsContext = createContext<Readonly<MenuFunctions>>({
+    closeAllMenus: noop,
+    addMenuCloseFunction: noop,
+});
+
+export const MenuFunctionsProvider = ({ children }: React.PropsWithChildren<unknown>) => {
+    const [menuCloseFunctions, setMenuCloseFunctions] = useState<Record<string, () => void>>({});
+
+    const addMenuCloseFunction = useCallback(
+        (func: () => void, id: string) => {
+            setMenuCloseFunctions((menuCloseFunctions) => ({ ...menuCloseFunctions, [id]: func }));
+        },
+        [setMenuCloseFunctions]
+    );
+
+    const closeAllMenus = useCallback(() => {
+        Object.keys(menuCloseFunctions).forEach((id) => {
+            menuCloseFunctions[id]();
+        });
+    }, [menuCloseFunctions]);
+
+    let contextValue: MenuFunctions = {
+        addMenuCloseFunction,
+        closeAllMenus,
+    };
+    contextValue = useMemo(() => contextValue, Object.values(contextValue));
+
+    return (
+        <MenuFunctionsContext.Provider value={contextValue}>
+            {children}
+        </MenuFunctionsContext.Provider>
+    );
+};

--- a/src/helpers/contexts/SettingsContext.tsx
+++ b/src/helpers/contexts/SettingsContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useMemo } from 'react';
+import React, { useMemo } from 'react';
+import { createContext } from 'use-context-selector';
 import useLocalStorage from '../hooks/useLocalStorage';
 
 interface Settings {

--- a/src/helpers/hooks/useLocalStorage.ts
+++ b/src/helpers/hooks/useLocalStorage.ts
@@ -25,7 +25,7 @@ const getLocalStorageOrDefault = <T>(key: string, defaultValue: T): T => {
 };
 
 const useLocalStorage = <T>(key: string, defaultValue: T) => {
-    const [value, setValue] = useState(getLocalStorageOrDefault(key, defaultValue));
+    const [value, setValue] = useState(() => getLocalStorageOrDefault(key, defaultValue));
 
     useEffect(() => {
         getCustomLocalStorage().setItem(key, JSON.stringify(value));

--- a/src/helpers/hooks/useSessionStorage.ts
+++ b/src/helpers/hooks/useSessionStorage.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-const getSessionStorageOrDefault = <T>(key: string, defaultValue: T): T => {
+export const getSessionStorageOrDefault = <T>(key: string, defaultValue: T): T => {
     const stored = sessionStorage.getItem(key);
     if (!stored) {
         return defaultValue;
@@ -9,7 +9,7 @@ const getSessionStorageOrDefault = <T>(key: string, defaultValue: T): T => {
 };
 
 const useSessionStorage = <T>(key: string, defaultValue: T) => {
-    const [value, setValue] = useState(getSessionStorageOrDefault(key, defaultValue));
+    const [value, setValue] = useState(() => getSessionStorageOrDefault(key, defaultValue));
 
     useEffect(() => {
         sessionStorage.setItem(key, JSON.stringify(value));

--- a/src/pages/main.tsx
+++ b/src/pages/main.tsx
@@ -15,6 +15,7 @@ import ReactFlowBox from '../components/ReactFlowBox';
 import { BackendNodesResponse } from '../helpers/Backend';
 import { AlertBoxContext, AlertType } from '../helpers/contexts/AlertBoxContext';
 import { GlobalProvider } from '../helpers/contexts/GlobalNodeState';
+import { MenuFunctionsProvider } from '../helpers/contexts/MenuFunctions';
 import { SettingsProvider } from '../helpers/contexts/SettingsContext';
 import { ipcRenderer } from '../helpers/safeIpc';
 import { SchemaMap } from '../helpers/SchemaMap';
@@ -100,36 +101,38 @@ const Main = ({ port }: MainProps) => {
                     reactFlowWrapper={reactFlowWrapper}
                     schemata={schemata}
                 >
-                    <VStack
-                        bg={bgColor}
-                        overflow="hidden"
-                        p={2}
-                    >
-                        <Header port={port} />
-                        <HStack
-                            as={Split}
-                            defaultSplitterColors={{
-                                color: '#71809633',
-                                hover: '#71809666',
-                                drag: '#718096EE',
-                            }}
-                            initialPrimarySize="380px"
-                            minPrimarySize="290px"
-                            minSecondarySize="75%"
-                            splitterSize="10px"
+                    <MenuFunctionsProvider>
+                        <VStack
+                            bg={bgColor}
+                            overflow="hidden"
+                            p={2}
                         >
-                            <NodeSelector
-                                height={height}
-                                schemata={schemata}
-                            />
+                            <Header port={port} />
+                            <HStack
+                                as={Split}
+                                defaultSplitterColors={{
+                                    color: '#71809633',
+                                    hover: '#71809666',
+                                    drag: '#718096EE',
+                                }}
+                                initialPrimarySize="380px"
+                                minPrimarySize="290px"
+                                minSecondarySize="75%"
+                                splitterSize="10px"
+                            >
+                                <NodeSelector
+                                    height={height}
+                                    schemata={schemata}
+                                />
 
-                            <ReactFlowBox
-                                edgeTypes={edgeTypes}
-                                nodeTypes={nodeTypes}
-                                wrapperRef={reactFlowWrapper}
-                            />
-                        </HStack>
-                    </VStack>
+                                <ReactFlowBox
+                                    edgeTypes={edgeTypes}
+                                    nodeTypes={nodeTypes}
+                                    wrapperRef={reactFlowWrapper}
+                                />
+                            </HStack>
+                        </VStack>
+                    </MenuFunctionsProvider>
                 </GlobalProvider>
             </SettingsProvider>
         </ReactFlowProvider>

--- a/src/pages/main.tsx
+++ b/src/pages/main.tsx
@@ -1,8 +1,9 @@
 import { Box, Center, HStack, Text, useColorModeValue, VStack } from '@chakra-ui/react';
 import { Split } from '@geoffcox/react-splitter';
 import { useWindowHeight } from '@react-hook/window-size';
-import { memo, useContext, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { EdgeTypes, NodeTypes, ReactFlowProvider } from 'react-flow-renderer';
+import { useContext } from 'use-context-selector';
 import useFetch, { CachePolicies } from 'use-http';
 import ChaiNNerLogo from '../components/chaiNNerLogo';
 import CustomEdge from '../components/CustomEdge';


### PR DESCRIPTION
This PR does a bunch of things around `GlobalContext`:

- Split `GlobalContext` into `GlobalContext` (mostly never-changing stuff) and `GlobalVolitileContext` (stuff that changes all the time (nodes, edges))
- Changed some APIs and returned context values to make them more memoizable.
- Use [`use-context-selector`](https://github.com/dai-shi/use-context-selector) for contexts to avoid re-rendering.
- Changed how input elements get their data to avoid re-rendering.
- More efficient way to store nodes and edges in session storage to avoid re-rendering.