### PR TITLE
Add unsaved changes warning on quit

### DIFF
--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -68,6 +68,7 @@ export interface SendChannels {
     'splash-finish': SendChannelInfo;
     'start-sleep-blocker': SendChannelInfo;
     'stop-sleep-blocker': SendChannelInfo;
+    'update-has-unsaved-changes': SendChannelInfo<[boolean]>;
 
     // history
     'history-undo': SendChannelInfo;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -927,6 +927,7 @@ const createWindow = async () => {
             const choice = dialog.showMessageBoxSync(mainWindow, {
                 type: 'question',
                 buttons: ['Yes', 'No'],
+                defaultId: 1,
                 title: 'Discard unsaved changes?',
                 message:
                     'The current chain has some unsaved changes. Do you really want to quit without saving?',

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -917,6 +917,24 @@ const createWindow = async () => {
         mainWindow.webContents.openDevTools();
     }
 
+    let hasUnsavedChanges = false;
+    ipcMain.on('update-has-unsaved-changes', (_, value) => {
+        hasUnsavedChanges = value;
+    });
+
+    mainWindow.on('close', (event) => {
+        if (hasUnsavedChanges) {
+            const choice = dialog.showMessageBoxSync(mainWindow, {
+                type: 'question',
+                buttons: ['Yes', 'No'],
+                title: 'Discard unsaved changes?',
+                message:
+                    'The current chain has some unsaved changes. Do you really want to quit without saving?',
+            });
+            if (choice > 0) event.preventDefault();
+        }
+    });
+
     // Opening file with chaiNNer
     const { file: filepath } = getArguments();
     if (filepath) {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -931,7 +931,7 @@ const createWindow = async () => {
                 message:
                     'The current chain has some unsaved changes. Do you really want to quit without saving?',
             });
-            if (choice > 0) event.preventDefault();
+            if (choice === 1) event.preventDefault();
         }
     });
 

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -223,7 +223,9 @@ export const GlobalProvider = ({
      */
     const [hasRelevantUnsavedChanges, setHasRelevantUnsavedChanges] = useState(false);
     useEffect(() => {
-        setHasRelevantUnsavedChanges(hasUnsavedChanges && (getNodes().length > 0 || !!savePath));
+        const value = hasUnsavedChanges && (getNodes().length > 0 || !!savePath);
+        setHasRelevantUnsavedChanges(value);
+        ipcRenderer.send('update-has-unsaved-changes', value);
     }, [hasUnsavedChanges, savePath, nodeChanges]);
 
     useEffect(() => {


### PR DESCRIPTION
Closes #219 (sorta)

I don't think this is possible to do with chakra menus, as there isn't a way I can think of to block the main process and wait for a response from the renderer. Using the system dialog was pretty easy.

This only half closes the issue since I didn't do the warning on file open.