### PR TITLE
Clearer interpolation slider

### DIFF
--- a/backend/nodes/ncnn_nodes.py
+++ b/backend/nodes/ncnn_nodes.py
@@ -276,7 +276,14 @@ class NcnnInterpolateModelsNode(NodeBase):
         self.inputs = [
             NcnnNetInput("Net A"),
             NcnnNetInput("Net B"),
-            SliderInput("Amount", 0, 100, 50, min_label="Net B", max_label="Net A"),
+            SliderInput(
+                "Amount",
+                0,
+                100,
+                50,
+                note_expression="`Net A ${value}% ― Net B ${100 - value}%`",
+                hide_ends=True,
+            ),
         ]
         self.outputs = [NcnnNetOutput()]
 

--- a/backend/nodes/ncnn_nodes.py
+++ b/backend/nodes/ncnn_nodes.py
@@ -276,7 +276,7 @@ class NcnnInterpolateModelsNode(NodeBase):
         self.inputs = [
             NcnnNetInput("Net A"),
             NcnnNetInput("Net B"),
-            SliderInput("Amount", 0, 100, 50),
+            SliderInput("Amount", 0, 100, 50, min_label="Net B", max_label="Net A"),
         ]
         self.outputs = [NcnnNetOutput()]
 

--- a/backend/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/nodes/properties/inputs/numeric_inputs.py
@@ -31,6 +31,8 @@ class NumberInput(BaseInput):
         step=1,
         optional=False,
         number_type="any",
+        minimum_label: str = None,
+        maximum_label: str = None,
     ):
         super().__init__(f"number::{number_type}", label)
         self.default = default
@@ -38,6 +40,8 @@ class NumberInput(BaseInput):
         self.maximum = maximum
         self.step = step
         self.optional = optional
+        self.minimum_label = minimum_label
+        self.maximum_label = maximum_label
 
     def toDict(self):
         return {
@@ -45,6 +49,8 @@ class NumberInput(BaseInput):
             "label": self.label,
             "min": self.minimum,
             "max": self.maximum,
+            "minLabel": self.minimum_label,
+            "maxLabel": self.maximum_label,
             "def": self.default,
             "step": self.step,
             "hasHandle": True,
@@ -146,12 +152,16 @@ class SliderInput(NumberInput):
         max_val: int = 100,
         default: int = 50,
         optional: bool = False,
+        min_label: str = None,
+        max_label: str = None,
     ):
         super().__init__(
             label,
             default=default,
             minimum=min_val,
             maximum=max_val,
+            minimum_label=min_label,
+            maximum_label=max_label,
             step=1,
             optional=optional,
             number_type="slider",

--- a/backend/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/nodes/properties/inputs/numeric_inputs.py
@@ -31,8 +31,8 @@ class NumberInput(BaseInput):
         step=1,
         optional=False,
         number_type="any",
-        minimum_label: str = None,
-        maximum_label: str = None,
+        hide_ends: bool = None,
+        note_expression: str = None,
     ):
         super().__init__(f"number::{number_type}", label)
         self.default = default
@@ -40,8 +40,8 @@ class NumberInput(BaseInput):
         self.maximum = maximum
         self.step = step
         self.optional = optional
-        self.minimum_label = minimum_label
-        self.maximum_label = maximum_label
+        self.note_expression = note_expression
+        self.hide_ends = hide_ends
 
     def toDict(self):
         return {
@@ -49,8 +49,8 @@ class NumberInput(BaseInput):
             "label": self.label,
             "min": self.minimum,
             "max": self.maximum,
-            "minLabel": self.minimum_label,
-            "maxLabel": self.maximum_label,
+            "hideEnds": self.hide_ends,
+            "noteExpression": self.note_expression,
             "def": self.default,
             "step": self.step,
             "hasHandle": True,
@@ -152,18 +152,18 @@ class SliderInput(NumberInput):
         max_val: int = 100,
         default: int = 50,
         optional: bool = False,
-        min_label: str = None,
-        max_label: str = None,
+        note_expression: str = None,
+        hide_ends: bool = None,
     ):
         super().__init__(
             label,
             default=default,
             minimum=min_val,
             maximum=max_val,
-            minimum_label=min_label,
-            maximum_label=max_label,
             step=1,
             optional=optional,
+            note_expression=note_expression,
+            hide_ends=hide_ends,
             number_type="slider",
         )
 

--- a/backend/nodes/pytorch_nodes.py
+++ b/backend/nodes/pytorch_nodes.py
@@ -61,9 +61,9 @@ class LoadModelNode(NodeBase):
     def __init__(self):
         """Constructor"""
         super().__init__()
