### PR TITLE
Fix nodeSelectorPanel width when collapsed

### DIFF
--- a/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
+++ b/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
@@ -140,7 +140,7 @@ const NodeSelector = memo(({ schemata, height }: NodeSelectorProps) => {
                 overflowX="hidden"
             >
                 <motion.div
-                    animate={{ width: collapsed ? '74px' : '300px' }}
+                    animate={{ width: collapsed ? '76px' : '300px' }}
                     initial={false}
                     transition={{ ease: 'easeInOut', duration: 0.25 }}
                 >


### PR DESCRIPTION
changing the scrollbar size made the nodes a bit smaller, so this fixes that