### PR TITLE
Removed nodes and edges array copy

### DIFF
--- a/src/components/ReactFlowBox.tsx
+++ b/src/components/ReactFlowBox.tsx
@@ -1,4 +1,5 @@
-/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/no-shadow */
+/* eslint-disable no-restricted-syntax */
 import { Box, useColorModeValue } from '@chakra-ui/react';
 import log from 'electron-log';
 import { DragEvent, memo, useCallback, useEffect, useMemo } from 'react';
@@ -20,9 +21,83 @@ import { EdgeData, NodeData, NodeSchema } from '../common-types';
 import { GlobalVolatileContext, GlobalContext } from '../helpers/contexts/GlobalNodeState';
 import { MenuFunctionsContext } from '../helpers/contexts/MenuFunctions';
 import { SettingsContext } from '../helpers/contexts/SettingsContext';
-import { snapToGrid } from '../helpers/reactFlowUtil';
+import { isSnappedToGrid, snapToGrid } from '../helpers/reactFlowUtil';
 
 const STARTING_Z_INDEX = 50;
+/**
+ * We what the nodes and edges to form the following layers:
+ *
+ * - Iterator nodes
+ * - Nodes inside iterators
+ * - Free nodes
+ * - Selected nodes
+ *   - Same layers within selected nodes as outside
+ *
+ * Note that child nodes of selected iterator nodes are implicitly selected as well.
+ *
+ * The zIndex of an edge will be `max(source, target) - 1`. Note that `-1` doesn't mean
+ * "the layer below", but "in between this layer and the below layer".
+ * The only exception is when the edge is selected but neither its not its target are selected.
+ * In this case, the edge will to be in the highest selected layer.
+ */
+const updateZIndexes = (
+    nodes: readonly Node<NodeData>[],
+    edges: readonly Edge<EdgeData>[]
+): void => {
+    const ITERATOR_INDEX = STARTING_Z_INDEX;
+    const ITERATOR_CHILDREN_INDEX = ITERATOR_INDEX + 2;
+    const FREE_NODES_INDEX = ITERATOR_CHILDREN_INDEX + 2;
+    const SELECTED_ADD = 10;
+    const MIN_SELECTED_INDEX = STARTING_Z_INDEX + SELECTED_ADD;
+
+    const selectedIterators = new Set<string>();
+    const nodeZIndexes = new Map<string, number>();
+
+    // set the zIndex of all nodes
+    for (const n of nodes) {
+        let zIndex;
+        if (n.type === 'iterator') {
+            zIndex = ITERATOR_INDEX;
+            if (n.selected) selectedIterators.add(n.id);
+        } else if (n.parentNode) {
+            zIndex = ITERATOR_CHILDREN_INDEX;
+        } else {
+            zIndex = FREE_NODES_INDEX;
+        }
+
+        if (n.selected) zIndex += SELECTED_ADD;
+
+        n.zIndex = zIndex;
+        nodeZIndexes.set(n.id, zIndex);
+    }
+
+    // fix up the child nodes of selected iterators
+    if (selectedIterators.size > 0) {
+        // all child nodes of selected iterators are implicitly selected
+        for (const n of nodes) {
+            if (selectedIterators.has(n.parentNode!)) {
+                const zIndex = ITERATOR_CHILDREN_INDEX + SELECTED_ADD;
+
+                n.zIndex = zIndex;
+                nodeZIndexes.set(n.id, zIndex);
+            }
+        }
+    }
+
+    // set the zIndex of all edges
+    for (const e of edges) {
+        let zIndex = Math.max(
+            nodeZIndexes.get(e.source) ?? STARTING_Z_INDEX,
+            nodeZIndexes.get(e.target) ?? STARTING_Z_INDEX
+        );
+
+        if (e.selected && zIndex < MIN_SELECTED_INDEX) {
+            zIndex += SELECTED_ADD;
+        }
+
+        e.zIndex = zIndex - 1;
+    }
+};
 
 interface ReactFlowBoxProps {
     nodeTypes: NodeTypes;
@@ -30,115 +105,107 @@ interface ReactFlowBoxProps {
     wrapperRef: React.RefObject<HTMLDivElement>;
 }
 const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) => {
-    const { nodes, edges, createNode, createConnection } = useContext(GlobalVolatileContext);
-    const { setNodes, setEdges, setZoom, setHoveredNode } = useContext(GlobalContext);
+    const { createNode, createConnection } = useContext(GlobalVolatileContext);
+    const {
+        setZoom,
+        setHoveredNode,
+        addNodeChanges,
+        addEdgeChanges,
+        changeNodes,
+        changeEdges,
+        setSetNodes,
+        setSetEdges,
+    } = useContext(GlobalContext);
     const { closeAllMenus } = useContext(MenuFunctionsContext);
 
     const useSnapToGrid = useContextSelector(SettingsContext, (c) => c.useSnapToGrid);
+    const [isSnapToGrid, , snapToGridAmount] = useSnapToGrid;
+
     const reactFlowInstance = useReactFlow();
 
-    const [_nodes, _setNodes, onNodesChange] = useNodesState<NodeData>([]);
-    const [_edges, _setEdges, onEdgesChange] = useEdgesState<EdgeData>([]);
-
-    const sortNodesAndEdges = useCallback(() => {
-        const iterators = nodes.filter((n) => n.type === 'iterator'); // .sort((i) => (i.selected ? 1 : -1));
-        let sortedNodes: Node<NodeData>[] = [];
-
-        // Sort the nodes in a way that makes iterators stack on each other correctly
-        // Put iterators below their children
-        iterators.forEach((_iterator, index) => {
-            const iterator = _iterator;
-            iterator.zIndex = STARTING_Z_INDEX + index * 5;
-            sortedNodes.push(iterator);
-            const children = nodes.filter((n) => n.parentNode === iterator.id);
-            // sorted.concat(children);
-            children.forEach((_child) => {
-                const child = _child;
-                child.zIndex = STARTING_Z_INDEX + index * 5 + 1;
-                // child.position.x = Math.min(Math.max(child.position.x, 0), iterator.width);
-                // child.position.y = Math.min(Math.max(child.position.y, 0), iterator.height);
-                sortedNodes.push(child);
-            });
-        });
-
-        // Put nodes not in iterators on top of the iterators
-        const freeNodes = nodes.filter((n) => n.type !== 'iterator' && !n.parentNode);
-        freeNodes.forEach((f) => {
-            sortedNodes.push(f);
-        });
-
-        const indexedEdges = edges.map((e) => {
-            const index = sortedNodes.find((n) => n.id === e.target)?.zIndex || 1000;
-            return { ...e, zIndex: index };
-        });
-
-        // This fixes the connection line being behind iterators if no edges are present
-        if (indexedEdges.length === 0) {
-            sortedNodes = sortedNodes.map((n) => ({ ...n, zIndex: -1 }));
-        }
-
-        _setNodes(sortedNodes);
-        _setEdges(indexedEdges);
-    }, [nodes, edges, _setNodes, _setEdges]);
+    const [nodes, setNodes, onNodesChange] = useNodesState<NodeData>([]);
+    const [edges, setEdges, onEdgesChange] = useEdgesState<EdgeData>([]);
 
     useEffect(() => {
-        sortNodesAndEdges();
-    }, [nodes, edges]);
+        setSetNodes(() => setNodes);
+        setSetEdges(() => setEdges);
+    }, [setNodes, setEdges]);
+
+    const selectedNodesKey = useMemo(
+        () =>
+            nodes
+                .filter((n) => n.selected)
+                .map((n) => n.id)
+                .join(''),
+        [nodes]
+    );
+    const selectedEdgesKey = useMemo(
+        () =>
+            edges
+                .filter((e) => e.selected)
+                .map((e) => e.id)
+                .join(''),
+        [edges]
+    );
+
+    // We don't want this to cause a re-render, so we will commit the greatest sin
+    // known to React developers: interior mutation.
+    useMemo(() => {
+        nodes.sort((a, b) => a.id.localeCompare(b.id));
+    }, [nodes.length]);
+    useMemo(() => {
+        edges.sort((a, b) => a.id.localeCompare(b.id));
+    }, [edges.length]);
+    useMemo(
+        () => updateZIndexes(nodes, edges),
+        [nodes.length, edges.length, selectedNodesKey, selectedEdgesKey]
+    );
+    useMemo(() => {
+        if (!isSnapToGrid) return;
+        for (const n of nodes) {
+            if (!isSnappedToGrid(n.position, snapToGridAmount)) {
+                n.position = snapToGrid(n.position, snapToGridAmount);
+            }
+        }
+    }, [isSnapToGrid && snapToGridAmount, nodes]);
 
     const onNodeDragStop = useCallback(() => {
-        setNodes(_nodes);
-        setEdges(_edges);
-    }, [_nodes, _edges]);
+        addNodeChanges();
+        addEdgeChanges();
+    }, [addNodeChanges, addEdgeChanges]);
 
     const onNodesDelete = useCallback(
         (_nodesToDelete: readonly Node<NodeData>[]) => {
-            // Prevent iterator helpers from being deleted
-            const iteratorsToDelete = _nodesToDelete
-                .filter((n) => n.type === 'iterator')
-                .map((n) => n.id);
-            const nodesToDelete = _nodesToDelete.filter(
-                (n) =>
-                    !(
-                        n.type === 'iteratorHelper' &&
-                        n.parentNode &&
-                        !iteratorsToDelete.includes(n.parentNode)
-                    )
-            );
+            const nodeIds = new Set(_nodesToDelete.map((n) => n.id));
 
-            const nodeIds = nodesToDelete.map((n) => n.id);
-            const newNodes = nodes.filter((n) => !nodeIds.includes(n.id));
-            setNodes(newNodes);
+            changeNodes((nodes) =>
+                nodes.filter((n) => {
+                    if (nodeIds.has(n.id)) {
+                        if (n.type === 'iteratorHelper') {
+                            // only delete iterator helper if the iterator itself is also removed
+                            return !nodeIds.has(n.parentNode!);
+                        }
+                        return false;
+                    }
+                    return true;
+                })
+            );
         },
-        [_setNodes, _nodes, setNodes, nodes]
+        [changeNodes]
     );
 
     const onEdgesDelete = useCallback(
         (edgesToDelete: readonly Edge<EdgeData>[]) => {
-            const edgeIds = edgesToDelete.map((e) => e.id);
-            const newEdges = edges.filter((e) => !edgeIds.includes(e.id));
-            setEdges(newEdges);
+            const edgeIds = new Set(edgesToDelete.map((e) => e.id));
+            changeEdges((edges) => edges.filter((e) => !edgeIds.has(e.id)));
         },
-        [setEdges, _edges, edges]
+        [changeEdges]
     );
 
     const onMoveEnd = useCallback(
         (event: unknown, viewport: Viewport) => setZoom(viewport.zoom),
         [setZoom]
     );
