### PR TITLE
Set Reference Image Scale Factor to 100%

### DIFF
--- a/backend/nodes/image_filter_nodes.py
+++ b/backend/nodes/image_filter_nodes.py
@@ -130,7 +130,7 @@ class AverageColorFixNode(NodeBase):
             BoundedNumberInput(
                 "Reference Image Scale Factor (%)",
                 minimum=0.1,
-                maximum=None,
+                maximum=100,
                 default=12.5,
                 step=12.5,
             ),


### PR DESCRIPTION
I think we had this before, but here it is again: The reference scale does not make any sense for factors >100%.