### PR TITLE
Add import/order rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,13 @@ module.exports = {
                     },
                 ],
                 'sort-imports': ['error', { ignoreDeclarationSort: true }],
+                'import/order': [
+                    'error',
+                    {
+                        groups: [['builtin', 'external'], 'internal', 'parent', 'sibling', 'index'],
+                        alphabetize: { order: 'asc', caseInsensitive: true },
+                    },
+                ],
             },
         },
     ],

--- a/src/helpers/hooks/useAsyncEffect.ts
+++ b/src/helpers/hooks/useAsyncEffect.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line max-classes-per-file
-import { useEffect } from 'react';
 import log from 'electron-log';
+import { useEffect } from 'react';
 import { noop } from '../util';
 
 /**

--- a/src/splash.tsx
+++ b/src/splash.tsx
@@ -1,8 +1,8 @@
 import { Center, ChakraProvider, Flex, Progress, Text, VStack } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
-import { ipcRenderer } from './helpers/safeIpc';
 import ChaiNNerLogo from './components/chaiNNerLogo';
+import { ipcRenderer } from './helpers/safeIpc';
 import './global.css';
 import theme from './splashTheme';
 


### PR DESCRIPTION
Since ESLint's built-in sort-imports rule can't order imports, I googled a little and found a rule that can.