### PR TITLE
ONNX runtime support

### DIFF
--- a/backend/src/nodes/categories.py
+++ b/backend/src/nodes/categories.py
@@ -9,6 +9,9 @@ IMAGE_CHANNEL = "Image (Channels)"
 # PyTorch
 PYTORCH = "PyTorch"
 
+# ONNX
+ONNX = "ONNX"
+
 # NCNN
 NCNN = "NCNN"
 
@@ -23,6 +26,7 @@ category_order = [
     IMAGE_UTILITY,
     IMAGE_CHANNEL,
     PYTORCH,
+    ONNX,
     NCNN,
     UTILITY,
 ]

--- a/backend/src/nodes/onnx_nodes.py
+++ b/backend/src/nodes/onnx_nodes.py
@@ -1,0 +1,141 @@
+import os
+from typing import Any, OrderedDict
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+from sanic.log import logger
+
+from .categories import ONNX
+from .node_base import NodeBase
+from .node_factory import NodeFactory
+from .properties.inputs import *
+from .properties.outputs import *
+from .utils.onnx_auto_split import onnx_auto_split_process
+from .utils.utils import get_h_w_c
+
+
+@NodeFactory.register("chainner:onnx:load_model")
+class OnnxLoadModelNode(NodeBase):
+    """ONNX Load Model node"""
+
+    def __init__(self):
+        """Constructor"""
+        super().__init__()
+        self.description = (
+            """Load ONNX model file (.onnx). Theoretically supports any ONNX model."""
+        )
+        self.inputs = [OnnxFileInput()]
+        self.outputs = [OnnxModelOutput(), TextOutput("Model Name")]
+
+        self.category = ONNX
+        self.name = "Load Model"
+        self.icon = "ONNX"
+        self.sub = "Input & Output"
+
+        self.model = None  # Defined in run
+
+    def run(self, path: str) -> Any:
+        """Read a pth file from the specified path and return it as a state dict
+        and loaded model after finding arch config"""
+
+        assert os.path.exists(path), f"Model file at location {path} does not exist"
+
+        assert os.path.isfile(path), f"Path {path} is not a file"
+
+        logger.info(f"Reading onnx model from path: {path}")
+        model = onnx.load_model(path)
+
+        basename = os.path.splitext(os.path.basename(path))[0]
+
+        return model, basename
+
+
+@NodeFactory.register("chainner:onnx:upscale_image")
+class OnnxImageUpscaleNode(NodeBase):
+    """Image Upscale node"""
+
+    def __init__(self):
+        """Constructor"""
+        super().__init__()
+        self.description = "Upscales an image using an ONNX Super-Resolution model."
+        self.inputs = [OnnxModelInput(), ImageInput()]
+        self.outputs = [ImageOutput("Upscaled Image")]
+
+        self.category = ONNX
+        self.name = "Upscale Image"
+        self.icon = "ONNX"
+        self.sub = "Processing"
+
+    def upscale(self, img: np.ndarray, model: onnx.ModelProto):
+        with torch.no_grad():
+            logger.info("Upscaling image")
+            session = ort.InferenceSession(
+                model,
+                providers=[
+                    "CPUExecutionProvider"
+                    if os.environ["device"] == "cpu"
+                    else "CUDAExecutionProvider"
+                ],
+            )
+            out, _ = onnx_auto_split_process(img, session)
+            del session
+            logger.info("Done upscaling")
+            return out
+
+    def run(self, model: onnx.ModelProto, img: np.ndarray) -> np.ndarray:
+        """Upscales an image with a pretrained model"""
+
+        logger.info(f"Upscaling image...")
+
+        # Assume in_nc is 3
+        in_nc = 3
+        _, _, c = get_h_w_c(img)
+
+        # Ensure correct amount of image channels for the model.
+        # The frontend should type-validate this enough where it shouldn't be needed,
+        # But I want to be extra safe
+
+        # Transparency hack (white/black background difference alpha)
+        if in_nc == 3 and c == 4:
+            # Ignore single-color alpha
+            unique = np.unique(img[:, :, 3])
+            if len(unique) == 1:
+                logger.info("Single color alpha channel, ignoring.")
+                output = self.upscale(img[:, :, :3], model)  # type: ignore
+                output = np.dstack((output, np.full(output.shape[:-1], unique[0])))
+            else:
+                img1 = np.copy(img[:, :, :3])
+                img2 = np.copy(img[:, :, :3])
+                for c in range(3):
+                    img1[:, :, c] *= img[:, :, 3]
+                    img2[:, :, c] = (img2[:, :, c] - 1) * img[:, :, 3] + 1
+
+                output1 = self.upscale(img1, model)  # type: ignore
+                output2 = self.upscale(img2, model)  # type: ignore
+                alpha = 1 - np.mean(output2 - output1, axis=2)  # type: ignore
+                output = np.dstack((output1, alpha))
+        else:
+            # Add extra channels if not enough (i.e single channel img, three channel model)
+            gray = False
+            if img.ndim == 2:
+                gray = True
+                logger.debug("Expanding image channels")
+                img = np.tile(np.expand_dims(img, axis=2), (1, 1, min(in_nc, 3)))  # type: ignore
+            # Remove extra channels if too many (i.e three channel image, single channel model)
+            elif img.shape[2] > in_nc:  # type: ignore
+                logger.warning("Truncating image channels")
+                img = img[:, :, :in_nc]
+            # Pad with solid alpha channel if needed (i.e three channel image, four channel model)
+            elif img.shape[2] == 3 and in_nc == 4:
+                logger.debug("Expanding image channels")
+                img = np.dstack((img, np.full(img.shape[:-1], 1.0)))
+
+            output = self.upscale(img, model)  # type: ignore
+
+            if gray:
+                output = np.average(output, axis=2).astype("float32")
+
+        output = np.clip(output, 0, 1)
+
+        return output

