### PR TITLE
Fix menu memory leak

### DIFF
--- a/src/components/ReactFlowBox.tsx
+++ b/src/components/ReactFlowBox.tsx
@@ -137,11 +137,15 @@ const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) =
         }
     }, [snapToGridAmount, nodes]);
 
-    const onDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
-        event.preventDefault();
-        // eslint-disable-next-line no-param-reassign
-        event.dataTransfer.dropEffect = 'move';
-    }, []);
+    const onDragOver = useCallback(
+        (event: DragEvent<HTMLDivElement>) => {
+            closeAllMenus();
+            event.preventDefault();
+            // eslint-disable-next-line no-param-reassign
+            event.dataTransfer.dropEffect = 'move';
+        },
+        [closeAllMenus]
+    );
 
     const onDragStart = useCallback(() => {
         setHoveredNode(null);
@@ -223,7 +227,9 @@ const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) =
                 onEdgesChange={onEdgesChange}
                 onEdgesDelete={onEdgesDelete}
                 // onSelectionChange={setSelectedElements}
+                onMouseDown={closeAllMenus}
                 onMoveEnd={onMoveEnd}
+                onMoveStart={closeAllMenus}
                 onNodeContextMenu={onNodeContextMenu}
                 onNodeDragStop={onNodeDragStop}
                 onNodesChange={onNodesChange}

--- a/src/components/node/NodeFooter.tsx
+++ b/src/components/node/NodeFooter.tsx
@@ -46,15 +46,8 @@ const NodeFooter = ({ id, isValid = false, invalidReason = '', isLocked }: NodeF
 
     const [isOpen, setIsOpen] = useState(false);
     useEffect(() => {
-        addMenuCloseFunction(() => {
-            setIsOpen(false);
-        }, id);
-    }, [isOpen]);
-    useEffect(() => {
-        addMenuCloseFunction(() => {
-            setIsOpen(false);
-        }, id);
-    }, []);
+        return addMenuCloseFunction(() => setIsOpen(false), id);
+    }, [id]);
 
     return (
         <Flex
@@ -106,6 +99,8 @@ const NodeFooter = ({ id, isValid = false, invalidReason = '', isLocked }: NodeF
             <Spacer />
             <Center>
                 <Menu
+                    closeOnBlur
+                    closeOnSelect
                     isOpen={isOpen}
                     onClose={() => {
                         setIsOpen(false);


### PR DESCRIPTION
Adding menu close functions by never removing any is a memory leak. A small one, but one nonetheless.

While I was testing this, I also improved when menus close. They will now close on a bunch more things which improves the overall feel of menus.