### PR TITLE
Fix node footer menu

### DIFF
--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -17,11 +17,11 @@ import ReactFlow, {
 } from 'react-flow-renderer';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { EdgeData, NodeData } from '../../common/common-types';
-import { DataTransferProcessorOptions, dataTransferProcessors } from '../helpers/dataTransfer';
 import { AlertBoxContext, AlertType } from '../contexts/AlertBoxContext';
 import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { MenuFunctionsContext } from '../contexts/MenuFunctions';
 import { SettingsContext } from '../contexts/SettingsContext';
+import { DataTransferProcessorOptions, dataTransferProcessors } from '../helpers/dataTransfer';
 import { isSnappedToGrid, snapToGrid } from '../helpers/reactFlowUtil';
 
 const STARTING_Z_INDEX = 50;
@@ -313,7 +313,6 @@ const ReactFlowBox = ({ wrapperRef, nodeTypes, edgeTypes }: ReactFlowBoxProps) =
                 onDrop={onDrop}
                 onEdgesChange={onEdgesChange}
                 onEdgesDelete={onEdgesDelete}
-                onMouseDown={closeAllMenus}
                 onMoveEnd={onMoveEnd}
                 onMoveStart={closeAllMenus}
                 onNodeDragStop={onNodeDragStop}

--- a/src/renderer/components/node/NodeFooter.tsx
+++ b/src/renderer/components/node/NodeFooter.tsx
@@ -131,7 +131,7 @@ const NodeFooter = ({ id, isValid = false, invalidReason = '', isLocked }: NodeF
                         </Center>
                     </MenuButton>
                     <Portal>
-                        <MenuList>
+                        <MenuList className="nodrag">
                             <MenuItem
                                 icon={<CopyIcon />}
                                 onClick={() => {

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -19,16 +19,16 @@ import {
     NodeData,
     Size,
 } from '../../common/common-types';
+import { ipcRenderer } from '../../common/safeIpc';
+import { ParsedSaveData, SaveData } from '../../common/SaveFile';
+import { SchemaMap } from '../../common/SchemaMap';
+import { createUniqueId, deriveUniqueId, parseHandle } from '../../common/util';
+import { copyNode } from '../helpers/reactFlowUtil';
 import { useAsyncEffect } from '../hooks/useAsyncEffect';
 import { ChangeCounter, useChangeCounter, wrapChanges } from '../hooks/useChangeCounter';
 import { useIpcRendererListener } from '../hooks/useIpcRendererListener';
 import { getSessionStorageOrDefault } from '../hooks/useSessionStorage';
-import { ipcRenderer } from '../../common/safeIpc';
-import { ParsedSaveData, SaveData } from '../../common/SaveFile';
-import { createUniqueId, deriveUniqueId, parseHandle } from '../../common/util';
 import { AlertBoxContext, AlertType } from './AlertBoxContext';
-import { SchemaMap } from '../../common/SchemaMap';
-import { copyNode } from '../helpers/reactFlowUtil';
 
 type SetState<T> = React.Dispatch<React.SetStateAction<T>>;
 


### PR DESCRIPTION
Closes #249

It turns out it was just the onMouseDown handler. It still reacts to other clicking like before, just without the issue. Also, I added the "nodrag" className to avoid being able to drag the node by the menu