### PR TITLE
Allow NCNN FP16

### DIFF
--- a/backend/nodes/ncnn_nodes.py
+++ b/backend/nodes/ncnn_nodes.py
@@ -120,17 +120,12 @@ class NcnnSaveNode(NodeBase):
         full_param_path = os.path.join(directory, full_param)
 
         logger.info(f"Writing NCNN model to paths: {full_bin_path} {full_param_path}")
-        bin_is_fp16 = bin_data.dtype == "float16"
-        bin_file_data = struct.pack(
-            "<I",
-            (FLAG_FLOAT_16 if bin_is_fp16 or os.environ["isFp16"] else FLAG_FLOAT_32),
-        ) + bin_data.astype(
-            np.float16 if bin_is_fp16 or os.environ["isFp16"] else np.float32
-        ).tobytes(
-            "F"
-        )
+        is_fp16 = os.environ["isFp16"] == "True"
+        flag = FLAG_FLOAT_16 if is_fp16 else FLAG_FLOAT_32
+        dtype = np.float16 if is_fp16 else np.float32
+        packed = struct.pack("<I", flag) + bin_data.astype(dtype).tobytes("F")
         with open(full_bin_path, "wb") as binary_file:
-            binary_file.write(bin_file_data)
+            binary_file.write(packed)
         with open(full_param_path, "w") as param_file:
             with open(param_path, "r") as original_param_file:
                 param_file.write(original_param_file.read())
@@ -190,17 +185,13 @@ class NcnnUpscaleImageNode(NodeBase):
         net.load_param(param_path)
 
         with tempfile.TemporaryDirectory(prefix="chaiNNer-") as tempdir:
-            bin_file_data = struct.pack(
-                "<I",
-                (FLAG_FLOAT_16 if os.environ["isFp16"] else FLAG_FLOAT_32),
-            ) + bin_data.astype(
-                np.float16 if os.environ["isFp16"] else np.float32
-            ).tobytes(
-                "F"
-            )
+            is_fp16 = os.environ["isFp16"] == "True"
+            flag = FLAG_FLOAT_16 if is_fp16 else FLAG_FLOAT_32
+            dtype = np.float16 if is_fp16 else np.float32
+            packed = struct.pack("<I", flag) + bin_data.astype(dtype).tobytes("F")
             temp_file = os.path.join(tempdir, "ncnn.bin")
             with open(temp_file, "wb") as binary_file:
-                binary_file.write(bin_file_data)
+                binary_file.write(packed)
             net.load_model(temp_file)
 
         # ncnn only supports 3 apparently

--- a/backend/nodes/ncnn_nodes.py
+++ b/backend/nodes/ncnn_nodes.py
@@ -189,18 +189,12 @@ class NcnnUpscaleImageNode(NodeBase):
         # Load model param and bin
         net.load_param(param_path)
 
-        bin_is_fp16 = True  # bin_data.dtype == "float16"
-
         with tempfile.TemporaryDirectory(prefix="chaiNNer-") as tempdir:
             bin_file_data = struct.pack(
                 "<I",
-                (
-                    FLAG_FLOAT_16
-                    if bin_is_fp16 or os.environ["isFp16"]
-                    else FLAG_FLOAT_32
-                ),
+                (FLAG_FLOAT_16 if os.environ["isFp16"] else FLAG_FLOAT_32),
             ) + bin_data.astype(
-                np.float16 if bin_is_fp16 or os.environ["isFp16"] else np.float32
+                np.float16 if os.environ["isFp16"] else np.float32
             ).tobytes(
                 "F"
             )

--- a/backend/nodes/pytorch_nodes.py
+++ b/backend/nodes/pytorch_nodes.py
@@ -29,7 +29,8 @@ def check_env():
 
     if os.environ["isFp16"] == "True":
         if os.environ["device"] == "cpu":
-            torch.set_default_tensor_type(torch.HalfTensor)
+            os.environ["isFp16"] = "False"
+            torch.set_default_tensor_type(torch.FloatTensor)
         elif os.environ["device"] == "cuda":
             torch.set_default_tensor_type(torch.cuda.HalfTensor)
         else:

--- a/backend/run.py
+++ b/backend/run.py
@@ -140,9 +140,7 @@ async def run(request: Request):
             logger.info(full_data)
             nodes_list = full_data["data"]
             os.environ["device"] = "cpu" if full_data["isCpu"] else "cuda"
-            os.environ["isFp16"] = (
-                "False" if full_data["isCpu"] else str(full_data["isFp16"])
-            )
+            os.environ["isFp16"] = str(full_data["isFp16"])
             logger.info(f"Using device: {os.environ['device']}")
             executor = Executor(nodes_list, app.loop, queue, app.ctx.cache.copy())
             request.app.ctx.executor = executor
@@ -181,7 +179,7 @@ async def run_individual(request: Request):
     full_data = request.json
     logger.info(full_data)
     os.environ["device"] = "cpu" if full_data["isCpu"] else "cuda"
