### PR TITLE
Add redo handler for ctrl+shift+z

### DIFF
--- a/src/renderer/components/HistoryProvider.tsx
+++ b/src/renderer/components/HistoryProvider.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Edge, Node, Viewport, useKeyPress, useReactFlow } from 'react-flow-renderer';
+import { Edge, Node, Viewport, useReactFlow } from 'react-flow-renderer';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { EdgeData, NodeData } from '../../common/common-types';

--- a/src/renderer/components/HistoryProvider.tsx
+++ b/src/renderer/components/HistoryProvider.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Edge, Node, Viewport, useReactFlow } from 'react-flow-renderer';
+import { Edge, Node, Viewport, useKeyPress, useReactFlow } from 'react-flow-renderer';
+import { useHotkeys } from 'react-hotkeys-hook';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { EdgeData, NodeData } from '../../common/common-types';
 import { noop } from '../../common/util';
@@ -115,6 +116,16 @@ export const HistoryProvider = ({ children }: React.PropsWithChildren<unknown>):
 
     useIpcRendererListener(
         'history-redo',
+        () => {
+            historyObj.history = historyObj.history.redo();
+            apply(historyObj.history.current);
+        },
+        [apply]
+    );
+
+    // Handler for ctrl+shift+z
+    useHotkeys(
+        'ctrl+shift+z, cmd+shift+z, meta+shift+z',
         () => {
             historyObj.history = historyObj.history.redo();
             apply(historyObj.history.current);

--- a/src/renderer/components/HistoryProvider.tsx
+++ b/src/renderer/components/HistoryProvider.tsx
@@ -125,7 +125,7 @@ export const HistoryProvider = ({ children }: React.PropsWithChildren<unknown>):
 
     // Handler for ctrl+shift+z
     useHotkeys(
-        'ctrl+shift+z, cmd+shift+z, meta+shift+z',
+        'ctrl+shift+z, cmd+shift+z',
         () => {
             historyObj.history = historyObj.history.redo();
             apply(historyObj.history.current);


### PR DESCRIPTION
Unfortunately you can't define multiple accelerators, but since this is just an alternate shortcut for people used to using ctrl+shift+z to redo in other programs, I think it works fine