### PR TITLE
Open recent

### DIFF
--- a/src/common/safeIpc.ts
+++ b/src/common/safeIpc.ts
@@ -40,7 +40,7 @@ export interface InvokeChannels {
     'file-save-json': ChannelInfo<void, [saveData: SaveData, savePath: string]>;
     'file-save-as-json': ChannelInfo<
         FileSaveResult,
-        [saveData: SaveData, savePath: string | undefined]
+        [saveData: SaveData, defaultPath: string | undefined]
     >;
     'get-cli-open': ChannelInfo<FileOpenResult<ParsedSaveData> | undefined>;
     'owns-backend': ChannelInfo<boolean>;
@@ -70,6 +70,8 @@ export interface SendChannels {
     'start-sleep-blocker': SendChannelInfo;
     'stop-sleep-blocker': SendChannelInfo;
     'update-has-unsaved-changes': SendChannelInfo<[boolean]>;
+    'update-open-recent-menu': SendChannelInfo<[string[]]>;
+    'clear-open-recent': SendChannelInfo;
     'window-maximized-change': SendChannelInfo<[maximized: boolean]>;
     'show-collected-information': SendChannelInfo<[info: Record<string, unknown>]>;
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -717,18 +717,16 @@ const setMainMenu = (openRecentRev: string[]) => {
                                       enabled: false,
                                   } as MenuItemConstructorOptions,
                               ]
-                            : openRecent
-                                  .slice(0, 9)
-                                  .map<MenuItemConstructorOptions>((filepath, i) => ({
-                                      label: filepath,
-                                      accelerator: `CmdOrCtrl+${i + 1}`,
-                                      click: async () => {
-                                          mainWindow.webContents.send(
-                                              'file-open',
-                                              await openSaveFile(filepath)
-                                          );
-                                      },
-                                  }))),
+                            : openRecent.map<MenuItemConstructorOptions>((filepath, i) => ({
+                                  label: filepath,
+                                  accelerator: i <= 9 ? `CmdOrCtrl+${i + 1}` : undefined,
+                                  click: async () => {
+                                      mainWindow.webContents.send(
+                                          'file-open',
+                                          await openSaveFile(filepath)
+                                      );
+                                  },
+                              }))),
                         { type: 'separator' },
                         {
                             label: 'Clear Recently Opened',

--- a/src/renderer/hooks/useOpenRecent.ts
+++ b/src/renderer/hooks/useOpenRecent.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect } from 'react';
+import { ipcRenderer } from '../../common/safeIpc';
+import { useIpcRendererListener } from './useIpcRendererListener';
+import useLocalStorage from './useLocalStorage';
+
+const MAX_ENTRIES = 20;
+
+export const useOpenRecent = () => {
+    const [recentlyOpen, setRecentlyOpen] = useLocalStorage<readonly string[]>(
+        'use-recently-open',
+        []
+    );
+
+    useEffect(() => {
+        ipcRenderer.send('update-open-recent-menu', recentlyOpen as string[]);
+    }, []);
+
+    const push = useCallback(
+        (path: string): void =>
+            setRecentlyOpen((prev) => {
+                if (prev.includes(path)) {
+                    // nothing changed
+                    if (prev[prev.length - 1] === path) return prev;
+
+                    // eslint-disable-next-line no-param-reassign
+                    prev = prev.filter((p) => p !== path);
+                }
+                const newPaths = [...prev, path];
+                if (newPaths.length > MAX_ENTRIES)
+                    newPaths.splice(0, newPaths.length - MAX_ENTRIES);
+
+                ipcRenderer.send('update-open-recent-menu', newPaths);
+
+                return newPaths;
+            }),
+        [setRecentlyOpen]
+    );
+
+    const remove = useCallback(
+        (path: string): void =>
+            setRecentlyOpen((prev) => {
+                if (!prev.includes(path)) {
+                    return prev;
+                }
+                const newPaths = prev.filter((p) => p !== path);
+
+                ipcRenderer.send('update-open-recent-menu', newPaths);
+
+                return newPaths;
+            }),
+        [setRecentlyOpen]
+    );
+
+    useIpcRendererListener(
+        'clear-open-recent',
+        () => {
+            setRecentlyOpen([]);
+            ipcRenderer.send('update-open-recent-menu', []);
+        },
+        [setRecentlyOpen]
+    );
+
+    return [recentlyOpen, push, remove] as const;
+};


### PR DESCRIPTION
fixes #244
fixes #245

This adds a small history for recently opened files. 20 entries are stored and the first 9 entries have a shortcut Ctrl+1 - Ctrl-9. These shortcuts allow you to quickly cycle between chains.

I also use the stored path to get a good default path for the open and save file dialogs (#244). 

![image](https://user-images.githubusercontent.com/20878432/169403147-a0bcfa87-d9a5-4b8e-972a-c6b429eadeb1.png)
