### PR TITLE
Memoize alert box context

### DIFF
--- a/src/helpers/contexts/AlertBoxContext.tsx
+++ b/src/helpers/contexts/AlertBoxContext.tsx
@@ -11,7 +11,7 @@ import {
     useDisclosure,
 } from '@chakra-ui/react';
 import { app, clipboard } from 'electron';
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { createContext } from 'use-context-selector';
 import { assertNever } from '../util';
 
@@ -36,16 +36,16 @@ export const AlertBoxProvider = ({ children }: React.PropsWithChildren<{}>) => {
     const [message, setMessage] = useState<string>('');
     const cancelRef = useRef<HTMLButtonElement>(null);
 
-    const showMessageBox = (
-        newAlertType: AlertType,
-        newTitle: string | null,
-        newMessage: string
-    ) => {
-        setAlertType(newAlertType);
-        setTitle(newTitle ?? newAlertType);
-        setMessage(newMessage);
-        onOpen();
-    };
+    const showMessageBox = useCallback(
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        (alertType: AlertType, title: string | null, message: string) => {
+            setAlertType(alertType);
+            setTitle(title ?? alertType);
+            setMessage(message);
+            onOpen();
+        },
+        [setAlertType, setTitle, setMessage, onOpen]
+    );
 
     const getButtons = (type: AlertType): JSX.Element => {
         switch (type) {
@@ -111,8 +111,11 @@ export const AlertBoxProvider = ({ children }: React.PropsWithChildren<{}>) => {
         app.quit();
     };
 
+    let value: AlertBox = { showMessageBox };
+    value = useMemo(() => value, Object.values(value));
+
     return (
-        <AlertBoxContext.Provider value={{ showMessageBox }}>
+        <AlertBoxContext.Provider value={value}>
             <AlertDialog
                 isCentered
                 isOpen={isOpen}

--- a/src/helpers/contexts/AlertBoxContext.tsx
+++ b/src/helpers/contexts/AlertBoxContext.tsx
@@ -16,7 +16,7 @@ import { createContext } from 'use-context-selector';
 import { assertNever } from '../util';
 
 interface AlertBox {
-    showMessageBox: (newAlertType: AlertType, newTitle: string | null, newMessage: string) => void;
+    showMessageBox: (alertType: AlertType, title: string | null, message: string) => void;
 }
 
 export enum AlertType {
@@ -37,11 +37,10 @@ export const AlertBoxProvider = ({ children }: React.PropsWithChildren<{}>) => {
     const cancelRef = useRef<HTMLButtonElement>(null);
 
     const showMessageBox = useCallback(
-        // eslint-disable-next-line @typescript-eslint/no-shadow
-        (alertType: AlertType, title: string | null, message: string) => {
-            setAlertType(alertType);
-            setTitle(title ?? alertType);
-            setMessage(message);
+        (newAlertType: AlertType, newTitle: string | null, newMessage: string) => {
+            setAlertType(newAlertType);
+            setTitle(newTitle ?? newAlertType);
+            setMessage(newMessage);
             onOpen();
         },
         [setAlertType, setTitle, setMessage, onOpen]


### PR DESCRIPTION
I also renaming `showMessageBox`'s parameters. This makes for a better dev experience:

![image](https://user-images.githubusercontent.com/20878432/167841733-5f2e59db-4b74-4136-abdd-346731da8011.png)
