### PR TITLE
Remember window size

### DIFF
--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -102,3 +102,9 @@ export interface UsableData {
     nodeType: string | undefined;
     percent?: number;
 }
+
+export interface WindowSize {
+    readonly maximized: boolean;
+    readonly width: number;
+    readonly height: number;
+}

--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -69,6 +69,7 @@ export interface SendChannels {
     'start-sleep-blocker': SendChannelInfo;
     'stop-sleep-blocker': SendChannelInfo;
     'update-has-unsaved-changes': SendChannelInfo<[boolean]>;
+    'window-maximized-change': SendChannelInfo<[maximized: boolean]>;
 
     // history
     'history-undo': SendChannelInfo;

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -47,3 +47,11 @@ export const lazy = <T>(fn: () => T): (() => T) => {
         return value;
     };
 };
+
+export const debounce = (fn: () => void, delay: number): (() => void) => {
+    let id: NodeJS.Timeout | undefined;
+    return () => {
+        if (id !== undefined) clearTimeout(id);
+        id = setTimeout(fn, delay);
+    };
+};

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -20,7 +20,7 @@ import portfinder from 'portfinder';
 import semver from 'semver';
 import { graphics } from 'systeminformation';
 import util from 'util';
-import { PythonKeys } from '../common/common-types';
+import { PythonKeys, WindowSize } from '../common/common-types';
 import { BrowserWindowWithSafeIpc, ipcMain } from '../common/safeIpc';
 import { SaveFile, openSaveFile } from '../common/SaveFile';
 import { checkFileExists, lazy } from '../common/util';
@@ -41,6 +41,9 @@ const localStorageLocation = path.join(app.getPath('userData'), 'settings');
 ipcMain.handle('get-localstorage-location', () => localStorageLocation);
 const localStorage = new LocalStorage(localStorageLocation);
 
+const lastWindowSize = JSON.parse(
+    localStorage.getItem('use-last-window-size') || 'null'
+) as WindowSize | null;
 const disableHardwareAcceleration = localStorage.getItem('disable-hw-accel') === 'true';
 if (disableHardwareAcceleration) {
     app.disableHardwareAcceleration();
@@ -659,14 +662,17 @@ const doSplashScreenChecks = async () =>
             await sleep(500);
             splash.destroy();
             mainWindow.show();
+            if (lastWindowSize?.maximized) {
+                mainWindow.maximize();
+            }
         });
     });
 
 const createWindow = async () => {
     // Create the browser window.
     mainWindow = new BrowserWindow({
-        width: 1280,
-        height: 720,
+        width: lastWindowSize?.width ?? 1280,
+        height: lastWindowSize?.height ?? 720,
         backgroundColor: '#1A202C',
         minWidth: 720,
         minHeight: 640,
@@ -859,6 +865,13 @@ const createWindow = async () => {
             });
             if (choice === 1) event.preventDefault();
         }
+    });
+
+    mainWindow.on('maximize', () => {
+        mainWindow.webContents.send('window-maximized-change', true);
+    });
+    mainWindow.on('unmaximize', () => {
+        mainWindow.webContents.send('window-maximized-change', false);
     });
 
     // Opening file with chaiNNer

--- a/src/renderer/hooks/useLastWindowSize.ts
+++ b/src/renderer/hooks/useLastWindowSize.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { WindowSize } from '../../common/common-types';
+import { debounce } from '../../common/util';
+import { useIpcRendererListener } from './useIpcRendererListener';
+import useLocalStorage from './useLocalStorage';
+
+const defaultSize: WindowSize = {
+    maximized: false,
+    width: 1280,
+    height: 720,
+};
+
+export const useLastWindowSize = () => {
+    const [, setSize] = useLocalStorage<WindowSize>('use-last-window-size', defaultSize);
+
+    useEffect(() => {
+        const listener = debounce(() => {
+            setSize((prev) => {
+                if (prev.maximized) return prev;
+                return {
+                    maximized: false,
+                    width: window.outerWidth,
+                    height: window.outerHeight,
+                };
+            });
+        }, 100);
+
+        window.addEventListener('resize', listener);
+        return () => window.removeEventListener('resize', listener);
+    }, [setSize]);
+
+    useIpcRendererListener(
+        'window-maximized-change',
+        (_, maximized) => {
+            setSize((prev) => ({ ...prev, maximized }));
+        },
+        [setSize]
+    );
+};

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -21,6 +21,7 @@ import { ExecutionProvider } from './contexts/ExecutionContext';
 import { GlobalProvider } from './contexts/GlobalNodeState';
 import { MenuFunctionsProvider } from './contexts/MenuFunctions';
 import { SettingsProvider } from './contexts/SettingsContext';
+import { useLastWindowSize } from './hooks/useLastWindowSize';
 
 const nodeTypes: NodeTypes = {
     regularNode: Node,
@@ -60,6 +61,8 @@ const Main = ({ port }: MainProps) => {
             ipcRenderer.send('backend-ready');
         }
     }, [response, data, loading, error, backendReady]);
+
+    useLastWindowSize();
 
     const loadingLogo = (
         <ChaiNNerLogo


### PR DESCRIPTION
fixes #123 

This wasn't actually that trivial. The main problem is that we have to store the last window size in localStorage. But localStorage can only be read once by the main process at start up and is otherwise inaccessible after the renderer window has been opened. From that point on, the solo owner of localStorage is the renderer window.