### PR TITLE
Resize, interpolation, and sliders

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
                 singleReturnOnly: false,
             },
         ],
+        endOfLine: 'auto',
     },
     settings: {
         'import/core-modules': ['electron'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,6 @@ module.exports = {
                 singleReturnOnly: false,
             },
         ],
-        endOfLine: 'auto',
     },
     settings: {
         'import/core-modules': ['electron'],

--- a/backend/nodes/image_dim_nodes.py
+++ b/backend/nodes/image_dim_nodes.py
@@ -22,12 +22,18 @@ class ImResizeByFactorNode(NodeBase):
         """Constructor"""
         super().__init__()
         self.description = (
-            "Resize an image by a scale factor (e.g. 2 for 200% or 0.5 for 50%). "
+            "Resize an image by a percent scale factor. "
             "Auto uses box for downsampling and lanczos for upsampling."
         )
         self.inputs = [
             ImageInput(),
-            NumberInput("Scale Factor", default=1.0, step=0.25),
+            BoundedNumberInput(
+                "Scale Factor (%)",
+                minimum=0.1,
+                maximum=None,
+                default=100.0,
+                step=25.0
+            ),
             InterpolationInput(),
         ]
         self.category = IMAGE_DIMENSION
@@ -42,7 +48,7 @@ class ImResizeByFactorNode(NodeBase):
         logger.info(f"Resizing image by {scale} via {interpolation}")
 
         h, w = img.shape[:2]
-        out_dims = (math.ceil(w * scale), math.ceil(h * scale))
+        out_dims = (math.ceil(w * (scale / 100)), math.ceil(h * (scale / 100)))
 
         return resize(img, out_dims, interpolation)
 

--- a/backend/nodes/image_dim_nodes.py
+++ b/backend/nodes/image_dim_nodes.py
@@ -28,11 +28,7 @@ class ImResizeByFactorNode(NodeBase):
         self.inputs = [
             ImageInput(),
             BoundedNumberInput(
-                "Scale Factor (%)",
-                minimum=0.1,
-                maximum=None,
-                default=100.0,
-                step=25.0
+                "Scale Factor (%)", minimum=0.1, maximum=None, default=100.0, step=25.0
             ),
             InterpolationInput(),
         ]

--- a/backend/nodes/image_filter_nodes.py
+++ b/backend/nodes/image_filter_nodes.py
@@ -126,7 +126,11 @@ class AverageColorFixNode(NodeBase):
             ImageInput("Image"),
             ImageInput("Reference Image"),
             BoundedNumberInput(
-                "Reference Image Scale Factor", default=0.125, step=0.125
+                "Reference Image Scale Factor (%)",
+                minimum=0.1,
+                maximum=None,
+                default=12.5,
+                step=12.5
             ),
         ]
         self.outputs = [ImageOutput()]
@@ -140,12 +144,12 @@ class AverageColorFixNode(NodeBase):
     ) -> np.ndarray:
         """Fixes the average color of the input image"""
 
-        if scale_factor != 1.0:
+        if scale_factor != 100.0:
             ref_img = cv2.resize(
                 ref_img,
                 None,
-                fx=scale_factor,
-                fy=scale_factor,
+                fx=scale_factor / 100,
+                fy=scale_factor / 100,
                 interpolation=cv2.INTER_AREA,
             )
 

--- a/backend/nodes/image_filter_nodes.py
+++ b/backend/nodes/image_filter_nodes.py
@@ -130,7 +130,7 @@ class AverageColorFixNode(NodeBase):
                 minimum=0.1,
                 maximum=None,
                 default=12.5,
-                step=12.5
+                step=12.5,
             ),
         ]
         self.outputs = [ImageOutput()]

--- a/backend/nodes/ncnn_nodes.py
+++ b/backend/nodes/ncnn_nodes.py
@@ -300,7 +300,7 @@ class NcnnInterpolateModelsNode(NodeBase):
             bin_a_mult = bin_a.astype(np.float64) * amount_a
             bin_b_mult = bin_b.astype(np.float64) * amount_b
             result = bin_a_mult + bin_b_mult