--- a/backend/src/nodes/properties/inputs/__init__.py
+++ b/backend/src/nodes/properties/inputs/__init__.py
@@ -5,4 +5,5 @@ from .generic_inputs import *
 from .ncnn_inputs import *
 from .numeric_inputs import *
 from .numpy_inputs import *
+from .onnx_inputs import *
 from .pytorch_inputs import *

--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -111,4 +111,4 @@ def ParamFileInput() -> FileInput:
 
 def OnnxFileInput() -> FileInput:
     """Input for submitting a local .onnx file"""
-    return FileInput("onnx", "ONNX Model File", [".onnx"])
+    return FileInput("onnx", "ONNX Model File", [".onnx"], has_handle=True)

--- a/backend/src/nodes/properties/inputs/file_inputs.py
+++ b/backend/src/nodes/properties/inputs/file_inputs.py
@@ -107,3 +107,8 @@ def BinFileInput() -> FileInput:
 def ParamFileInput() -> FileInput:
     """Input for submitting a local .param file"""
     return FileInput("param", "NCNN Param File", [".param"])
+
+
+def OnnxFileInput() -> FileInput:
+    """Input for submitting a local .onnx file"""
+    return FileInput("onnx", "ONNX Model File", [".onnx"])

--- a/backend/src/nodes/properties/inputs/onnx_inputs.py
+++ b/backend/src/nodes/properties/inputs/onnx_inputs.py
@@ -1,0 +1,8 @@
+from .base_input import BaseInput
+
+
+class OnnxModelInput(BaseInput):
+    """Input for onnx model"""
+
+    def __init__(self, label: str = "Model"):
+        super().__init__(f"onnx::model", label)

--- a/backend/src/nodes/properties/outputs/__init__.py
+++ b/backend/src/nodes/properties/outputs/__init__.py
@@ -3,4 +3,5 @@ from .file_outputs import *
 from .generic_outputs import *
 from .ncnn_outputs import *
 from .numpy_outputs import *
+from .onnx_outputs import *
 from .pytorch_outputs import *

--- a/backend/src/nodes/properties/outputs/onnx_outputs.py
+++ b/backend/src/nodes/properties/outputs/onnx_outputs.py
@@ -1,0 +1,6 @@
+from .base_output import BaseOutput
+
+
+def OnnxModelOutput(label: str = "Model"):
+    """Output for onnx model"""
+    return BaseOutput("onnx::model", label)

--- a/backend/src/nodes/utils/onnx_auto_split.py
+++ b/backend/src/nodes/utils/onnx_auto_split.py
@@ -4,36 +4,16 @@ import gc
 from typing import Tuple, Union
 
 import numpy as np
-from ncnn_vulkan import ncnn
-from sanic.log import logger
-
-
-def fix_dtype_range(img):
-    dtype_max = 1
-    try:
-        dtype_max = np.iinfo(img.dtype).max
-    except:
-        logger.debug("img dtype is not an int")
-
-    img = (
-        (np.clip(img.astype("float32") / dtype_max, 0, 1) * 255)
-        .round()
-        .astype(np.uint8)
-    )
-    return img
+import onnxruntime
 
 
 # NCNN version of the 'auto_split_upscale' function