-
-    const [isSnapToGrid, , snapToGridAmount] = useSnapToGrid;
-
-    useEffect(() => {
-        if (isSnapToGrid) {
-            const alignedNodes = nodes.map((n) => {
-                if (n.parentNode) {
-                    return n;
-                }
-                return { ...n, position: snapToGrid(n.position, snapToGridAmount) };
-            });
-            _setNodes(alignedNodes);
-        }
-    }, [snapToGridAmount, nodes]);
 
     const onDragOver = useCallback(
         (event: DragEvent<HTMLDivElement>) => {
@@ -152,11 +219,10 @@ const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) =
 
     const onDragStart = useCallback(() => {
         setHoveredNode(null);
-    }, []);
+    }, [setHoveredNode]);
 
     const onDrop = useCallback(
         (event: DragEvent<HTMLDivElement>) => {
-            // log.info('dropped');
             event.preventDefault();
 
             if (!wrapperRef.current) return;
@@ -196,11 +262,6 @@ const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) =
         [createNode, wrapperRef.current, reactFlowInstance]
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const onNodeContextMenu = useCallback((event, node) => {
-        // TODO implement this
-    }, []);
-
     return (
         <Box
             bg={useColorModeValue('gray.100', 'gray.800')}
@@ -213,11 +274,11 @@ const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) =
             <ReactFlow
                 deleteKeyCode={useMemo(() => ['Backspace', 'Delete'], [])}
                 edgeTypes={edgeTypes}
-                edges={_edges}
+                edges={edges}
                 maxZoom={8}
                 minZoom={0.125}
                 nodeTypes={nodeTypes}
-                nodes={_nodes}
+                nodes={nodes}
                 snapGrid={useMemo(() => [snapToGridAmount, snapToGridAmount], [snapToGridAmount])}
                 snapToGrid={isSnapToGrid}
                 style={{
@@ -230,11 +291,9 @@ const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) =
                 onDrop={onDrop}
                 onEdgesChange={onEdgesChange}
                 onEdgesDelete={onEdgesDelete}
-                // onSelectionChange={setSelectedElements}
                 onMouseDown={closeAllMenus}
                 onMoveEnd={onMoveEnd}
                 onMoveStart={closeAllMenus}
-                onNodeContextMenu={onNodeContextMenu}
                 onNodeDragStop={onNodeDragStop}
                 onNodesChange={onNodesChange}
                 onNodesDelete={onNodesDelete}

--- a/src/components/ReactFlowBox.tsx
+++ b/src/components/ReactFlowBox.tsx
@@ -25,7 +25,7 @@ import { isSnappedToGrid, snapToGrid } from '../helpers/reactFlowUtil';
 
 const STARTING_Z_INDEX = 50;
 /**
- * We what the nodes and edges to form the following layers:
+ * We want the nodes and edges to form the following layers:
  *
  * - Iterator nodes
  * - Nodes inside iterators

--- a/src/components/node/IteratorHelperNode.tsx
+++ b/src/components/node/IteratorHelperNode.tsx
@@ -1,7 +1,8 @@
 import { Center, useColorModeValue, VStack } from '@chakra-ui/react';
 import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useReactFlow } from 'react-flow-renderer';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { NodeData } from '../../common-types';
+import { EdgeData, NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
 import { GlobalVolatileContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import getAccentColor from '../../helpers/getNodeAccentColors';
@@ -16,8 +17,9 @@ interface IteratorHelperNodeProps {
 }
 
 const IteratorHelperNode = ({ data, selected }: IteratorHelperNodeProps) => {
-    const edges = useContextSelector(GlobalVolatileContext, (c) => c.edges);
+    const edgeChanges = useContextSelector(GlobalVolatileContext, (c) => c.edgeChanges);
     const { schemata, updateIteratorBounds, setHoveredNode } = useContext(GlobalContext);
+    const { getEdges } = useReactFlow<NodeData, EdgeData>();
 
     const { id, inputData, isLocked, parentNode, schemaId } = data;
 
@@ -37,9 +39,9 @@ const IteratorHelperNode = ({ data, selected }: IteratorHelperNodeProps) => {
 
     useEffect(() => {
         if (inputs.length) {
-            setValidity(checkNodeValidity({ id, inputs, inputData, edges }));
+            setValidity(checkNodeValidity({ id, inputs, inputData, edges: getEdges() }));
         }
-    }, [inputData, edges.length]);
+    }, [inputData, edgeChanges, getEdges]);
 
     const targetRef = useRef<HTMLDivElement>(null);
     const [checkedSize, setCheckedSize] = useState(false);
@@ -52,7 +54,7 @@ const IteratorHelperNode = ({ data, selected }: IteratorHelperNodeProps) => {
             });
             setCheckedSize(true);
         }
-    }, [checkedSize]);
+    }, [checkedSize, updateIteratorBounds]);
 
     return (
         <Center

--- a/src/components/node/IteratorNode.tsx
+++ b/src/components/node/IteratorNode.tsx
@@ -1,7 +1,8 @@
 import { Center, Text, useColorModeValue, VStack } from '@chakra-ui/react';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { useReactFlow } from 'react-flow-renderer';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { NodeData } from '../../common-types';
+import { EdgeData, NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
 import { GlobalVolatileContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import getAccentColor from '../../helpers/getNodeAccentColors';
@@ -26,8 +27,9 @@ const IteratorNodeWrapper = memo(({ data, selected }: IteratorNodeProps) => (
 ));
 
 const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => {
-    const edges = useContextSelector(GlobalVolatileContext, (c) => c.edges);
+    const edgeChanges = useContextSelector(GlobalVolatileContext, (c) => c.edgeChanges);
     const { schemata } = useContext(GlobalContext);
+    const { getEdges } = useReactFlow<NodeData, EdgeData>();
 
     const {
         id,
@@ -62,11 +64,11 @@ const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => {
                     id,
                     inputs,
                     inputData,
-                    edges,
+                    edges: getEdges(),
                 })
             );
         }
-    }, [inputData, edges.length]);
+    }, [inputData, edgeChanges]);
 
     return (
         <>

--- a/src/components/node/IteratorNodeBody.tsx
+++ b/src/components/node/IteratorNodeBody.tsx
@@ -90,7 +90,7 @@ const IteratorNodeBody = ({
             setIteratorSize(size);
             updateIteratorBounds(id, size);
         }
-    }, [resizeRef?.resizable]);
+    }, [resizeRef?.resizable, setIteratorSize, updateIteratorBounds]);
 
     return (
         <Resizable

--- a/src/components/node/Node.tsx
+++ b/src/components/node/Node.tsx
@@ -9,8 +9,9 @@ import {
     VStack,
 } from '@chakra-ui/react';
 import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useReactFlow } from 'react-flow-renderer';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { NodeData } from '../../common-types';
+import { EdgeData, NodeData } from '../../common-types';
 import checkNodeValidity from '../../helpers/checkNodeValidity';
 import { GlobalVolatileContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
 import getAccentColor from '../../helpers/getNodeAccentColors';
@@ -33,8 +34,9 @@ interface NodeProps {
 }
 
 const Node = memo(({ data, selected }: NodeProps) => {
-    const edges = useContextSelector(GlobalVolatileContext, (c) => c.edges);
+    const edgeChanges = useContextSelector(GlobalVolatileContext, (c) => c.edgeChanges);
     const { schemata, updateIteratorBounds, setHoveredNode } = useContext(GlobalContext);
+    const { getEdges } = useReactFlow<NodeData, EdgeData>();
 
     const { id, inputData, isLocked, parentNode, schemaId } = data;
 
@@ -54,9 +56,9 @@ const Node = memo(({ data, selected }: NodeProps) => {
 
     useEffect(() => {
         if (inputs.length) {
-            setValidity(checkNodeValidity({ id, inputs, inputData, edges }));
+            setValidity(checkNodeValidity({ id, inputs, inputData, edges: getEdges() }));
         }
-    }, [inputData, edges.length]);
+    }, [inputData, edgeChanges]);
 
     const targetRef = useRef<HTMLDivElement>(null);
     const [checkedSize, setCheckedSize] = useState(false);
@@ -69,7 +71,7 @@ const Node = memo(({ data, selected }: NodeProps) => {
             });
             setCheckedSize(true);
         }
-    }, [checkedSize, targetRef.current?.offsetHeight]);
+    }, [checkedSize, targetRef.current?.offsetHeight, updateIteratorBounds]);
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [showMenu, setShowMenu] = useState(false);

--- a/src/helpers/contexts/ExecutionContext.tsx
+++ b/src/helpers/contexts/ExecutionContext.tsx
@@ -108,7 +108,7 @@ export const ExecutionProvider = ({ children }: React.PropsWithChildren<{}>) => 
             }
         }, 1000);
         return () => clearTimeout(id);
-    }, [status]);
+    }, [status, unAnimateEdges]);
 
     const [eventSource, eventSourceStatus] = useBackendEventSource(port);
 
@@ -176,7 +176,7 @@ export const ExecutionProvider = ({ children }: React.PropsWithChildren<{}>) => 
             unAnimateEdges();
             setStatus(ExecutionStatus.READY);
         }
-    }, [eventSourceStatus]);
+    }, [eventSourceStatus, unAnimateEdges]);
 
     const run = async () => {
         const nodes = getNodes();

--- a/src/helpers/contexts/GlobalNodeState.tsx
+++ b/src/helpers/contexts/GlobalNodeState.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-shadow */
 import log from 'electron-log';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
@@ -10,7 +9,7 @@ import {
     Viewport,
     XYPosition,
 } from 'react-flow-renderer';
-import { createContext, useContext, useContextSelector } from 'use-context-selector';
+import { createContext, useContext } from 'use-context-selector';
 import {
     EdgeData,
     InputData,
@@ -23,19 +22,18 @@ import {
 import { useAsyncEffect } from '../hooks/useAsyncEffect';
 import { useIpcRendererListener } from '../hooks/useIpcRendererListener';
 import { getSessionStorageOrDefault } from '../hooks/useSessionStorage';
-import { snapToGrid } from '../reactFlowUtil';
+import { useChangeCounter, ChangeCounter, wrapChanges } from '../hooks/useChangeCounter';
 import { ipcRenderer } from '../safeIpc';
 import { ParsedSaveData, SaveData } from '../SaveFile';
 import { SchemaMap } from '../SchemaMap';
 import { copyNode, parseHandle, createUniqueId, deriveUniqueId } from '../util';
 import { AlertBoxContext, AlertType } from './AlertBoxContext';
-import { SettingsContext } from './SettingsContext';
 
 type SetState<T> = React.Dispatch<React.SetStateAction<T>>;
 
 interface GlobalVolatile {
-    nodes: readonly Node<NodeData>[];
-    edges: readonly Edge<EdgeData>[];
+    nodeChanges: ChangeCounter;
+    edgeChanges: ChangeCounter;
     createNode: (proto: NodeProto) => void;
     createConnection: (connection: Connection) => void;
     isNodeInputLocked: (id: string, index: number) => boolean;
@@ -45,8 +43,12 @@ interface GlobalVolatile {
 interface Global {
     schemata: SchemaMap;
     reactFlowWrapper: React.RefObject<Element>;
-    setNodes: SetState<Node<NodeData>[]>;
-    setEdges: SetState<Edge<EdgeData>[]>;
+    setSetNodes: SetState<SetState<Node<NodeData>[]>>;
+    setSetEdges: SetState<SetState<Edge<EdgeData>[]>>;
+    addNodeChanges: () => void;
+    addEdgeChanges: () => void;
+    changeNodes: SetState<Node<NodeData>[]>;
+    changeEdges: SetState<Edge<EdgeData>[]>;
     isValidConnection: (connection: Readonly<Connection>) => boolean;
     useAnimateEdges: () => readonly [
         (nodeIdsToAnimate?: readonly string[] | undefined) => void,
@@ -90,14 +92,13 @@ export const GlobalContext = createContext<Readonly<Global>>({} as Global);
 const createNodeImpl = (
     { position, data, nodeType }: NodeProto,
     schemata: SchemaMap,
-    snapToGridAmount: number,
     parent?: Node<NodeData>
 ): Node<NodeData>[] => {
     const id = createUniqueId();
     const newNode: Node<Mutable<NodeData>> = {
         type: nodeType,
         id,
-        position: snapToGrid(position, snapToGridAmount),
+        position,
         data: {
             ...data,
             id,
@@ -144,7 +145,6 @@ const createNodeImpl = (
                     },
                 },
                 schemata,
-                snapToGridAmount,
                 newNode
             );
             extraNodes.push(...subNode);
@@ -153,10 +153,6 @@ const createNodeImpl = (
 
     return [newNode, ...extraNodes];
 };
-
-const cachedNodes = getSessionStorageOrDefault<Node<NodeData>[]>('cachedNodes', []);
-const cachedEdges = getSessionStorageOrDefault<Edge<EdgeData>[]>('cachedEdges', []);
-const cachedViewport = getSessionStorageOrDefault<Viewport | null>('cachedViewport', null);
 
 interface GlobalProviderProps {
     schemata: SchemaMap;
@@ -168,30 +164,50 @@ export const GlobalProvider = ({
     schemata,
     reactFlowWrapper,
 }: React.PropsWithChildren<GlobalProviderProps>) => {
-    const useSnapToGrid = useContextSelector(SettingsContext, (c) => c.useSnapToGrid);
-    const [, , snapToGridAmount] = useSnapToGrid;
-
     const { sendAlert, sendToast, showAlert } = useContext(AlertBoxContext);
 
-    const [nodes, setNodes] = useState<Node<NodeData>[]>(cachedNodes);
-    const [edges, setEdges] = useState<Edge<EdgeData>[]>(cachedEdges);
-    const { setViewport, getViewport, getNode, getNodes, getEdges } = useReactFlow<
-        NodeData,
-        EdgeData
-    >();
+    const [nodeChanges, addNodeChanges] = useChangeCounter();
+    const [edgeChanges, addEdgeChanges] = useChangeCounter();
+    const {
+        setViewport,
+        getViewport,
+        getNode,
+        getNodes,
+        getEdges,
+        setNodes: rfSetNodes,
+        setEdges: rfSetEdges,
+    } = useReactFlow<NodeData, EdgeData>();
+
+    const [setNodes, setSetNodes] = useState(() => rfSetNodes);
+    const [setEdges, setSetEdges] = useState(() => rfSetEdges);
+
+    const changeNodes = useMemo(
+        () => wrapChanges(setNodes, addNodeChanges),
+        [setNodes, addNodeChanges]
+    );
+    const changeEdges = useMemo(
+        () => wrapChanges(setEdges, addEdgeChanges),
+        [setEdges, addEdgeChanges]
+    );
 
     // Cache node state to avoid clearing state when refreshing
     useEffect(() => {
         const timerId = setTimeout(() => {
-            sessionStorage.setItem('cachedNodes', JSON.stringify(nodes));
-            sessionStorage.setItem('cachedEdges', JSON.stringify(edges));
+            sessionStorage.setItem('cachedNodes', JSON.stringify(getNodes()));
+            sessionStorage.setItem('cachedEdges', JSON.stringify(getEdges()));
             sessionStorage.setItem('cachedViewport', JSON.stringify(getViewport()));
-        }, 1000);
+        }, 100);
         return () => clearTimeout(timerId);
-    }, [nodes, edges]);
+    }, [nodeChanges, edgeChanges]);
     useEffect(() => {
+        const cachedNodes = getSessionStorageOrDefault<Node<NodeData>[]>('cachedNodes', []);
+        const cachedEdges = getSessionStorageOrDefault<Edge<EdgeData>[]>('cachedEdges', []);
+        const cachedViewport = getSessionStorageOrDefault<Viewport | null>('cachedViewport', null);
+
+        changeNodes(cachedNodes);
+        changeEdges(cachedEdges);
         if (cachedViewport) setViewport(cachedViewport);
-    }, []);
+    }, [changeNodes, changeEdges]);
 
     const [savePath, setSavePath] = useState<string | undefined>();
 
@@ -203,12 +219,14 @@ export const GlobalProvider = ({
      *
      * Some changes to the chain might not be worth saving (e.g. animation status).
      */
-    const hasRelevantUnsavedChanges: boolean =
-        hasUnsavedChanges && (nodes.length > 0 || !!savePath);
+    const [hasRelevantUnsavedChanges, setHasRelevantUnsavedChanges] = useState(false);
+    useEffect(() => {
+        setHasRelevantUnsavedChanges(hasUnsavedChanges && (getNodes().length > 0 || !!savePath));
+    }, [hasUnsavedChanges, savePath, nodeChanges]);
 
     useEffect(() => {
         setHasUnsavedChanges(true);
-    }, [nodes, edges]);
+    }, [nodeChanges, edgeChanges]);
     useEffect(() => {
         const id = setTimeout(() => {
             const dot = hasRelevantUnsavedChanges ? ' •' : '';
@@ -219,17 +237,22 @@ export const GlobalProvider = ({
 
     const modifyNode = useCallback(
         (id: string, mapFn: (oldNode: Node<NodeData>) => Node<NodeData>) => {
-            setNodes((nodes) => {
-                const node = nodes.find((n) => n.id === id);
-                if (!node) {
-                    log.error(`Cannot modify missing node with id ${id}`);
-                    return nodes;
+            changeNodes((nodes) => {
+                const newNodes: Node<NodeData>[] = [];
+                // eslint-disable-next-line no-restricted-syntax
+                for (const n of nodes) {
+                    if (n.id === id) {
+                        const newNode = mapFn(n);
+                        if (newNode === n) return nodes;
+                        newNodes.push(newNode);
+                    } else {
+                        newNodes.push(n);
+                    }
                 }
-                const newNode = mapFn(node);
-                return [...nodes.filter((n) => n.id !== id), newNode];
+                return newNodes;
             });
         },
-        [setNodes]
+        [changeNodes]
     );
 
     const dumpState = useCallback((): SaveData => {
@@ -266,15 +289,15 @@ export const GlobalProvider = ({
                         'The file you are trying to open has been modified outside of chaiNNer. The modifications may cause chaiNNer to behave incorrectly or in unexpected ways. The file will now be loaded with the modifications.',
                 });
             }
-            setNodes(validNodes);
-            setEdges(validEdges);
+            changeNodes(validNodes);
+            changeEdges(validEdges);
             if (loadPosition) {
                 setViewport(savedData.viewport);
             }
             setSavePath(path);
             setHasUnsavedChanges(false);
         },
-        [schemata]
+        [schemata, changeNodes, changeEdges]
     );
 
     const clearState = useCallback(async () => {
@@ -293,11 +316,11 @@ export const GlobalProvider = ({
             }
         }
 
-        setEdges([]);
-        setNodes([]);
+        changeNodes([]);
+        changeEdges([]);
         setSavePath(undefined);
         setViewport({ x: 0, y: 0, zoom: 1 });
-    }, [hasRelevantUnsavedChanges, setEdges, setNodes, setSavePath, setViewport]);
+    }, [hasRelevantUnsavedChanges, changeNodes, changeEdges, setSavePath, setViewport]);
 
     const performSave = useCallback(
         (saveAs: boolean) => {
@@ -371,7 +394,7 @@ export const GlobalProvider = ({
 
     const removeNodeById = useCallback(
         (id: string) => {
-            setNodes((nodes) => {
+            changeNodes((nodes) => {
                 const node = nodes.find((n) => n.id === id);
                 if (node && node.type !== 'iteratorHelper') {
                     return nodes.filter((n) => n.id !== id && n.parentNode !== id);
@@ -379,25 +402,25 @@ export const GlobalProvider = ({
                 return nodes;
             });
         },
-        [setNodes]
+        [changeNodes]
     );
 
     const removeEdgeById = useCallback(
         (id: string) => {
-            setEdges((edges) => edges.filter((e) => e.id !== id));
+            changeEdges((edges) => edges.filter((e) => e.id !== id));
         },
-        [setEdges]
+        [changeEdges]
     );
 
     const createNode = useCallback(
         (proto: NodeProto): void => {
-            setNodes((nodes) => {
+            changeNodes((nodes) => {
                 const parent = hoveredNode ? nodes.find((n) => n.id === hoveredNode) : undefined;
-                const newNodes = createNodeImpl(proto, schemata, snapToGridAmount, parent);
+                const newNodes = createNodeImpl(proto, schemata, parent);
                 return [...nodes, ...newNodes];
             });
         },
-        [setNodes, schemata, hoveredNode]
+        [changeNodes, schemata, hoveredNode]
     );
 
     const createConnection = useCallback(
@@ -416,12 +439,12 @@ export const GlobalProvider = ({
                 animated: false,
                 data: {},
             };
-            setEdges((edges) => [
+            changeEdges((edges) => [
                 ...edges.filter((edge) => edge.targetHandle !== targetHandle),
                 newEdge,
             ]);
         },
-        [setEdges]
+        [changeEdges]
     );
 
     const isValidConnection = useCallback(
@@ -556,14 +579,14 @@ export const GlobalProvider = ({
 
     const isNodeInputLocked = useCallback(
         (id: string, index: number): boolean => {
-            return edges.some(
+            return getEdges().some(
                 (e) =>
                     e.target === id &&
                     !!e.targetHandle &&
                     parseHandle(e.targetHandle).index === index
             );
         },
-        [edges]
+        [edgeChanges]
     );
 
     const useIteratorSize = useCallback(
@@ -586,7 +609,7 @@ export const GlobalProvider = ({
     // TODO: this can probably be cleaned up but its good enough for now
     const updateIteratorBounds = useCallback(
         (id: string, iteratorSize: IteratorSize | null, dimensions?: Size) => {
-            setNodes((nodes) => {
+            changeNodes((nodes) => {
                 const nodesToUpdate = nodes.filter((n) => n.parentNode === id);
                 const iteratorNode = nodes.find((n) => n.id === id);
                 if (iteratorNode && nodesToUpdate.length > 0) {
@@ -637,7 +660,7 @@ export const GlobalProvider = ({
                 return nodes;
             });
         },
-        [setNodes]
+        [changeNodes]
     );
 
     const setIteratorPercent = useCallback(
@@ -660,7 +683,7 @@ export const GlobalProvider = ({
                     .map((n) => n.id),
             ]);
 
-            setNodes((nodes) => {
+            changeNodes((nodes) => {
                 const newNodes = nodes
                     .filter((n) => nodesToCopy.has(n.id) || nodesToCopy.has(n.parentNode!))
                     .map<Node<NodeData>>((n) => {
@@ -697,7 +720,7 @@ export const GlobalProvider = ({
                 return [...nodes, ...newNodes];
             });
 
-            setEdges((edges) => {
+            changeEdges((edges) => {
                 const newEdges = edges
                     .filter((e) => nodesToCopy.has(e.target))
                     .map<Edge<EdgeData>>((e) => {
@@ -720,7 +743,7 @@ export const GlobalProvider = ({
                 return [...edges, ...newEdges];
             });
         },
-        [getNodes, setNodes, setEdges]
+        [getNodes, changeNodes, changeEdges]
     );
 
     const clearNode = useCallback(
@@ -737,8 +760,8 @@ export const GlobalProvider = ({
     const [zoom, setZoom] = useState(1);
 
     let globalChainValue: GlobalVolatile = {
-        nodes,
-        edges,
+        nodeChanges,
+        edgeChanges,
         createNode,
         createConnection,
         isNodeInputLocked,
@@ -750,8 +773,12 @@ export const GlobalProvider = ({
     let globalValue: Global = {
         schemata,
         reactFlowWrapper,
-        setNodes,
-        setEdges,
+        setSetNodes,
+        setSetEdges,
+        addNodeChanges,
+        addEdgeChanges,
+        changeNodes,
+        changeEdges,
         isValidConnection,
         useAnimateEdges,
         useInputData,

--- a/src/helpers/hooks/useChangeCounter.ts
+++ b/src/helpers/hooks/useChangeCounter.ts
@@ -6,7 +6,7 @@ export const useChangeCounter = () => {
     const [counter, setCounter] = useState(0);
 
     const change = useCallback(() => {
-        // we have to warp at some point, so I just arbitrarily chose 1 million
+        // we have to wrap at some point, so I just arbitrarily chose 1 million
         setCounter((prev) => (prev + 1) % 1_000_000);
     }, [setCounter]);
 

--- a/src/helpers/hooks/useChangeCounter.ts
+++ b/src/helpers/hooks/useChangeCounter.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+
+export type ChangeCounter = number & { __changeCounter: true };
+
+export const useChangeCounter = () => {
+    const [counter, setCounter] = useState(0);
+
+    const change = useCallback(() => {
+        // we have to warp at some point, so I just arbitrarily chose 1 million
+        setCounter((prev) => (prev + 1) % 1_000_000);
+    }, [setCounter]);
+
+    return [counter as ChangeCounter, change] as const;
+};
+
+export const wrapChanges = <T>(
+    setter: React.Dispatch<React.SetStateAction<T>>,
+    addChange: () => void
+): React.Dispatch<React.SetStateAction<T>> => {
+    return (value) => {
+        setter(value);
+        addChange();
+    };
+};

--- a/src/helpers/reactFlowUtil.ts
+++ b/src/helpers/reactFlowUtil.ts
@@ -1,6 +1,5 @@
 import { XYPosition } from 'react-flow-renderer';
 
-// eslint-disable-next-line import/prefer-default-export
 export const snapToGrid = (
     position: Readonly<XYPosition>,
     snapToGridAmount: number
@@ -8,3 +7,8 @@ export const snapToGrid = (
     x: position.x - (position.x % snapToGridAmount),
     y: position.y - (position.y % snapToGridAmount),
 });
+
+export const isSnappedToGrid = (
+    position: Readonly<XYPosition>,
+    snapToGridAmount: number
+): boolean => position.x % snapToGridAmount === 0 && position.y % snapToGridAmount === 0;


### PR DESCRIPTION
This removes the nodes and edges arrays in GlobalNodeState.

Changes:
- `createNode` no longer snaps nodes to a user-defined grid. ReactFlowBox will now always handle this.
- Added `nodeChanges` and `edgeChanges` to notify components and effects when the internal edges and nodes array change significantly. I.e. components will only notified of node changes after the user stopped dragging a node, so the UI stays responsive.
- New zIndex order. I had to redo the whole thing because the old way didn't really work with the new single-array way.
