### PR TITLE
Added node list collapse button, restyled collapse

### DIFF
--- a/backend/src/nodes/image_adj_nodes.py
+++ b/backend/src/nodes/image_adj_nodes.py
@@ -253,4 +253,3 @@ class AdaptiveThresholdNode(NodeBase):
         )
 
         return result.astype("float32") / 255
-

--- a/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
+++ b/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
@@ -109,13 +109,17 @@ const NodeSelector = memo(({ schemata, height }: NodeSelectorProps) => {
 
     const [showCollapseButtons, setShowCollapseButtons] = useState(false);
 
-    const defaultIndex = [['', favoriteNodes]].concat([...byCategories]).map((_, index) => index);
+    const defaultIndex = Array.from({ length: byCategories.size + 1 }, (_, i) => i);
     const [accordionIndex, setAccordionIndex] = useState<ExpandedIndex>(defaultIndex);
 
+    const accordionIsCollapsed = typeof accordionIndex !== 'number' && accordionIndex.length === 0;
+
     const toggleAccordion = () => {
-        if (typeof accordionIndex !== 'number' && accordionIndex.length === 0)
+        if (accordionIsCollapsed) {
             setAccordionIndex(defaultIndex);
-        else setAccordionIndex([]);
+        } else {
+            setAccordionIndex([]);
+        }
     };
 
     return (
@@ -205,8 +209,7 @@ const NodeSelector = memo(({ schemata, height }: NodeSelectorProps) => {
                                                 pt="2px"
                                                 w="20px"
                                             >
-                                                {typeof accordionIndex !== 'number' &&
-                                                accordionIndex.length === 0 ? (
+                                                {accordionIsCollapsed ? (
                                                     <BsCaretDownFill />
                                                 ) : (
                                                     <BsCaretUpFill />

--- a/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
+++ b/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
@@ -238,27 +238,25 @@ const NodeSelector = memo(({ schemata, height }: NodeSelectorProps) => {
                                             />
                                         );
                                     })}
-                                    {!collapsed && (
-                                        <AccordionItem>
-                                            <Box p={4}>
-                                                <TextBox
-                                                    collapsed={collapsed}
-                                                    text="Missing nodes? Click to open the dependency manager!"
-                                                    toolTip={
-                                                        collapsed
-                                                            ? 'Missing nodes? Click to open the dependency manager!'
-                                                            : ''
-                                                    }
-                                                    onClick={onOpen}
-                                                />
-                                            </Box>
-                                            {/* TODO: Replace this with a single instance of the dep manager that shares a global open/close state */}
-                                            <DependencyManager
-                                                isOpen={isOpen}
-                                                onClose={onClose}
+                                    <AccordionItem>
+                                        <Box p={4}>
+                                            <TextBox
+                                                collapsed={collapsed}
+                                                text="Missing nodes? Click to open the dependency manager!"
+                                                toolTip={
+                                                    collapsed
+                                                        ? 'Missing nodes? Click to open the dependency manager!'
+                                                        : ''
+                                                }
+                                                onClick={onOpen}
                                             />
-                                        </AccordionItem>
-                                    )}
+                                        </Box>
+                                        {/* TODO: Replace this with a single instance of the dep manager that shares a global open/close state */}
+                                        <DependencyManager
+                                            isOpen={isOpen}
+                                            onClose={onClose}
+                                        />
+                                    </AccordionItem>
                                 </Accordion>
                             </Box>
                         </TabPanel>


### PR DESCRIPTION
New on-hover tabs for collapsing/expanding sidebar and node categories. Subject to further changes, but want to go ahead and get the functionality merged.

closes joeyballentine/chaiNNer#122