-def ncnn_auto_split_process(
+def onnx_auto_split_process(
     lr_img: np.ndarray,
-    net,
+    session: onnxruntime.InferenceSession,
     overlap: int = 16,
     max_depth: Union[int, None] = None,
     current_depth: int = 1,
-    input_name: str = "data",
-    output_name: str = "output",
-    blob_vkallocator=None,
-    staging_vkallocator=None,
 ) -> Tuple[np.ndarray, int]:
     """
     Run NCNN upscaling with automatic recursive tile splitting based on ability to process with current size
@@ -45,46 +25,22 @@ def ncnn_auto_split_process(
     #     gc.collect()
     #     raise RuntimeError("Upscaling killed mid-processing")
 
+    input_name = session.get_inputs()[0].name
+    output_name = session.get_outputs()[0].name
+
     # Prevent splitting from causing an infinite out-of-vram loop
     if current_depth > 15:
-        ncnn.destroy_gpu_instance()
         gc.collect()
         raise RuntimeError("Splitting stopped to prevent infinite loop")
 
     # Attempt to upscale if unknown depth or if reached known max depth
     if max_depth is None or max_depth == current_depth:
-        ex = net.create_extractor()
-        ex.set_blob_vkallocator(blob_vkallocator)
-        ex.set_workspace_vkallocator(blob_vkallocator)
-        ex.set_staging_vkallocator(staging_vkallocator)
         # ex.set_light_mode(True)
         try:
-            lr_img_fix = fix_dtype_range(lr_img.copy())
-            mat_in = ncnn.Mat.from_pixels(
-                lr_img_fix,
-                ncnn.Mat.PixelType.PIXEL_RGB,
-                lr_img_fix.shape[1],
-                lr_img_fix.shape[0],
-            )
-            mean_vals = []
-            norm_vals = [1 / 255.0, 1 / 255.0, 1 / 255.0]
-            mat_in.substract_mean_normalize(mean_vals, norm_vals)
-            ex.input(input_name, mat_in)
-            _, mat_out = ex.extract(output_name)
-            result = np.array(mat_out).transpose(1, 2, 0).astype(np.float32)
-            del ex, mat_in, mat_out
-            # # Clear VRAM
-            # blob_vkallocator.clear()
-            # staging_vkallocator.clear()
-            return result.copy(), current_depth
+            output: np.ndarray = session.run([output_name], {input_name: lr_img})
+            return output.copy(), current_depth
         except Exception as e:
-            # Check to see if its actually the NCNN out of memory error
-            if "failed" in str(e):
-                # clear VRAM
-                if blob_vkallocator is not None and staging_vkallocator is not None:
-                    blob_vkallocator.clear()
-                    staging_vkallocator.clear()
-                del ex
+            if "ONNXRuntimeError" in str(e) and "allocate memory" in str(e):
                 gc.collect()
             else:
                 # Re-raise the exception if not an OOM error
@@ -104,41 +60,33 @@ def ncnn_auto_split_process(
 
     # Recursively upscale the quadrants
     # After we go through the top left quadrant, we know the maximum depth and no longer need to test for out-of-memory
-    top_left_rlt, depth = ncnn_auto_split_process(
+    top_left_rlt, depth = onnx_auto_split_process(
         top_left,
-        net,
+        session,
         overlap=overlap,
         max_depth=max_depth,
         current_depth=current_depth + 1,
-        blob_vkallocator=blob_vkallocator,
-        staging_vkallocator=staging_vkallocator,
     )
-    top_right_rlt, _ = ncnn_auto_split_process(
+    top_right_rlt, _ = onnx_auto_split_process(
         top_right,
-        net,
+        session,
         overlap=overlap,
         max_depth=depth,
         current_depth=current_depth + 1,
-        blob_vkallocator=blob_vkallocator,
-        staging_vkallocator=staging_vkallocator,
     )
-    bottom_left_rlt, _ = ncnn_auto_split_process(
+    bottom_left_rlt, _ = onnx_auto_split_process(
         bottom_left,
-        net,
+        session,
         overlap=overlap,
         max_depth=depth,
         current_depth=current_depth + 1,
-        blob_vkallocator=blob_vkallocator,
-        staging_vkallocator=staging_vkallocator,
     )
-    bottom_right_rlt, _ = ncnn_auto_split_process(
+    bottom_right_rlt, _ = onnx_auto_split_process(
         bottom_right,
-        net,
+        session,
         overlap=overlap,
         max_depth=depth,
         current_depth=current_depth + 1,
-        blob_vkallocator=blob_vkallocator,
-        staging_vkallocator=staging_vkallocator,
     )
 
     tl_h, _ = top_left.shape[:2]

--- a/backend/src/nodes/utils/pytorch_auto_split.py
+++ b/backend/src/nodes/utils/pytorch_auto_split.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import gc
 import os
-
 from typing import Tuple, Union
 
 import torch
@@ -90,6 +89,7 @@ def auto_split_process(
         model,
         scale=scale,
         overlap=overlap,
+        max_depth=max_depth,
         current_depth=current_depth + 1,
     )
     top_right_rlt, _ = auto_split_process(

--- a/backend/src/nodes/utils/utils.py
+++ b/backend/src/nodes/utils/utils.py
@@ -196,3 +196,127 @@ def tensor2np(
 
     # has to be in range (0,255) before changing to np.uint8, else np.float32
     return img_np.astype(imtype)
+
+
+def np_bgr_to_rgb(image: np.ndarray) -> np.ndarray:
+    out: np.ndarray = image[::-1, ...]
+    return out
+
+
+def np_rgb_to_bgr(image: np.ndarray) -> np.ndarray:
+    # same operation as bgr_to_rgb(), flip image channels
+    return np_bgr_to_rgb(image)
+
+
+def np_bgra_to_rgba(image: np.ndarray) -> np.ndarray:
+    out: np.ndarray = image[[2, 1, 0, 3], ...]  # type: ignore
+    return out
+
+
+def np_rgba_to_bgra(image: np.ndarray) -> np.ndarray:
+    # same operation as bgra_to_rgba(), flip image channels
+    return np_bgra_to_rgba(image)
+
+
+def np2nptensor(
+    img: np.ndarray,
+    bgr2rgb=True,
+    data_range=1.0,
+    normalize=False,
+    change_range=True,
+    add_batch=True,
+) -> np.ndarray:  # type: ignore
+    """Converts a numpy image array into a numpy Tensor array.
+    Parameters:
+        img (numpy array): the input image numpy array
+        add_batch (bool): choose if new tensor needs batch dimension added
+    """
+    if not isinstance(img, np.ndarray):  # images expected to be uint8 -> 255
+        raise TypeError("Got unexpected object type, expected np.ndarray")
+    # check how many channels the image has, then condition. ie. RGB, RGBA, Gray
+    # if bgr2rgb:
+    #     img = img[
+    #         :, :, [2, 1, 0]
+    #     ]  # BGR to RGB -> in numpy, if using OpenCV, else not needed. Only if image has colors.
+    if change_range:
+        dtype = img.dtype
+        maxval = MAX_VALUES_BY_DTYPE.get(dtype, 1.0)
+        t_dtype = np.dtype("float32")
+        img = img.astype(t_dtype) / maxval  # ie: uint8 = /255
+    # "HWC to CHW" and "numpy to tensor"
+    img = np.ascontiguousarray(np.transpose(img, (2, 0, 1))).astype(np.float32)
+    if bgr2rgb:
+        # BGR to RGB -> in tensor, if using OpenCV, else not needed. Only if image has colors.)
+        if (
+            img.shape[0] % 3 == 0
+        ):  # RGB or MultixRGB (3xRGB, 5xRGB, etc. For video tensors.)
+            img = np_bgr_to_rgb(img)  # type: ignore
+        elif img.shape[0] == 4:  # RGBA
+            img = np_bgra_to_rgba(img)  # type: ignore
+    if add_batch:
+        img = np.expand_dims(
+            img, axis=0
+        )  # Add fake batch dimension = 1 . squeeze() will remove the dimensions of size 1
+    if normalize:
+        img = norm(img)
+    return img  # type: ignore
+
+
+def nptensor2np(
+    img: np.ndarray,
+    rgb2bgr=True,
+    remove_batch=True,
+    data_range=255,
+    denormalize=False,
+    change_range=True,
+    imtype: Type = np.uint8,
+) -> np.ndarray:
+    """Converts a Tensor array into a numpy image array.
+    Parameters:
+        img (tensor): the input image tensor array
+            4D(B,(3/1),H,W), 3D(C,H,W), or 2D(H,W), any range, RGB channel order
+        remove_batch (bool): choose if tensor of shape BCHW needs to be squeezed
+        denormalize (bool): Used to denormalize from [-1,1] range back to [0,1]
+        imtype (type): the desired type of the converted numpy array (np.uint8
+            default)
+    Output:
+        img (np array): 3D(H,W,C) or 2D(H,W), [0,255], np.uint8 (default)
+    """
+    n_dim = img.ndim
+
+    img = img.astype(np.float32)
+
+    if n_dim in (4, 3):
+        # if n_dim == 4, has to convert to 3 dimensions
+        if n_dim == 4 and remove_batch:
+            # remove a fake batch dimension
+            img = img.squeeze(0)
+
+        if img.shape[0] == 3 and rgb2bgr:  # RGB
+            # RGB to BGR -> in tensor, if using OpenCV, else not needed. Only if image has colors.
+            img_np = np_rgb_to_bgr(img)
+        elif img.shape[0] == 4 and rgb2bgr:  # RGBA
+            # RGBA to BGRA -> in tensor, if using OpenCV, else not needed. Only if image has colors.
+            img_np = np_rgba_to_bgra(img)
+        else:
+            img_np = img
+        img_np = np.transpose(img_np, (1, 2, 0))  # CHW to HWC
+    elif n_dim == 2:
+        img_np = img
+    else:
+        raise TypeError(
+            f"Only support 4D, 3D and 2D tensor. But received with dimension: {n_dim:d}"
+        )
+
+    # if rgb2bgr:
+    # img_np = img_np[[2, 1, 0], :, :] #RGB to BGR -> in numpy, if using OpenCV, else not needed. Only if image has colors.
+    # TODO: Check: could denormalize in the begining in tensor form instead
+    if denormalize:
+        img_np = denorm(img_np)  # denormalize if needed
+    if change_range:
+        img_np = np.clip(
+            data_range * img_np, 0, data_range
+        ).round()  # np.clip to the data_range
+
+    # has to be in range (0,255) before changing to np.uint8, else np.float32
+    return img_np.astype(imtype)

--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -1,12 +1,15 @@
 import asyncio
 import functools
 import gc
+import logging
 import os
 import platform
 import sys
 import traceback
 from json import dumps as stringify
 
+# pylint: disable=unused-import
+import cv2
 from sanic import Sanic
 from sanic.log import logger
 from sanic.request import Request
@@ -15,47 +18,52 @@ from sanic_cors import CORS
 
 from nodes.categories import category_order
 
-# pylint: disable=unused-import
-import cv2
-
 # Remove broken QT env var
 if platform.system() == "Linux":
     os.environ.pop("QT_QPA_PLATFORM_PLUGIN_PATH")
 
 # pylint: disable=ungrouped-imports,wrong-import-position
-from nodes import (
-    image_adj_nodes,
-    image_chan_nodes,
-    image_dim_nodes,
-    image_filter_nodes,
-    image_iterator_nodes,
-    image_nodes,
-    image_util_nodes,
-)
+from nodes import image_adj_nodes  # type: ignore
+from nodes import image_chan_nodes  # type: ignore
+from nodes import image_dim_nodes  # type: ignore
+from nodes import image_filter_nodes  # type: ignore
+from nodes import image_iterator_nodes  # type: ignore
+from nodes import image_nodes  # type: ignore
+from nodes import image_util_nodes  # type: ignore
 
 try:
     import torch
 
     # pylint: disable=unused-import,ungrouped-imports
-    from nodes import pytorch_nodes
+    from nodes import pytorch_nodes  # type: ignore
 except Exception as e:
     torch = None
     logger.warning(e)
     logger.info("PyTorch most likely not installed")
 
 try:
+    import onnx
+    import onnxruntime
+
+    # pylint: disable=unused-import,ungrouped-imports
+    from nodes import onnx_nodes  # type: ignore
+except Exception as e:
+    logger.warning(e)
+    logger.info("ONNX most likely not installed")
+
+
+try:
     # pylint: disable=unused-import
     import ncnn_vulkan
 
     # pylint: disable=unused-import,ungrouped-imports
-    from nodes import ncnn_nodes
+    from nodes import ncnn_nodes  # type: ignore
 except Exception as e:
     logger.warning(e)
     logger.info("NCNN most likely not installed")
 
 # pylint: disable=unused-import
-from nodes import utility_nodes
-
+from nodes import utility_nodes  # type: ignore
 from nodes.node_factory import NodeFactory
 from process import Executor
 
@@ -67,7 +75,6 @@ app.ctx.cache = dict()
 app.config.REQUEST_TIMEOUT = sys.maxsize
 app.config.RESPONSE_TIMEOUT = sys.maxsize
 
-import logging
 
 from sanic.log import access_logger
 

--- a/backend/tests/test_categories.py
+++ b/backend/tests/test_categories.py
@@ -3,4 +3,4 @@ from ..src.nodes.categories import category_order
 
 def test_categories():
     assert isinstance(category_order, list)
-    assert len(category_order) == 9
+    assert len(category_order) == 10

--- a/src/common/dependencies.ts
+++ b/src/common/dependencies.ts
@@ -1,52 +1,70 @@
 import { isMac } from './env';
 
-export interface Dependency {
-    name: string;
+export interface PyPiPackage {
     packageName: string;
     version: string;
     findLink?: string;
+}
+export interface Dependency {
+    name: string;
+    packages: PyPiPackage[];
 }
 
 export const getOptionalDependencies = (isNvidiaAvailable: boolean): Dependency[] => [
     {
         name: 'PyTorch',
-        packageName: 'torch',
-        version: `1.10.2+${isNvidiaAvailable && !isMac ? 'cu113' : 'cpu'}`,
-        findLink: `https://download.pytorch.org/whl/${
-            isNvidiaAvailable && !isMac ? 'cu113' : 'cpu'
-        }/torch_stable.html`,
+        packages: [
+            {
+                packageName: 'torch',
+                version: `1.10.2+${isNvidiaAvailable && !isMac ? 'cu113' : 'cpu'}`,
+                findLink: `https://download.pytorch.org/whl/${
+                    isNvidiaAvailable && !isMac ? 'cu113' : 'cpu'
+                }/torch_stable.html`,
+            },
+        ],
     },
     {
         name: 'NCNN',
-        packageName: 'ncnn-vulkan',
-        version: '2022.4.1',
+        packages: [{ packageName: 'ncnn-vulkan', version: '2022.4.1' }],
+    },
+    {
+        name: 'ONNX',
+        packages: [
+            {
+                packageName: 'onnx',
+                version: '1.11.0',
+            },
+            {
+                packageName: isNvidiaAvailable ? 'onnxruntime-gpu' : 'onnxruntime',
+                version: '1.11.1',
+            },
+            {
+                packageName: 'protobuf',
+                version: '3.16.0',
+            },
+        ],
     },
 ];
 
 export const requiredDependencies: Dependency[] = [
     {
         name: 'Sanic',
-        packageName: 'sanic',
-        version: '21.9.3',
+        packages: [{ packageName: 'sanic', version: '21.9.3' }],
     },
     {
         name: 'Sanic Cors',
-        packageName: 'Sanic-Cors',
-        version: '1.0.1',
+        packages: [{ packageName: 'Sanic-Cors', version: '1.0.1' }],
     },
     {
         name: 'OpenCV',
-        packageName: 'opencv-python',
-        version: '4.5.5.64',
+        packages: [{ packageName: 'opencv-python', version: '4.5.5.64' }],
     },
     {
         name: 'NumPy',
-        packageName: 'numpy',
-        version: '1.22.3',
+        packages: [{ packageName: 'numpy', version: '1.22.3' }],
     },
     {
         name: 'Pillow (PIL)',
-        packageName: 'Pillow',
-        version: '9.1.0',
+        packages: [{ packageName: 'Pillow', version: '9.1.0' }],
     },
 ];

--- a/src/common/pip.ts
+++ b/src/common/pip.ts
@@ -24,6 +24,7 @@ export const runPip = async (args: readonly string[], onStdio: OnStdio = {}): Pr
         log.info(`Running pip command: ${args.slice(1).join(' ')}`);
 
         const child = spawn(python, args);
+
         let stdout = '';
 
         child.stdout.on('data', (data) => {

--- a/src/common/pipInstallWithProgress.ts
+++ b/src/common/pipInstallWithProgress.ts
@@ -1,0 +1,192 @@
+import { execSync, spawn } from 'child_process';
+import log from 'electron-log';
+import fs from 'fs';
+import https from 'https';
+import Downloader from 'nodejs-file-downloader';
+import os from 'os';
+import path from 'path';
+import { URL } from 'url';
+import { PyPiPackage } from './dependencies';
+import { noop } from './util';
+
+export interface OnStdio {
+    onStdout?: (data: string) => void;
+    onStderr?: (data: string) => void;
+}
+
+const tempDir = os.tmpdir();
+
+const isValidUrl = (s: string): boolean => {
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const url = new URL(s);
+        return true;
+    } catch (_) {
+        return false;
+    }
+};
+
+const downloadWheelAndInstall = async (
+    pythonPath: string,
+    url: string,
+    fileName: string,
+    onProgress?: (percent: number) => void,
+    onStdio: OnStdio = {}
+) =>
+    new Promise<void>((resolve, reject) => {
+        const { onStdout = noop, onStderr = (data) => log.error(data) } = onStdio;
+        let lastProgressNum: number | null = null;
+        const downloader = new Downloader({
+            url,
+            directory: tempDir,
+            fileName,
+            onProgress: (percentage) => {
+                const progressNum = Math.floor(Number(percentage));
+                if (progressNum % 5 === 0 && lastProgressNum !== progressNum) {
+                    onStdout(`Download at: ${progressNum}%\n`);
+                    lastProgressNum = progressNum;
+                }
+                onProgress?.(Number(percentage) * 0.9 + 1);
+            },
+        });
+
+        try {
+            downloader.download().then(() => {
+                onProgress?.(98);
+                onStdout('Installing package from whl...\n');
+                const installProcess = spawn(pythonPath, [
+                    '-m',
+                    'pip',
+                    'install',
+                    path.join(tempDir, fileName),
+                ]);
+                installProcess.stdout.on('data', (data) => {
+                    onStdout(String(data));
+                });
+                installProcess.on('close', () => {
+                    onProgress?.(99);
+                    fs.rmSync(path.join(tempDir, fileName));
+                    // onOutput('Temp files removed.\n');
+                    onProgress?.(100);
+                    resolve();
+                });
+            }, reject);
+        } catch (error) {
+            log.error(error);
+            reject(error);
+        }
+    });
+
+const pipInstallWithProgress = async (
+    python: string,
+    pkg: PyPiPackage,
+    onProgress?: (percentage: number) => void,
+    onStdio: OnStdio = {}
+) =>
+    new Promise<Buffer | void>((resolve, reject) => {
+        const { onStdout = noop, onStderr = (data) => log.error(data) } = onStdio;
+        log.info('Beginning pip install...');
+        onProgress?.(0);
+        let args = [
+            'install',
+            '--upgrade',
+            `${pkg.packageName}==${pkg.version}`,
+            '--disable-pip-version-check',
+        ];
+        if (pkg.findLink) {
+            args = [...args, '-f', pkg.findLink];
+        }
+        const pipRequest = spawn(python, ['-m', 'pip', ...args]);
+
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        pipRequest.stdout.on('data', async (data) => {
+            const stringData = String(data);
+            onStdout(stringData);
+            const wheelRegex = /([^\s\\]*)[.]whl/g;
+            const matches = stringData.match(wheelRegex);
+            if (matches) {
+                const [wheelFileName] = matches;
+                pipRequest.kill();
+                onProgress?.(1);
+                log.info(`Found whl: ${wheelFileName}`);
+
+                if (isValidUrl(wheelFileName)) {
+                    const wheelName = wheelFileName.split('/').slice(-1)[0];
+                    await downloadWheelAndInstall(
+                        python,
+                        wheelFileName,
+                        wheelName,
+                        onProgress,
+                        onStdio
+                    ).then(() => {
+                        resolve();
+                    });
+                } else {
+                    const req = https.get(
+                        `https://pypi.org/pypi/${pkg.packageName}/json`,
+                        (res) => {
+                            let output = '';
+
+                            res.on('data', (d) => {
+                                output += String(d);
+                            });
+
+                            res.on('close', () => {
+                                if (output) {
+                                    const releaseData = JSON.parse(output) as {
+                                        releases: Record<
+                                            string,
+                                            { filename: string; url: string }[]
+                                        >;
+                                    };
+                                    const releases = Array.from(releaseData.releases[pkg.version]);
+                                    const find = releases.find(
+                                        (file) => file.filename === wheelFileName
+                                    );
+                                    if (!find)
+                                        throw new Error(
+                                            `Unable for find correct file for ${pkg.packageName}==${pkg.version}`
+                                        );
+                                    const { url } = find;
+                                    onStdout(`Downloading package from PyPi at: ${url}\n`);
+                                    downloadWheelAndInstall(
+                                        python,
+                                        url,
+                                        wheelFileName,
+                                        onProgress,
+                                        onStdio
+                                    ).then(() => resolve(), reject);
+                                }
+                            });
+                        }
+                    );
+
+                    req.on('error', (error) => {
+                        onStderr(String(error));
+                        log.error('Error installing normal way, resorting to generic pip install.');
+                        const result = execSync(`${python} -m pip ${args.join(' ')}`);
+                        resolve(result);
+                    });
+
+                    req.end();
+                }
+            }
+        });
+
+        pipRequest.stderr.on('data', () => {
+            // log.debug(String(data));
+        });
+
+        pipRequest.on('error', (error) => {
+            onStderr(String(error));
+            reject(error);
+        });
+
+        pipRequest.on('close', (code) => {
+            if (code === 0) {
+                resolve();
+            }
+        });
+    });
+
+export default pipInstallWithProgress;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -328,14 +328,16 @@ const checkPythonDeps = async (splashWindow: BrowserWindowWithSafeIpc) => {
         const installedPackages = new Set(Object.keys(pipList));
 
         const pending = requiredDependencies.filter((dep) => {
-            if (installedPackages.has(dep.packageName)) return false;
-            log.info(`Dependency ${dep.name} (${dep.packageName}) not found.`);
-            return true;
+            return dep.packages.some((pkg) => {
+                if (installedPackages.has(pkg.packageName)) return false;
+                log.info(`Dependency ${dep.name} (${pkg.packageName}) not found.`);
+                return true;
+            });
         });
         if (pending.length > 0) {
             log.info(`Installing ${pending.length} missing dependencies...`);
             splashWindow.webContents.send('installing-deps');
-            await runPipInstall(pending);
+            await runPipInstall(pending, undefined, undefined, true);
         }
     } catch (error) {
         log.error(error);

--- a/src/renderer/components/node/NodeInputs.tsx
+++ b/src/renderer/components/node/NodeInputs.tsx
@@ -25,22 +25,15 @@ const pickInput = (type: string, props: FullInputProps) => {
     let InputType: React.MemoExoticComponent<(props: any) => JSX.Element> = GenericInput;
     switch (type) {
         case 'file::image':
-            InputType = FileInput;
-            break;
         case 'file::pth':
-            InputType = FileInput;
-            break;
         case 'file::video':
+        case 'file::bin':
+        case 'file::param':
+        case 'file::onnx':
             InputType = FileInput;
             break;
         case 'file::directory':
             InputType = DirectoryInput;
-            break;
-        case 'file::bin':
-            InputType = FileInput;
-            break;
-        case 'file::param':
-            InputType = FileInput;
             break;
         case 'text::any':
             InputType = TextInput;
@@ -49,14 +42,8 @@ const pickInput = (type: string, props: FullInputProps) => {
             InputType = TextAreaInput;
             break;
         case 'dropdown::str':
-            InputType = DropDownInput;
-            break;
         case 'dropdown::image-extensions':
-            InputType = DropDownInput;
-            break;
         case 'dropdown::math-operations':
-            InputType = DropDownInput;
-            break;
         case 'dropdown::generic':
             InputType = DropDownInput;
             break;

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -385,6 +385,7 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                                                         >
                                                             <Progress
                                                                 hasStripe
+                                                                isAnimated
                                                                 value={progress}
                                                                 w="full"
                                                             />

--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -178,7 +178,7 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
 
     const uninstallPackage = (dep: Dependency) => {
         setUninstallingPackage(dep);
-        changePackages(() => runPipUninstall([dep.packageName], onStdio));
+        changePackages(() => runPipUninstall([dep], setProgress, onStdio));
     };
 
     useEffect(() => {
@@ -188,15 +188,18 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
     }, [shellOutput]);
 
     const availableUpdates = useMemo(() => {
-        return availableDeps.filter(({ packageName, version }) => {
-            if (!pipList) {
-                return false;
-            }
-            if (!pipList[packageName]) {
-                return true;
-            }
-            return !checkSemver(version, pipList[packageName]);
-        }).length;
+        return availableDeps.filter(
+            ({ packages }) =>
+                packages.filter(({ packageName, version }) => {
+                    if (!pipList) {
+                        return false;
+                    }
+                    if (!pipList[packageName]) {
+                        return true;
+                    }
+                    return !checkSemver(version, pipList[packageName]);
+                }).length
+        ).length;
     }, [pipList, availableDeps]);
 
     // eslint-disable-next-line react/jsx-no-constructed-context-values
@@ -262,114 +265,134 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                                 {!pipList ? (
                                     <Spinner />
                                 ) : (
-                                    availableDeps.map((dep) => (
-                                        <VStack
-                                            key={dep.name}
-                                            w="full"
-                                        >
-                                            <Flex
-                                                align="center"
+                                    availableDeps.map((dep) => {
+                                        const allDepPackagesInstalled = dep.packages.every(
+                                            (p) => pipList[p.packageName]
+                                        );
+                                        const allDepPackageVersionsString = dep.packages
+                                            .map((p) => pipList[p.packageName])
+                                            .join('/');
+                                        return (
+                                            <VStack
                                                 key={dep.name}
                                                 w="full"
                                             >
-                                                {/* <Text>{`Installed version: ${dep.version ?? 'None'}`}</Text> */}
-                                                <Text
-                                                    color={
-                                                        pipList[dep.packageName]
-                                                            ? 'inherit'
-                                                            : 'red.500'
-                                                    }
-                                                    flex="1"
-                                                    textAlign="left"
+                                                <Flex
+                                                    align="center"
+                                                    key={dep.name}
+                                                    w="full"
                                                 >
-                                                    {`${dep.name} (${
-                                                        pipList[dep.packageName]
-                                                            ? pipList[dep.packageName]
-                                                            : 'not installed'
-                                                    })`}
-                                                </Text>
-                                                {pipList[dep.packageName] ? (
-                                                    <HStack>
+                                                    {/* <Text>{`Installed version: ${dep.version ?? 'None'}`}</Text> */}
+                                                    <Text
+                                                        color={
+                                                            allDepPackagesInstalled
+                                                                ? 'inherit'
+                                                                : 'red.500'
+                                                        }
+                                                        flex="1"
+                                                        textAlign="left"
+                                                    >
+                                                        {`${dep.name} (${
+                                                            allDepPackagesInstalled
+                                                                ? allDepPackageVersionsString
+                                                                : 'not installed'
+                                                        })`}
+                                                    </Text>
+                                                    {dep.packages.length ===
+                                                    dep.packages.filter(
+                                                        (p) => pipList[p.packageName]
+                                                    ).length ? (
+                                                        <HStack>
+                                                            <Button
+                                                                colorScheme="blue"
+                                                                disabled={
+                                                                    dep.packages.some((p) =>
+                                                                        checkSemver(
+                                                                            p.version,
+                                                                            pipList[p.packageName]
+                                                                        )
+                                                                    ) || isRunningShell
+                                                                }
+                                                                isLoading={isRunningShell}
+                                                                leftIcon={<DownloadIcon />}
+                                                                size="sm"
+                                                                onClick={() => installPackage(dep)}
+                                                            >
+                                                                {`Update${
+                                                                    dep.packages.some(
+                                                                        (p) =>
+                                                                            !checkSemver(
+                                                                                p.version,
+                                                                                pipList[
+                                                                                    p.packageName
+                                                                                ]
+                                                                            )
+                                                                    )
+                                                                        ? ` (${allDepPackageVersionsString})`
+                                                                        : ''
+                                                                }`}
+                                                            </Button>
+                                                            <Button
+                                                                colorScheme="red"
+                                                                disabled={isRunningShell}
+                                                                leftIcon={<DeleteIcon />}
+                                                                size="sm"
+                                                                onClick={() => {
+                                                                    showAlert({
+                                                                        type: AlertType.WARN,
+                                                                        title: 'Uninstall',
+                                                                        message: `Are you sure you want to uninstall ${dep.name}?`,
+                                                                        buttons: [
+                                                                            'Cancel',
+                                                                            'Uninstall',
+                                                                        ],
+                                                                        defaultButton: 0,
+                                                                    })
+                                                                        .then((button) => {
+                                                                            if (button === 1) {
+                                                                                uninstallPackage(
+                                                                                    dep
+                                                                                );
+                                                                            }
+                                                                        })
+                                                                        .catch((error) =>
+                                                                            log.error(error)
+                                                                        );
+                                                                }}
+                                                            >
+                                                                Uninstall
+                                                            </Button>
+                                                        </HStack>
+                                                    ) : (
                                                         <Button
                                                             colorScheme="blue"
-                                                            disabled={
-                                                                checkSemver(
-                                                                    dep.version,
-                                                                    pipList[dep.packageName]
-                                                                ) || isRunningShell
-                                                            }
+                                                            disabled={isRunningShell}
                                                             isLoading={isRunningShell}
                                                             leftIcon={<DownloadIcon />}
                                                             size="sm"
                                                             onClick={() => installPackage(dep)}
                                                         >
-                                                            {`Update${
-                                                                !checkSemver(
-                                                                    dep.version,
-                                                                    pipList[dep.packageName]
-                                                                )
-                                                                    ? ` (${dep.version})`
-                                                                    : ''
-                                                            }`}
+                                                            Install
                                                         </Button>
-                                                        <Button
-                                                            colorScheme="red"
-                                                            disabled={isRunningShell}
-                                                            leftIcon={<DeleteIcon />}
-                                                            size="sm"
-                                                            onClick={() => {
-                                                                showAlert({
-                                                                    type: AlertType.WARN,
-                                                                    title: 'Uninstall',
-                                                                    message: `Are you sure you want to uninstall ${dep.name}?`,
-                                                                    buttons: [
-                                                                        'Cancel',
-                                                                        'Uninstall',
-                                                                    ],
-                                                                    defaultButton: 0,
-                                                                })
-                                                                    .then((button) => {
-                                                                        if (button === 1) {
-                                                                            uninstallPackage(dep);
-                                                                        }
-                                                                    })
-                                                                    .catch((error) =>
-                                                                        log.error(error)
-                                                                    );
-                                                            }}
-                                                        >
-                                                            Uninstall
-                                                        </Button>
-                                                    </HStack>
-                                                ) : (
-                                                    <Button
-                                                        colorScheme="blue"
-                                                        disabled={isRunningShell}
-                                                        isLoading={isRunningShell}
-                                                        leftIcon={<DownloadIcon />}
-                                                        size="sm"
-                                                        onClick={() => installPackage(dep)}
-                                                    >
-                                                        Install
-                                                    </Button>
-                                                )}
-                                            </Flex>
-                                            {isRunningShell &&
-                                                (installingPackage || uninstallingPackage)?.name ===
-                                                    dep.name && (
-                                                    <Center
-                                                        h={8}
-                                                        w="full"
-                                                    >
-                                                        <Progress
-                                                            hasStripe
-                                                            value={progress}
+                                                    )}
+                                                </Flex>
+                                                {isRunningShell &&
+                                                    (installingPackage || uninstallingPackage)
+                                                        ?.name === dep.name && (
+                                                        <Center
+                                                            h={8}
                                                             w="full"
-                                                        />
-                                                    </Center>
-                                                )}
-                                        </VStack>
-                                    ))
+                                                        >
+                                                            <Progress
+                                                                hasStripe
+                                                                value={progress}
+                                                                w="full"
+                                                            />
+                                                        </Center>
+                                                    )}
+                                            </VStack>
+                                        );
+                                    })
                                 )}
                             </VStack>
                             <Accordion

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -271,8 +271,8 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
                     unAnimateEdges();
                     setStatus(ExecutionStatus.READY);
                 }
-            } catch (err) {
-                sendAlert(AlertType.ERROR, null, 'An unexpected error occurred.');
+            } catch (err: unknown) {
+                sendAlert(AlertType.ERROR, null, `An unexpected error occurred: ${String(err)}`);
                 unAnimateEdges();
                 setStatus(ExecutionStatus.READY);
             }

--- a/src/renderer/helpers/getNodeAccentColors.ts
+++ b/src/renderer/helpers/getNodeAccentColors.ts
@@ -18,6 +18,8 @@ export default (category: string | undefined): string => {
             return '#2B6CB0';
         case 'PyTorch':
             return '#DD6B20';
+        case 'ONNX':
+            return '#63B3ED';
         case 'NCNN':
             return '#ED64A6';
         default:


### PR DESCRIPTION
- Implements ONNX runtime inference
- Allows converted PyTorch models to be chained into the ONNX load model
- Re-implements pipInstallWithProgress as this feature was removed and is useful (can be replaced in the future if a different solution is found)
- Implements the ability for dependencies to have multiple packages associated with them. For ONNX, this includes `onnx`, `onnxruntime-gpu`, and `protobuf`