-    os.environ["isFp16"] = "False" if full_data["isCpu"] else str(full_data["isFp16"])
+    os.environ["isFp16"] = str(full_data["isFp16"])
     logger.info(f"Using device: {os.environ['device']}")
     # Create node based on given category/name information
     node_instance = NodeFactory.create_node(full_data["schemaId"])

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -139,8 +139,8 @@ const SettingsModal = ({ isOpen, onClose }: SettingsModalProps) => {
                     <Switch
                         defaultChecked={isSnapToGrid}
                         size="lg"
-                        onChange={() => {
-                            setIsSnapToGrid(!isSnapToGrid);
+                        onChange={(event) => {
+                            setIsSnapToGrid(event.target.checked);
                         }}
                     />
                 </HStack>
@@ -301,8 +301,8 @@ const SettingsModal = ({ isOpen, onClose }: SettingsModalProps) => {
                     <Switch
                         defaultChecked={isSystemPython}
                         size="lg"
-                        onChange={() => {
-                            setIsSystemPython(!isSystemPython);
+                        onChange={(event) => {
+                            setIsSystemPython(event.target.checked);
                         }}
                     />
                 </HStack>
@@ -345,8 +345,8 @@ const SettingsModal = ({ isOpen, onClose }: SettingsModalProps) => {
                     <Switch
                         defaultChecked={isDisHwAccel}
                         size="lg"
-                        onChange={() => {
-                            setIsDisHwAccel(!isDisHwAccel);
+                        onChange={(event) => {
+                            setIsDisHwAccel(event.target.checked);
                         }}
                     />
                 </HStack>

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -29,11 +29,11 @@ import {
     useColorMode,
     useDisclosure,
 } from '@chakra-ui/react';
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect } from 'react';
 import { useContext } from 'use-context-selector';
+import { ipcRenderer } from '../../common/safeIpc';
 import { SettingsContext } from '../contexts/SettingsContext';
 import { useAsyncEffect } from '../hooks/useAsyncEffect';
-import { ipcRenderer } from '../../common/safeIpc';
 
 interface SettingsModalProps {
     isOpen: boolean;
@@ -52,28 +52,17 @@ const SettingsModal = ({ isOpen, onClose }: SettingsModalProps) => {
     const [isSnapToGrid, setIsSnapToGrid, snapToGridAmount, setSnapToGridAmount] = useSnapToGrid;
     const [isDisHwAccel, setIsDisHwAccel] = useDisHwAccel;
 
-    const [isNvidiaAvailable, setIsNvidiaAvailable] = useState(false);
-
     useAsyncEffect(
         {
-            supplier: async () =>
-                [
-                    (await ipcRenderer.invoke('get-gpu-name')) || 'GPU not detected',
-                    await ipcRenderer.invoke('get-has-nvidia'),
-                ] as const,
-            successEffect: ([gpuName, hasNvidia]) => {
+            supplier: async () => (await ipcRenderer.invoke('get-gpu-name')) || 'GPU not detected',
+            successEffect: (gpuName) => {
                 if (gpuName.toLowerCase().includes('rtx')) {
                     setIsFp16(true);
                 }
-                setIsNvidiaAvailable(hasNvidia);
             },
         },
         []
     );
-
-    useEffect(() => {
-        setIsCpu(!isNvidiaAvailable);
-    }, [isNvidiaAvailable]);
 
     useEffect(() => {
         if (isCpu && isFp16) {
@@ -226,17 +215,15 @@ const SettingsModal = ({ isOpen, onClose }: SettingsModalProps) => {
                         marginTop={0}
                         textAlign="left"
                     >
-                        Use CPU for PyTorch instead of GPU. Forced if Nvidia (CUDA) GPU not
-                        detected.
+                        Use CPU for PyTorch instead of GPU. This option does not affect NCNN.
                     </Text>
                 </VStack>
                 <HStack>
                     <Switch
                         defaultChecked={isCpu}
-                        isDisabled={!isNvidiaAvailable}
                         size="lg"
-                        onChange={() => {
-                            setIsCpu(!isCpu);
+                        onChange={(event) => {
+                            setIsCpu(event.target.checked);
                         }}
                     />
                 </HStack>
@@ -263,17 +250,16 @@ const SettingsModal = ({ isOpen, onClose }: SettingsModalProps) => {
                         marginTop={0}
                         textAlign="left"
                     >
-                        Runs PyTorch in half-precision (FP16) mode for less VRAM usage. RTX GPUs
-                        also get a speedup.
+                        Runs PyTorch and NCNN in half-precision (FP16) mode for less VRAM usage. RTX
+                        GPUs also get a speedup.
                     </Text>
                 </VStack>
                 <HStack>
                     <Switch
                         defaultChecked={isFp16}
-                        isDisabled={isCpu}
                         size="lg"
-                        onChange={() => {
-                            setIsFp16(!isFp16);
+                        onChange={(event) => {
+                            setIsFp16(event.target.checked);
                         }}
                     />
                 </HStack>

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -233,7 +233,7 @@ export const ExecutionProvider = ({ children }: React.PropsWithChildren<{}>) => 
                 const response = await backend.run({
                     data,
                     isCpu,
-                    isFp16: isFp16 && !isCpu,
+                    isFp16,
                 });
                 if (response.exception) {
                     sendAlert(AlertType.ERROR, null, response.exception);


### PR DESCRIPTION
This PR allows NCNN users to change the CPU/fp16 settings instead of those settings being disabled. The CPU setting doesn't do anything for NCNN yet though.

FP16 on the other hand is now the sole contributor to what gets an NCNN bin saved as fp16 or not. This is to hopefully fix black output on old AMD cards, though the fix is unconfirmed at the moment.