### PR TITLE
Removed unnecessary hover conditions

### DIFF
--- a/src/renderer/components/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge.tsx
@@ -61,7 +61,7 @@ const CustomEdge = ({
     return (
         <g
             style={{
-                cursor: isHovered ? 'pointer' : 'default',
+                cursor: 'pointer',
             }}
             onDragEnter={() => setHoveredNode(parentNode.parentNode)}
             onMouseEnter={() => setIsHovered(true)}
@@ -79,7 +79,7 @@ const CustomEdge = ({
                     transitionDuration: '0.15s',
                     transitionProperty: 'stroke-width, stroke',
                     transitionTimingFunction: 'ease-in-out',
-                    cursor: isHovered ? 'pointer' : 'default',
+                    cursor: 'pointer',
                 }}
             />
             <path
@@ -88,7 +88,7 @@ const CustomEdge = ({
                     strokeWidth: 18,
                     fill: 'none',
                     stroke: 'none',
-                    cursor: isHovered ? 'pointer' : 'default',
+                    cursor: 'pointer',
                 }}
             />
             <foreignObject


### PR DESCRIPTION
The cursor property only takes effect when the element is hovered, so the condition is unnecessary.