### PR TITLE
Added support for drag'n'dropping files

### DIFF
--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -27,6 +27,7 @@ export interface Input {
     readonly def?: InputSchemaValue;
     readonly default?: InputSchemaValue;
     readonly options?: InputOption[];
+    readonly filetypes?: string[];
 }
 export interface Output {
     readonly type: string;

--- a/src/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -5,12 +5,17 @@ import ReactMarkdown from 'react-markdown';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeSchema } from '../../common-types';
 import { GlobalVolatileContext, GlobalContext } from '../../helpers/contexts/GlobalNodeState';
+import { ChainnerDragData, TransferTypes } from '../../helpers/dataTransfer';
 import RepresentativeNode from '../node/RepresentativeNode';
 
 const onDragStart = (event: DragEvent<HTMLDivElement>, node: NodeSchema) => {
-    event.dataTransfer.setData('application/reactflow/schema', JSON.stringify(node));
-    event.dataTransfer.setData('application/reactflow/offsetX', String(event.nativeEvent.offsetX));
-    event.dataTransfer.setData('application/reactflow/offsetY', String(event.nativeEvent.offsetY));
+    const data: ChainnerDragData = {
+        schemaId: node.schemaId,
+        offsetX: event.nativeEvent.offsetX,
+        offsetY: event.nativeEvent.offsetY,
+    };
+
+    event.dataTransfer.setData(TransferTypes.ChainerSchema, JSON.stringify(data));
     // eslint-disable-next-line no-param-reassign
     event.dataTransfer.effectAllowed = 'move';
 };

--- a/src/helpers/contexts/GlobalNodeState.tsx
+++ b/src/helpers/contexts/GlobalNodeState.tsx
@@ -79,7 +79,7 @@ interface Global {
     setZoom: SetState<number>;
 }
 
