### PR TITLE
Minor RFB refactor

### DIFF
--- a/src/components/ReactFlowBox.tsx
+++ b/src/components/ReactFlowBox.tsx
@@ -13,6 +13,7 @@ import ReactFlow, {
     useEdgesState,
     useNodesState,
     useReactFlow,
+    Viewport,
 } from 'react-flow-renderer';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { EdgeData, NodeData, NodeSchema } from '../common-types';
@@ -30,7 +31,7 @@ interface ReactFlowBoxProps {
 }
 const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) => {
     const { nodes, edges, createNode, createConnection } = useContext(GlobalVolatileContext);
-    const { setNodes, setEdges, onMoveEnd, setHoveredNode } = useContext(GlobalContext);
+    const { setNodes, setEdges, setZoom, setHoveredNode } = useContext(GlobalContext);
     const { closeAllMenus } = useContext(MenuFunctionsContext);
 
     const useSnapToGrid = useContextSelector(SettingsContext, (c) => c.useSnapToGrid);
@@ -120,8 +121,10 @@ const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) =
         [setEdges, _edges, edges]
     );
 
-    const memoNodeTypes = useMemo(() => nodeTypes, []);
-    const memoEdgeTypes = useMemo(() => edgeTypes, []);
+    const onMoveEnd = useCallback(
+        (event: unknown, viewport: Viewport) => setZoom(viewport.zoom),
+        [setZoom]
+    );
 
     const [isSnapToGrid, , snapToGridAmount] = useSnapToGrid;
 
@@ -209,11 +212,11 @@ const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) =
         >
             <ReactFlow
                 deleteKeyCode={useMemo(() => ['Backspace', 'Delete'], [])}
-                edgeTypes={memoEdgeTypes}
+                edgeTypes={edgeTypes}
                 edges={_edges}
                 maxZoom={8}
                 minZoom={0.125}
-                nodeTypes={memoNodeTypes}
+                nodeTypes={nodeTypes}
                 nodes={_nodes}
                 snapGrid={useMemo(() => [snapToGridAmount, snapToGridAmount], [snapToGridAmount])}
                 snapToGrid={isSnapToGrid}

--- a/src/helpers/contexts/GlobalNodeState.tsx
+++ b/src/helpers/contexts/GlobalNodeState.tsx
@@ -64,7 +64,6 @@ interface Global {
     removeEdgeById: (id: string) => void;
     toggleNodeLock: (id: string) => void;
     clearNode: (id: string) => void;
-    onMoveEnd: (event: unknown, viewport: Viewport) => void;
     useIteratorSize: (
         id: string
     ) => readonly [setSize: (size: IteratorSize) => void, defaultSize: Size];
@@ -75,6 +74,7 @@ interface Global {
     ) => void;
     setIteratorPercent: (id: string, percent: number) => void;
     setHoveredNode: SetState<string | null | undefined>;
+    setZoom: SetState<number>;
 }
 
 interface NodeProto {
@@ -703,10 +703,6 @@ export const GlobalProvider = ({
     );
 
     const [zoom, setZoom] = useState(1);
-    const onMoveEnd = useCallback(
-        (event: unknown, viewport: Viewport) => setZoom(viewport.zoom),
-        [setZoom]
-    );
 
     let globalChainValue: GlobalVolatile = {
         nodes,
@@ -736,7 +732,7 @@ export const GlobalProvider = ({
         setIteratorPercent,
         useIteratorSize,
         setHoveredNode,
-        onMoveEnd,
+        setZoom,
     };
     globalValue = useMemo(() => globalValue, Object.values(globalValue));
 


### PR DESCRIPTION
I always annoyed me that `onMoveEnd`, a method very specific to `ReactFlowBox`, was in global.

Also, I removed 2 unnecessary memos.