### PR TITLE
Fixed env type hack

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -2,5 +2,6 @@
 	"extends": "../tsconfig.json",
 	"compilerOptions": {
 		"module": "CommonJS",
+		"types": ["electron"]
 	}
 }

--- a/src/common/env.ts
+++ b/src/common/env.ts
@@ -3,6 +3,4 @@ import os from 'os';
 export const isMac = process.platform === 'darwin';
 export const isM1 = isMac && (os.cpus()[0]?.model.includes('Apple M1') ?? false);
 
-export const isRenderer =
-    typeof process !== 'undefined' &&
-    (process as unknown as { type: 'browser' | 'renderer' | 'worker' }).type === 'renderer';
+export const isRenderer = typeof process !== 'undefined' && process.type === 'renderer';


### PR DESCRIPTION
TS-node didn't load Electron's type declarations, so I added a hack to get around this in #377. This PR removes the hack and makes TS-node load Electron's type declarations properly.