### PR TITLE
ESLint: Disable 2 annoying rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,12 +64,14 @@ module.exports = {
                 project: './tsconfig.json',
             },
             rules: {
+                'no-restricted-syntax': 'off',
                 'react/require-default-props': 'off',
                 '@typescript-eslint/no-non-null-assertion': 'off',
                 '@typescript-eslint/no-floating-promises': ['error', { ignoreIIFE: true }],
                 '@typescript-eslint/no-unnecessary-condition': 'warn',
                 'eslint-comments/no-unused-enable': 'warn',
                 'eslint-comments/no-unused-disable': 'warn',
+                'import/prefer-default-export': 'off',
                 'react/jsx-sort-props': [
                     'error',
                     {

--- a/src/components/HistoryProvider.tsx
+++ b/src/components/HistoryProvider.tsx
@@ -61,7 +61,6 @@ class EditHistory<T> {
 
 type HistoryState = readonly [Node<NodeData>[], Edge<EdgeData>[], Viewport];
 
-// eslint-disable-next-line import/prefer-default-export
 export const HistoryProvider = ({ children }: React.PropsWithChildren<unknown>): JSX.Element => {
     const changeId = useContextSelector(
         GlobalVolatileContext,

--- a/src/components/ReactFlowBox.tsx
+++ b/src/components/ReactFlowBox.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-/* eslint-disable no-restricted-syntax */
 import { Box, useColorModeValue } from '@chakra-ui/react';
 import log from 'electron-log';
 import { DragEvent, memo, useCallback, useEffect, useMemo } from 'react';

--- a/src/helpers/SchemaMap.ts
+++ b/src/helpers/SchemaMap.ts
@@ -13,7 +13,6 @@ const BLANK_SCHEMA: NodeSchema = {
     schemaId: '',
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export class SchemaMap {
     readonly schemata: readonly NodeSchema[];
 

--- a/src/helpers/contexts/GlobalNodeState.tsx
+++ b/src/helpers/contexts/GlobalNodeState.tsx
@@ -240,7 +240,6 @@ export const GlobalProvider = ({
         (id: string, mapFn: (oldNode: Node<NodeData>) => Node<NodeData>) => {
             changeNodes((nodes) => {
                 const newNodes: Node<NodeData>[] = [];
-                // eslint-disable-next-line no-restricted-syntax
                 for (const n of nodes) {
                     if (n.id === id) {
                         const newNode = mapFn(n);

--- a/src/helpers/hooks/useIpcRendererListener.ts
+++ b/src/helpers/hooks/useIpcRendererListener.ts
@@ -2,7 +2,6 @@ import { IpcRendererEvent } from 'electron';
 import { useEffect } from 'react';
 import { ChannelArgs, SendChannels, ipcRenderer } from '../safeIpc';
 
-// eslint-disable-next-line import/prefer-default-export
 export const useIpcRendererListener = <C extends keyof SendChannels>(
     channel: C,
     listener: (event: IpcRendererEvent, ...args: ChannelArgs<C>) => void,


### PR DESCRIPTION
I disabled 2 rules I find annoying:

- `no-restricted-syntax`: This rule mainly disallowed the use for `for of` in our code. It does this because `for of` is quite expensive when transpiled down to ES5 to support older browsers. However, we don't have to worry about old browsers, so our `for of`s don't get transpiled.
- `import/prefer-default-export`: We already talked about how I dislike default exports because IDEs can't auto import them.