-interface NodeProto {
+export interface NodeProto {
     position: XYPosition;
     data: Omit<NodeData, 'id' | 'inputData'> & { inputData?: InputData };
     nodeType: string;

--- a/src/helpers/dataTransfer.ts
+++ b/src/helpers/dataTransfer.ts
@@ -1,0 +1,120 @@
+import { XYPosition } from 'react-flow-renderer';
+import log from 'electron-log';
+import { extname } from 'path';
+import { NodeProto } from './contexts/GlobalNodeState';
+import { SchemaMap } from './SchemaMap';
+import { FileOpenResult, ipcRenderer } from './safeIpc';
+import { SaveFile } from './SaveFile';
+
+export interface ChainnerDragData {
+    schemaId: string;
+    offsetX?: number;
+    offsetY?: number;
+}
+
+export const enum TransferTypes {
+    ChainerSchema = 'application/chainner/schema',
+}
+
+export interface DataTransferProcessorOptions {
+    createNode: (proto: NodeProto) => void;
+    getNodePosition: (offsetX?: number, offsetY?: number) => XYPosition;
+    schemata: SchemaMap;
+}
+
+export const openSaveFile = async (path: string): Promise<FileOpenResult> => {
+    try {
+        const saveData = await SaveFile.read(path);
+        return { kind: 'Success', path, saveData };
+    } catch (error) {
+        log.error(error);
+        return { kind: 'Error', path, error: String(error) };
+    }
+};
+
+/**
+ * Returns `false` if the data couldn't not be processed by this processor.
+ *
+ * Returns `true` if the data has been successfully transferred.
+ */
+export type DataTransferProcessor = (
+    dataTransfer: DataTransfer,
+    options: DataTransferProcessorOptions
+) => boolean;
+
+const chainnerSchemaProcessor: DataTransferProcessor = (
+    dataTransfer,
+    { getNodePosition, createNode, schemata }
+) => {
+    if (!dataTransfer.getData(TransferTypes.ChainerSchema)) return false;
+
+    const { schemaId, offsetX, offsetY } = JSON.parse(
+        dataTransfer.getData(TransferTypes.ChainerSchema)
+    ) as ChainnerDragData;
+
+    const nodeSchema = schemata.get(schemaId);
+
+    createNode({
+        position: getNodePosition(offsetX, offsetY),
+        data: { schemaId },
+        nodeType: nodeSchema.nodeType,
+    });
+    return true;
+};
+
+const openChainnerFileProcessor: DataTransferProcessor = (dataTransfer) => {
+    if (dataTransfer.files.length === 1) {
+        const [file] = dataTransfer.files;
+        if (/\.chn/i.test(file.path)) {
+            // found a .chn file
+
+            openSaveFile(file.path)
+                .then((result) => {
+                    // TODO: 1 is hard-coded. Find a better way
+                    ipcRenderer.sendTo(1, 'file-open', result);
+                })
+                .catch((reason) => log.error(reason));
+
+            return true;
+        }
+    }
+    return false;
+};
+
+const openImageFileProcessor: DataTransferProcessor = (
+    dataTransfer,
+    { schemata, getNodePosition, createNode }
+) => {
+    const LOAD_IMAGE_ID = 'chainner:image:load';
+    if (!schemata.has(LOAD_IMAGE_ID)) return false;
+    const schema = schemata.get(LOAD_IMAGE_ID);
+    const fileTypes = schema.inputs[0]?.filetypes;
+    if (!fileTypes) return false;
+
+    if (dataTransfer.files.length === 1) {
+        const [file] = dataTransfer.files;
+        const extension = extname(file.path).toLowerCase();
+        if (fileTypes.includes(extension)) {
+            // found a supported image file
+
+            createNode({
+                // hard-coded offset because it looks nicer
+                position: getNodePosition(100, 100),
+                data: {
+                    schemaId: LOAD_IMAGE_ID,
+                    inputData: { 0: file.path },
+                },
+                nodeType: schema.nodeType,
+            });
+
+            return true;
+        }
+    }
+    return false;
+};
+
+export const dataTransferProcessors: readonly DataTransferProcessor[] = [
+    chainnerSchemaProcessor,
+    openChainnerFileProcessor,
+    openImageFileProcessor,
+];

--- a/src/helpers/dataTransfer.ts
+++ b/src/helpers/dataTransfer.ts
@@ -33,7 +33,7 @@ export const openSaveFile = async (path: string): Promise<FileOpenResult> => {
 };
 
 /**
- * Returns `false` if the data couldn't not be processed by this processor.
+ * Returns `false` if the data could not be processed by this processor.
  *
  * Returns `true` if the data has been successfully transferred.
  */

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import semver from 'semver';
 import { graphics, Systeminformation } from 'systeminformation';
 import util from 'util';
 import { PythonKeys } from './common-types';
+import { openSaveFile } from './helpers/dataTransfer';
 import { getNvidiaSmi } from './helpers/nvidiaSmi';
 import { BrowserWindowWithSafeIpc, FileOpenResult, ipcMain } from './helpers/safeIpc';
 import { SaveFile } from './helpers/SaveFile';
@@ -744,21 +745,7 @@ const createWindow = async () => {
                         });
                         if (canceled) return;
 
-                        try {
-                            const saveData = await SaveFile.read(filepath);
-                            mainWindow.webContents.send('file-open', {
-                                kind: 'Success',
-                                path: filepath,
-                                saveData,
-                            });
-                        } catch (error) {
-                            log.error(error);
-                            mainWindow.webContents.send('file-open', {
-                                kind: 'Error',
-                                path: filepath,
-                                error: String(error),
-                            });
-                        }
+                        mainWindow.webContents.send('file-open', await openSaveFile(filepath));
                     },
                 },
                 { type: 'separator' },


### PR DESCRIPTION
I simplified the internal data transfer we do for drag'n'dropping nodes from the node selector panel and added support for dragging in .chn and image files.

The whole thing is implemented via a list of processors that all get a chance to process the dropped data. This makes it easy to add support for more files types and other stuff in the future.

Right now, dropping a single image file and dropping a single .chn file are supported. Multiple files are not supported.