### PR TITLE
Remember last directory

### DIFF
--- a/src/components/inputs/DirectoryInput.tsx
+++ b/src/components/inputs/DirectoryInput.tsx
@@ -5,43 +5,51 @@ import { useContextSelector } from 'use-context-selector';
 import { ipcRenderer } from '../../helpers/safeIpc';
 import { GlobalVolatileContext } from '../../helpers/contexts/GlobalNodeState';
 import { InputProps } from './props';
+import { useLastDirectory } from '../../helpers/hooks/useLastDirectory';
 
 type DirectoryInputProps = InputProps;
 
-const DirectoryInput = memo(({ id, index, isLocked, useInputData }: DirectoryInputProps) => {
-    const isInputLocked = useContextSelector(GlobalVolatileContext, (c) =>
-        c.isNodeInputLocked(id, index)
-    );
+const DirectoryInput = memo(
+    ({ id, index, isLocked, useInputData, schemaId }: DirectoryInputProps) => {
+        const isInputLocked = useContextSelector(GlobalVolatileContext, (c) =>
+            c.isNodeInputLocked(id, index)
+        );
 
-    const [directory, setDirectory] = useInputData<string>(index);
+        const [directory, setDirectory] = useInputData<string>(index);
+        const { getLastDirectory, setLastDirectory } = useLastDirectory(`${schemaId} ${index}`);
 
-    const onButtonClick = async () => {
-        const { canceled, filePaths } = await ipcRenderer.invoke('dir-select', directory ?? '');
-        const path = filePaths[0];
-        if (!canceled && path) {
-            setDirectory(path);
-        }
-    };
+        const onButtonClick = async () => {
+            const { canceled, filePaths } = await ipcRenderer.invoke(
+                'dir-select',
+                directory ?? getLastDirectory() ?? ''
+            );
+            const path = filePaths[0];
+            if (!canceled && path) {
+                setDirectory(path);
+                setLastDirectory(path);
+            }
+        };
 
-    return (
-        <InputGroup>
-            <InputLeftElement pointerEvents="none">
-                <BsFolderPlus />
-            </InputLeftElement>
-            <Input
-                isReadOnly
-                isTruncated
-                className="nodrag"
-                cursor="pointer"
-                disabled={isLocked || isInputLocked}
-                draggable={false}
-                placeholder="Select a directory..."
-                value={directory ?? ''}
-                // eslint-disable-next-line @typescript-eslint/no-misused-promises
-                onClick={onButtonClick}
-            />
-        </InputGroup>
-    );
-});
+        return (
+            <InputGroup>
+                <InputLeftElement pointerEvents="none">
+                    <BsFolderPlus />
+                </InputLeftElement>
+                <Input
+                    isReadOnly
+                    isTruncated
+                    className="nodrag"
+                    cursor="pointer"
+                    disabled={isLocked || isInputLocked}
+                    draggable={false}
+                    placeholder="Select a directory..."
+                    value={directory ?? ''}
+                    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+                    onClick={onButtonClick}
+                />
+            </InputGroup>
+        );
+    }
+);
 
 export default DirectoryInput;

--- a/src/components/inputs/FileInput.tsx
+++ b/src/components/inputs/FileInput.tsx
@@ -6,6 +6,7 @@ import { useContextSelector } from 'use-context-selector';
 import { GlobalVolatileContext } from '../../helpers/contexts/GlobalNodeState';
 import { ipcRenderer } from '../../helpers/safeIpc';
 import { checkFileExists } from '../../helpers/util';
+import { useLastDirectory } from '../../helpers/hooks/useLastDirectory';
 import ImagePreview from './previews/ImagePreview';
 import TorchModelPreview from './previews/TorchModelPreview';
 import { InputProps } from './props';
@@ -13,7 +14,6 @@ import { InputProps } from './props';
 interface FileInputProps extends InputProps {
     filetypes: readonly string[];
     type: string;
-    schemaId: string;
 }
 
 const FileInput = memo(
@@ -56,8 +56,10 @@ const FileInput = memo(
             }, [binFilePath]);
         }
 
