### PR TITLE
Fixed iterators crashing the app

### DIFF
--- a/src/components/node/IteratorNodeBody.tsx
+++ b/src/components/node/IteratorNodeBody.tsx
@@ -68,13 +68,13 @@ const IteratorNodeBody = ({
 }: IteratorNodeBodyProps) => {
     const zoom = useContextSelector(GlobalVolatileContext, (c) => c.zoom);
     const hoveredNode = useContextSelector(GlobalVolatileContext, (c) => c.hoveredNode);
-    const { useIteratorSize, setHoveredNode, updateIteratorBounds } = useContext(GlobalContext);
+    const { defaultIteratorSize, setIteratorSize, setHoveredNode, updateIteratorBounds } =
+        useContext(GlobalContext);
 
     const { useSnapToGrid } = useContext(SettingsContext);
     const [isSnapToGrid, , snapToGridAmount] = useSnapToGrid;
 
-    const [setIteratorSize, defaultSize] = useIteratorSize(id);
-    const { width, height } = iteratorSize ?? defaultSize;
+    const { width, height } = iteratorSize ?? defaultIteratorSize;
 
     const [resizeRef, setResizeRef] = useState<Resizable | null>(null);
 
@@ -84,10 +84,10 @@ const IteratorNodeBody = ({
             const size = {
                 offsetTop: resizable.offsetTop,
                 offsetLeft: resizable.offsetLeft,
-                width: width || defaultSize.width,
-                height: height || defaultSize.height,
+                width,
+                height,
             };
-            setIteratorSize(size);
+            setIteratorSize(id, size);
             updateIteratorBounds(id, size);
         }
     }, [resizeRef?.resizable, setIteratorSize, updateIteratorBounds]);
@@ -95,7 +95,7 @@ const IteratorNodeBody = ({
     return (
         <Resizable
             className="nodrag"
-            defaultSize={defaultSize}
+            defaultSize={defaultIteratorSize}
             enable={{
                 top: false,
                 right: true,
@@ -132,7 +132,7 @@ const IteratorNodeBody = ({
                     width: (width < maxWidth ? maxWidth : width) + d.width,
                     height: (height < maxHeight ? maxHeight : height) + d.height,
                 };
-                setIteratorSize(size);
+                setIteratorSize(id, size);
                 updateIteratorBounds(id, size);
             }}
         >

--- a/src/helpers/contexts/GlobalNodeState.tsx
+++ b/src/helpers/contexts/GlobalNodeState.tsx
@@ -43,6 +43,7 @@ interface GlobalVolatile {
 interface Global {
     schemata: SchemaMap;
     reactFlowWrapper: React.RefObject<Element>;
+    defaultIteratorSize: Size;
     setSetNodes: SetState<SetState<Node<NodeData>[]>>;
     setSetEdges: SetState<SetState<Edge<EdgeData>[]>>;
     addNodeChanges: () => void;
@@ -66,9 +67,7 @@ interface Global {
     duplicateNode: (id: string) => void;
     toggleNodeLock: (id: string) => void;
     clearNode: (id: string) => void;
-    useIteratorSize: (
-        id: string
-    ) => readonly [setSize: (size: IteratorSize) => void, defaultSize: Size];
+    setIteratorSize: (id: string, size: IteratorSize) => void;
     updateIteratorBounds: (
         id: string,
         iteratorSize: IteratorSize | null,
@@ -153,6 +152,8 @@ const createNodeImpl = (
 
     return [newNode, ...extraNodes];
 };
+
+const defaultIteratorSize: Size = { width: 1280, height: 720 };
 
 interface GlobalProviderProps {
     schemata: SchemaMap;
@@ -589,19 +590,13 @@ export const GlobalProvider = ({
         [edgeChanges]
     );
 
-    const useIteratorSize = useCallback(
-        (id: string) => {
-            const defaultSize: Size = { width: 1280, height: 720 };
-
-            const setIteratorSize = (size: IteratorSize) => {
-                modifyNode(id, (old) => {
-                    const newNode = copyNode(old);
-                    newNode.data.iteratorSize = size;
-                    return newNode;
-                });
-            };
-
-            return [setIteratorSize, defaultSize] as const;
+    const setIteratorSize = useCallback(
+        (id: string, size: IteratorSize) => {
+            modifyNode(id, (old) => {
+                const newNode = copyNode(old);
+                newNode.data.iteratorSize = size;
+                return newNode;
+            });
         },
         [modifyNode]
     );
@@ -773,6 +768,7 @@ export const GlobalProvider = ({
     let globalValue: Global = {
         schemata,
         reactFlowWrapper,
+        defaultIteratorSize,
         setSetNodes,
         setSetEdges,
         addNodeChanges,
@@ -789,7 +785,7 @@ export const GlobalProvider = ({
         duplicateNode,
         updateIteratorBounds,
         setIteratorPercent,
-        useIteratorSize,
+        setIteratorSize,
         setHoveredNode,
         setZoom,
     };


### PR DESCRIPTION
This fixes the new bug around iterators I mentioned on Discord.

The problem was that, while `useIteratorSize` was memoized, its `setIteratorSize` function was not. This caused the layout effect to recursively invoke itself. I.e. `setIterator` would cause the nodes to update, which caused a re-render for `IteratorNodeBody`, which made a new `setIterator` function, which caused the layout effect to call `setIterator`, and so on.

The fix quite simple. I split `useIteratorSize` into its two components. Both components are memoized now, so the re-renders don't trigger the layout effect anymore.