### PR TITLE
Added tooltip delay

### DIFF
--- a/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -64,6 +64,7 @@ const RepresentativeNodeWrapper = ({ node, collapsed = false }: RepresentativeNo
                 hasArrow
                 borderRadius={8}
                 label={<ReactMarkdown>{node.description}</ReactMarkdown>}
+                openDelay={200}
                 px={2}
                 py={1}
             >


### PR DESCRIPTION
I added a small delay to prevent tooltips from half-opening when you move the cursor over the node selector to get to a specific node. The delay is barely noticeable.