-            logger.info(result)
+
             return result.astype(np.float32)
         except Exception as e:
             raise ValueError(
@@ -314,7 +314,7 @@ class NcnnInterpolateModelsNode(NodeBase):
         new_net_tuple = (param_path_a, interp_50, input_name_a, output_name_a)
         result = NcnnUpscaleImageNode().run(new_net_tuple, fake_img)
         del interp_50, new_net_tuple
-        logger.info(result)
+
         mean_color = np.mean(result)
         del result
         return mean_color > 0.5

--- a/backend/nodes/ncnn_nodes.py
+++ b/backend/nodes/ncnn_nodes.py
@@ -274,15 +274,15 @@ class NcnnInterpolateModelsNode(NodeBase):
         super().__init__()
         self.description = "Interpolate two NCNN models of the same type together."
         self.inputs = [
-            NcnnNetInput("Net A"),
-            NcnnNetInput("Net B"),
+            NcnnNetInput("Model A"),
+            NcnnNetInput("Model B"),
             SliderInput(
-                "Amount",
+                "Weights",
                 0,
                 100,
                 50,
-                note_expression="`Net A ${value}% ― Net B ${100 - value}%`",
-                hide_ends=True,
+                note_expression="`Model A ${100 - value}% ― Model B ${value}%`",
+                ends=("A", "B"),
             ),
         ]
         self.outputs = [NcnnNetOutput()]
@@ -294,8 +294,8 @@ class NcnnInterpolateModelsNode(NodeBase):
 
     def perform_interp(self, bin_a: np.ndarray, bin_b: np.ndarray, amount: int):
         try:
-            amount_a = amount / 100
-            amount_b = 1 - amount_a
+            amount_b = amount / 100
+            amount_a = 1 - amount_b
 
             bin_a_mult = bin_a.astype(np.float64) * amount_a
             bin_b_mult = bin_b.astype(np.float64) * amount_b

--- a/backend/nodes/properties/inputs/ncnn_inputs.py
+++ b/backend/nodes/properties/inputs/ncnn_inputs.py
@@ -4,5 +4,5 @@ from .base_input import BaseInput
 class NcnnNetInput(BaseInput):
     """Input for ncnn network"""
 
-    def __init__(self, label: str = "Network"):
+    def __init__(self, label: str = "Model"):
         super().__init__(f"ncnn::net", label)

--- a/backend/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/nodes/properties/inputs/numeric_inputs.py
@@ -1,3 +1,5 @@
+from typing import Union, Tuple
+
 from .base_input import BaseInput
 
 
@@ -31,7 +33,6 @@ class NumberInput(BaseInput):
         step=1,
         optional=False,
         number_type="any",
-        hide_ends: bool = None,
         note_expression: str = None,
     ):
         super().__init__(f"number::{number_type}", label)
@@ -41,7 +42,6 @@ class NumberInput(BaseInput):
         self.step = step
         self.optional = optional
         self.note_expression = note_expression
-        self.hide_ends = hide_ends
 
     def toDict(self):
         return {
@@ -49,7 +49,6 @@ class NumberInput(BaseInput):
             "label": self.label,
             "min": self.minimum,
             "max": self.maximum,
-            "hideEnds": self.hide_ends,
             "noteExpression": self.note_expression,
             "def": self.default,
             "step": self.step,
@@ -153,7 +152,7 @@ class SliderInput(NumberInput):
         default: int = 50,
         optional: bool = False,
         note_expression: str = None,
-        hide_ends: bool = None,
+        ends: Union[Tuple[int, int], Tuple[str, str]] = (None, None),
     ):
         super().__init__(
             label,
@@ -163,9 +162,23 @@ class SliderInput(NumberInput):
             step=1,
             optional=optional,
             note_expression=note_expression,
-            hide_ends=hide_ends,
             number_type="slider",
         )
+        self.ends = (min_val, max_val) if ends == (None, None) else ends
+
+    def toDict(self):
+        return {
+            "type": self.input_type,
+            "label": self.label,
+            "min": self.minimum,
+            "max": self.maximum,
+            "noteExpression": self.note_expression,
+            "ends": self.ends,
+            "def": self.default,
+            "step": self.step,
+            "hasHandle": True,
+            "optional": self.optional,
+        }
 
     def enforce(self, value):
         return clampInt(value, self.minimum, self.maximum)

--- a/backend/nodes/properties/outputs/ncnn_outputs.py
+++ b/backend/nodes/properties/outputs/ncnn_outputs.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
 
-def NcnnNetOutput(label: str = "Network") -> Dict:
+def NcnnNetOutput(label: str = "Model") -> Dict:
     """Output for ncnn network"""
     return {
         "type": "ncnn::net",

--- a/backend/nodes/pytorch_nodes.py
+++ b/backend/nodes/pytorch_nodes.py
@@ -236,12 +236,12 @@ class InterpolateNode(NodeBase):
             ModelInput("Model A"),
             ModelInput("Model B"),
             SliderInput(
-                "Amount",
+                "Weights",
                 0,
                 100,
                 50,
-                note_expression="`Model A ${value}% ― Model B ${100 - value}%`",
-                hide_ends=True,
+                note_expression="`Model A ${100 - value}% ― Model B ${value}%`",
+                ends=("A", "B"),
             ),
         ]
         self.outputs = [ModelOutput()]
@@ -253,8 +253,8 @@ class InterpolateNode(NodeBase):
 
     def perform_interp(self, model_a: OrderedDict, model_b: OrderedDict, amount: int):
         try:
-            amount_a = amount / 100
-            amount_b = 1 - amount_a
+            amount_b = amount / 100
+            amount_a = 1 - amount_b
 
             state_dict = OrderedDict()
             for k, v_1 in model_a.items():

--- a/src/components/inputs/SliderInput.tsx
+++ b/src/components/inputs/SliderInput.tsx
@@ -21,7 +21,7 @@ interface SliderInputProps extends InputProps {
     max: number;
     def?: number;
     accentColor: string;
-    hideEnds?: boolean;
+    ends?: Array<string | number> | null;
     noteExpression?: string;
 }
 
@@ -43,7 +43,7 @@ const SliderInput = memo(
         def,
         min,
         max,
-        hideEnds,
+        ends,
         noteExpression,
         accentColor,
         isLocked,
@@ -64,7 +64,7 @@ const SliderInput = memo(
         return (
             <VStack w="full">
                 <HStack w="full">
-                    {!hideEnds && <Text fontSize="xs">{min}</Text>}
+                    {ends && <Text fontSize="xs">{ends[0]}</Text>}
                     <Slider
                         defaultValue={def}
                         focusThumbOnChange={false}
@@ -95,7 +95,7 @@ const SliderInput = memo(
                             <SliderThumb />
                         </Tooltip>
                     </Slider>
-                    {!hideEnds && <Text fontSize="xs">{max}</Text>}
+                    {ends && <Text fontSize="xs">{ends[1]}</Text>}
                     <NumberInput
                         className="nodrag"
                         defaultValue={def}

--- a/src/helpers/migrations.js
+++ b/src/helpers/migrations.js
@@ -265,22 +265,25 @@ const toV072 = (data) => {
     data.nodes.forEach((node) => {
         // Convert Resize (Factor) and Average Color Fix to percentage
         if (node.data.schemaId === 'chainner:image:resize_factor') {
-            node.data.inputData['1'] = node.data.inputData['1'] * 100.0;
+            // eslint-disable-next-line no-param-reassign, prefer-destructuring
+            node.data.inputData['1'] *= 100.0;
         }
         if (node.data.schemaId === 'chainner:image:average_color_fix') {
-            node.data.inputData['2'] = node.data.inputData['2'] * 100.0;
+            // eslint-disable-next-line no-param-reassign, prefer-destructuring
+            node.data.inputData['2'] *= 100.0;
         }
         // Invert interpolation weight
         if (
-            [
-                'chainner:pytorch:interpolate_models', 'chainner:ncnn:interpolate_models'
-            ].includes(node.data.schemaId)
+            ['chainner:pytorch:interpolate_models', 'chainner:ncnn:interpolate_models'].includes(
+                node.data.schemaId
+            )
         ) {
+            // eslint-disable-next-line no-param-reassign, prefer-destructuring
             node.data.inputData['2'] = 100 - node.data.inputData['2'];
         }
     });
     return data;
-}
+};
 
 // ==============
 

--- a/src/helpers/migrations.js
+++ b/src/helpers/migrations.js
@@ -261,6 +261,27 @@ const toV070 = (data) => {
     return data;
 };
 
+const toV072 = (data) => {
+    data.nodes.forEach((node) => {
+        // Convert Resize (Factor) and Average Color Fix to percentage
+        if (node.data.schemaId === 'chainner:image:resize_factor') {
+            node.data.inputData['1'] = node.data.inputData['1'] * 100.0;
+        }
+        if (node.data.schemaId === 'chainner:image:average_color_fix') {
+            node.data.inputData['2'] = node.data.inputData['2'] * 100.0;
+        }
+        // Invert interpolation weight
+        if (
+            [
+                'chainner:pytorch:interpolate_models', 'chainner:ncnn:interpolate_models'
+            ].includes(node.data.schemaId)
+        ) {
+            node.data.inputData['2'] = 100 - node.data.inputData['2'];
+        }
+    });
+    return data;
+}
+
 // ==============
 
 export const migrate = (_version, data) => {
@@ -310,6 +331,15 @@ export const migrate = (_version, data) => {
             convertedData = toV070(convertedData);
         } catch (error) {
             log.warn('Failed to convert to v0.7.0', error);
+        }
+    }
+
+    // v0.7.2
+    if (semver.lt(version, '0.7.2')) {
+        try {
+            convertedData = toV072(convertedData);
+        } catch (error) {
+            log.warn('Failed to convert to v0.7.2', error);
         }
     }
 


### PR DESCRIPTION
-Changed scale factor for Resize (Factor) and Average Color Fix to percentages.
-Changed SliderInput so that custom end labels can be added. Default is (min, max). None will hide the end labels.
-Reversed weight values for pytorch and ncnn model interpolation so that sliding left increases weight of A and right increases weight of B. Labeled ends A and B accordingly.
-Added migrations for scale factor and interpolation value changes.