### PR TITLE
Tweaked how images saved to allow non-ascii

### DIFF
--- a/backend/src/nodes/image_nodes.py
+++ b/backend/src/nodes/image_nodes.py
@@ -161,7 +161,10 @@ class ImWriteNode(NodeBase):
 
         os.makedirs(base_directory, exist_ok=True)
 
-        status = cv2.imwrite(full_path, img)
+        status, buf_img = cv2.imencode(f".{extension}", img)
+        with open(full_path, "wb") as outf:
+            bytes_written = outf.write(buf_img)
+            status = status and bytes_written == len(buf_img)
 
         return status
 


### PR DESCRIPTION
Switched from imwrite to imencode -> basic BufferedWriter.write() to allow for saving files with non-ascii file names. Changed status to bool(imencode retval * bytes written) so that run() will return false if imencode fails or the correct number of bytes is not written to file.