+        const { getLastDirectory, setLastDirectory } = useLastDirectory(`${schemaId} ${index}`);
+
         const onButtonClick = async () => {
-            const fileDir = filePath ? path.dirname(filePath) : undefined;
+            const fileDir = filePath ? path.dirname(filePath) : getLastDirectory();
             const fileFilter = [
                 {
                     name: label,
@@ -73,6 +75,7 @@ const FileInput = memo(
             const selectedPath = filePaths[0];
             if (!canceled && selectedPath) {
                 setFilePath(selectedPath);
+                setLastDirectory(path.dirname(selectedPath));
             }
         };
 

--- a/src/components/inputs/props.ts
+++ b/src/components/inputs/props.ts
@@ -6,6 +6,7 @@ export interface InputProps {
     readonly inputData: InputData;
     readonly isLocked: boolean;
     readonly label: string;
+    readonly schemaId: string;
     readonly useInputData: <T extends InputSchemaValue>(
         index: number
     ) => readonly [T | undefined, (value: T) => void];

--- a/src/components/node/NodeInputs.tsx
+++ b/src/components/node/NodeInputs.tsx
@@ -19,7 +19,6 @@ interface FullInputProps extends Input, InputProps {
     type: string;
     accentColor: string;
     hasHandle?: boolean;
-    schemaId: string;
 }
 
 // TODO: perhaps make this an object instead of a switch statement

--- a/src/helpers/hooks/useLastDirectory.ts
+++ b/src/helpers/hooks/useLastDirectory.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { getLocalStorage } from '../util';
+
+export interface UseLastDirectory {
+    readonly getLastDirectory: () => string | undefined;
+    readonly setLastDirectory: (dir: string) => void;
+}
+
+export const useLastDirectory = (key: string): UseLastDirectory => {
+    return useMemo<UseLastDirectory>(() => {
+        const storage = getLocalStorage();
+        const storageKey = `use-last-directory-${key}`;
+        return {
+            getLastDirectory: () => {
+                return storage.getItem(storageKey) || undefined;
+            },
+            setLastDirectory: (dir) => {
+                storage.setItem(storageKey, dir);
+            },
+        };
+    }, [key]);
+};

--- a/src/helpers/hooks/useLocalStorage.ts
+++ b/src/helpers/hooks/useLocalStorage.ts
@@ -1,15 +1,10 @@
 import { useEffect, useState } from 'react';
+import { getLocalStorage } from '../util';
 
 // TODO: Remove old localStorage code once enough time has passed that most users have migrated
 
-const getCustomLocalStorage = (): Storage => {
-    const storage = (global as Record<string, unknown>).customLocalStorage;
-    if (storage === undefined) throw new Error('Custom storage not defined');
-    return storage as Storage;
-};
-
 const getLocalStorageOrDefault = <T>(key: string, defaultValue: T): T => {
-    const customStorage = getCustomLocalStorage();
+    const customStorage = getLocalStorage();
 
     const stored = customStorage.getItem(key);
     const old = localStorage.getItem(key);
@@ -28,7 +23,7 @@ const useLocalStorage = <T>(key: string, defaultValue: T) => {
     const [value, setValue] = useState(() => getLocalStorageOrDefault(key, defaultValue));
 
     useEffect(() => {
-        getCustomLocalStorage().setItem(key, JSON.stringify(value));
+        getLocalStorage().setItem(key, JSON.stringify(value));
     }, [key, value]);
 
     return [value, setValue] as const;

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -29,3 +29,9 @@ export const parseHandle = (handle: string): ParsedHandle => {
         index: Number(handle.substring(37)),
     };
 };
+
+export const getLocalStorage = (): Storage => {
+    const storage = (global as Record<string, unknown>).customLocalStorage;
+    if (storage === undefined) throw new Error('Custom storage not defined');
+    return storage as Storage;
+};


### PR DESCRIPTION
ChaiNNer will now remember (local storage) the last folder you opened on a per node type per input basis. This should make things easier.

---

Prettier decided to reformat `DirectoryInput.tsx` because the parameters got too long. It's best reviewed with the "Hide whitespace changes" option enabled.