-        self.description = """Load PyTorch state dict file (.pth) into an 
-            auto-detected supported model architecture. Supports most variations 
-            of the RRDB architecture (ESRGAN, Real-ESRGAN, RealSR, BSRGAN, SPSR) 
+        self.description = """Load PyTorch state dict file (.pth) into an
+            auto-detected supported model architecture. Supports most variations
+            of the RRDB architecture (ESRGAN, Real-ESRGAN, RealSR, BSRGAN, SPSR)
             and Real-ESRGAN's SRVGG architecture."""
         self.inputs = [PthFileInput()]
         self.outputs = [ModelOutput(), TextOutput("Model Name")]
@@ -229,13 +229,13 @@ class InterpolateNode(NodeBase):
     def __init__(self):
         """Constructor"""
         super().__init__()
-        self.description = """Interpolate two of the same kind of model state-dict 
-             together. Note: models must share a common 'pretrained model' ancestor 
+        self.description = """Interpolate two of the same kind of model state-dict
+             together. Note: models must share a common 'pretrained model' ancestor
              in order to be interpolatable."""
         self.inputs = [
             ModelInput("Model A"),
             ModelInput("Model B"),
-            SliderInput("Amount", 0, 100, 50),
+            SliderInput("Amount", 0, 100, 50, min_label="Model B", max_label="Model A"),
         ]
         self.outputs = [ModelOutput()]
 
@@ -426,7 +426,7 @@ class ConvertTorchToONNXNode(NodeBase):
     def __init__(self):
         """Constructor"""
         super().__init__()
-        self.description = """Convert a PyTorch model to ONNX (for converting to NCNN). 
+        self.description = """Convert a PyTorch model to ONNX (for converting to NCNN).
             Use convertmodel.com to convert to NCNN for now."""
         self.inputs = [ModelInput(), DirectoryInput(), TextInput("Model Name")]
         self.outputs = []

--- a/backend/nodes/pytorch_nodes.py
+++ b/backend/nodes/pytorch_nodes.py
@@ -235,7 +235,14 @@ class InterpolateNode(NodeBase):
         self.inputs = [
             ModelInput("Model A"),
             ModelInput("Model B"),
-            SliderInput("Amount", 0, 100, 50, min_label="Model B", max_label="Model A"),
+            SliderInput(
+                "Amount",
+                0,
+                100,
+                50,
+                note_expression="`Model A ${value}% ― Model B ${100 - value}%`",
+                hide_ends=True,
+            ),
         ]
         self.outputs = [ModelOutput()]
 

