### PR TITLE
Added dev tools toggle to menu

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -871,6 +871,7 @@ const createWindow = async () => {
                           { role: 'window' },
                       ]
                     : [{ role: 'close' }]),
+                ...(!app.isPackaged ? [{ type: 'separator' }, { role: 'toggleDevTools' }] : []),
             ],
         },
         {


### PR DESCRIPTION
It always annoyed me that I couldn't re-open the dev tools when testing, so I added a menu entry for it. The menu entry is only visible during development, not in the final build.