### PR TITLE
Fixed VRAM

### DIFF
--- a/src/components/SystemStats.tsx
+++ b/src/components/SystemStats.tsx
@@ -52,7 +52,7 @@ const SystemStats = () => {
                 </Box>
             </Tooltip>
 
-            {usage.vram && (
+            {usage.vram !== null && (
                 <Tooltip
                     borderRadius={8}
                     label={`${usage.vram.toFixed(1)}%`}

--- a/src/helpers/hooks/useSystemUsage.ts
+++ b/src/helpers/hooks/useSystemUsage.ts
@@ -37,7 +37,7 @@ const getVRamUsage = async () => ipcRenderer.invoke('get-vram-usage');
 export interface SystemUsage {
     readonly cpu: number;
     readonly ram: number;
-    readonly vram: number;
+    readonly vram: number | null;
 }
 
 const getSystemUsage = async (): Promise<SystemUsage> => {
@@ -46,7 +46,7 @@ const getSystemUsage = async (): Promise<SystemUsage> => {
 };
 
 const useSystemUsage = (delay: number): SystemUsage => {
-    const [usage, setUsage] = useState<SystemUsage>({ cpu: 0, ram: 0, vram: 0 });
+    const [usage, setUsage] = useState<SystemUsage>({ cpu: 0, ram: 0, vram: null });
 
     useAsyncInterval({ supplier: getSystemUsage, successEffect: setUsage }, delay);
 

--- a/src/helpers/safeIpc.ts
+++ b/src/helpers/safeIpc.ts
@@ -26,7 +26,7 @@ interface InvokeChannels {
     'get-port': ChannelInfo<number>;
     'get-localstorage-location': ChannelInfo<string>;
     'get-app-version': ChannelInfo<string>;
-    'get-vram-usage': ChannelInfo<number>;
+    'get-vram-usage': ChannelInfo<number | null>;
     'dir-select': ChannelInfo<Electron.OpenDialogReturnValue, [dirPath: string]>;
     'file-select': ChannelInfo<
         Electron.OpenDialogReturnValue,

--- a/src/main.ts
+++ b/src/main.ts
@@ -459,7 +459,6 @@ const checkNvidiaSmi = async () => {
 
                 vramChecker.stdout.on('data', (data) => {
                     const [, vramTotal, vramUsed] = String(data).split(/\s*,\s*/, 4);
-
                     const usage = (Number(vramUsed) / Number(vramTotal)) * 100;
                     if (Number.isFinite(usage)) {
                         lastVRam = usage;

--- a/src/main.ts
+++ b/src/main.ts
@@ -458,9 +458,7 @@ const checkNvidiaSmi = async () => {
                 );
 
                 vramChecker.stdout.on('data', (data) => {
-                    const [, vramTotal, vramUsed] = String(data)
-                        .split('\n')[0]
-                        .split(/\s*,\s*/, 4);
+                    const [, vramTotal, vramUsed] = String(data).split(/\s*,\s*/, 4);
 
                     const usage = (Number(vramUsed) / Number(vramTotal)) * 100;
                     if (Number.isFinite(usage)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -461,7 +461,6 @@ const checkNvidiaSmi = async () => {
                     const [, vramTotal, vramUsed] = String(data)
                         .split('\n')[0]
                         .split(/\s*,\s*/, 4);
-                    console.log(String(data));
 
                     const usage = (Number(vramUsed) / Number(vramTotal)) * 100;
                     if (Number.isFinite(usage)) {


### PR DESCRIPTION
This fixes the VRAM display on my laptop.

The first problem was that my laptop has an Nvidia GPU and an integrated Intel HD Graphics. This means that the VRAM usage of my NV is 0 most of the time. However, the VRAM usage assumed that 0 = no GPU. So now null = no GPU.

The second problem was that Nvidia SMI would random add new lines into the output. Examples:

```
NVIDIA GeForce GTX 950M
, 4096, 0, 4055, 0, 0

NVIDIA GeForce GTX 950M
, 4096, 0, 4055, 0
, 0
``` 

This messed up the parsing, which caused either NaN or Infinite VRAM usage to be displayed. So I fixed the parsing and added a check, so only finite numbers get passed to the front end.