--- a/src/components/inputs/SliderInput.tsx
+++ b/src/components/inputs/SliderInput.tsx
@@ -18,12 +18,24 @@ import { InputProps } from './props';
 interface SliderInputProps extends InputProps {
     min: number;
     max: number;
+    minLabel?: string;
+    maxLabel?: string;
     def?: number;
     accentColor: string;
 }
 
 const SliderInput = memo(
-    ({ index, useInputData, def, min, max, accentColor, isLocked }: SliderInputProps) => {
+    ({
+        index,
+        useInputData,
+        def,
+        min,
+        max,
+        minLabel,
+        maxLabel,
+        accentColor,
+        isLocked,
+    }: SliderInputProps) => {
         const [input, setInput] = useInputData<number>(index);
         const [sliderValue, setSliderValue] = useState(input ?? def);
         const [showTooltip, setShowTooltip] = useState(false);
@@ -34,7 +46,12 @@ const SliderInput = memo(
 
         return (
             <HStack w="full">
-                <Text fontSize="xs">{min}</Text>
+                <Text
+                    fontSize="xs"
+                    whiteSpace="nowrap"
+                >
+                    {minLabel ?? min}
+                </Text>
                 <Slider
                     defaultValue={def}
                     focusThumbOnChange={false}
@@ -65,7 +82,12 @@ const SliderInput = memo(
                         <SliderThumb />
                     </Tooltip>
                 </Slider>
-                <Text fontSize="xs">{max}</Text>
+                <Text
+                    fontSize="xs"
+                    whiteSpace="nowrap"
+                >
+                    {maxLabel ?? max}
+                </Text>
                 <NumberInput
                     className="nodrag"
                     defaultValue={def}

--- a/src/components/inputs/SliderInput.tsx
+++ b/src/components/inputs/SliderInput.tsx
@@ -11,6 +11,7 @@ import {
     SliderTrack,
     Text,
     Tooltip,
+    VStack,
 } from '@chakra-ui/react';
 import { memo, useEffect, useState } from 'react';
 import { InputProps } from './props';
@@ -18,11 +19,22 @@ import { InputProps } from './props';
 interface SliderInputProps extends InputProps {
     min: number;
     max: number;
-    minLabel?: string;
-    maxLabel?: string;
     def?: number;
     accentColor: string;
+    hideEnds?: boolean;
+    noteExpression?: string;
 }
+
+const tryEvaluate = (expression: string, args: Record<string, unknown>): string | undefined => {
+    try {
+        return String(
+            // eslint-disable-next-line @typescript-eslint/no-implied-eval
+            new Function(...Object.keys(args), `return ${expression};`)(...Object.values(args))
+        );
+    } catch (error) {
+        return undefined;
+    }
+};
 
 const SliderInput = memo(
     ({
@@ -31,8 +43,8 @@ const SliderInput = memo(
         def,
         min,
         max,
-        minLabel,
-        maxLabel,
+        hideEnds,
+        noteExpression,
         accentColor,
         isLocked,
     }: SliderInputProps) => {
@@ -44,77 +56,75 @@ const SliderInput = memo(
             setSliderValue(input);
         }, [input]);
 
+        const expr = noteExpression
+            ? tryEvaluate(noteExpression, { min, max, value: sliderValue ?? def })
+            : undefined;
+        const filled = !expr;
+
         return (
-            <HStack w="full">
-                <Text
-                    fontSize="xs"
-                    whiteSpace="nowrap"
-                >
-                    {minLabel ?? min}
-                </Text>
-                <Slider
-                    defaultValue={def}
-                    focusThumbOnChange={false}
-                    isDisabled={isLocked}
-                    max={max}
-                    min={min}
-                    step={1}
-                    value={sliderValue ?? def}
-                    onChange={setSliderValue}
-                    onChangeEnd={setInput}
-                    onMouseEnter={() => setShowTooltip(true)}
-                    onMouseLeave={() => setShowTooltip(false)}
-                >
-                    <SliderTrack>
-                        <SliderFilledTrack bg={accentColor} />
-                    </SliderTrack>
-                    <Tooltip
-                        hasArrow
-                        bg={accentColor}
-                        borderRadius={8}
-                        color="white"
-                        isOpen={showTooltip}
-                        label={sliderValue}
-                        placement="top"
-                        px={2}
-                        py={1}
+            <VStack w="full">
+                <HStack w="full">
+                    {!hideEnds && <Text fontSize="xs">{min}</Text>}
+                    <Slider
+                        defaultValue={def}
+                        focusThumbOnChange={false}
+                        isDisabled={isLocked}
+                        max={max}
+                        min={min}
+                        step={1}
+                        value={sliderValue ?? def}
+                        onChange={setSliderValue}
+                        onChangeEnd={setInput}
+                        onMouseEnter={() => setShowTooltip(true)}
+                        onMouseLeave={() => setShowTooltip(false)}
                     >
-                        <SliderThumb />
-                    </Tooltip>
-                </Slider>
-                <Text
-                    fontSize="xs"
-                    whiteSpace="nowrap"
-                >
-                    {maxLabel ?? max}
-                </Text>
-                <NumberInput
-                    className="nodrag"
-                    defaultValue={def}
-                    draggable={false}
-                    // precision={precision}
-                    isDisabled={isLocked}
-                    max={max}
-                    min={min}
-                    placeholder={def !== undefined ? String(def) : undefined}
-                    size="xs"
-                    step={1}
-                    value={sliderValue ?? def}
-                    onChange={(_, v) => {
-                        setInput(Math.min(Math.max(v, min), max));
-                    }}
-                >
-                    <NumberInputField
-                        m={0}
-                        p={1}
-                        w="3.1rem"
-                    />
-                    <NumberInputStepper w={4}>
-                        <NumberIncrementStepper />
-                        <NumberDecrementStepper />
-                    </NumberInputStepper>
-                </NumberInput>
-            </HStack>
+                        <SliderTrack>
+                            {filled ? <SliderFilledTrack bg={accentColor} /> : <SliderTrack />}
+                        </SliderTrack>
+                        <Tooltip
+                            hasArrow
+                            bg={accentColor}
+                            borderRadius={8}
+                            color="white"
+                            isOpen={showTooltip}
+                            label={sliderValue}
+                            placement="top"
+                            px={2}
+                            py={1}
+                        >
+                            <SliderThumb />
+                        </Tooltip>
+                    </Slider>
+                    {!hideEnds && <Text fontSize="xs">{max}</Text>}
+                    <NumberInput
+                        className="nodrag"
+                        defaultValue={def}
+                        draggable={false}
+                        // precision={precision}
+                        isDisabled={isLocked}
+                        max={max}
+                        min={min}
+                        placeholder={def !== undefined ? String(def) : undefined}
+                        size="xs"
+                        step={1}
+                        value={sliderValue ?? def}
+                        onChange={(_, v) => {
+                            setInput(Math.min(Math.max(v, min), max));
+                        }}
+                    >
+                        <NumberInputField
+                            m={0}
+                            p={1}
+                            w="3.1rem"
+                        />
+                        <NumberInputStepper w={4}>
+                            <NumberIncrementStepper />
+                            <NumberDecrementStepper />
+                        </NumberInputStepper>
+                    </NumberInput>
+                </HStack>
+                {expr && <Text fontSize="xs">{expr}</Text>}
+            </VStack>
         );
     }
 );


### PR DESCRIPTION
fixes #184.

---

This PR adds a *potenial* security risk. To evaluate the note string, I have to execute JS code given by the backend. Right now, the slider will just blindly execute this code. If we ever allow third-party nodes, we'll have to rethink this approach.