### PR TITLE
Option for displaying trailing zeros

### DIFF
--- a/backend/src/nodes/image_adj_nodes.py
+++ b/backend/src/nodes/image_adj_nodes.py
@@ -24,7 +24,12 @@ class HueAndSaturationNode(NodeBase):
         self.inputs = [
             ImageInput(),
             SliderInput(
-                "Hue", minimum=-180, maximum=180, default=0, step=0.1, controls_step=1
+                "Hue",
+                minimum=-180,
+                maximum=180,
+                default=0,
+                step=0.1,
+                controls_step=1,
             ),
             SliderInput(
                 "Saturation",
@@ -164,10 +169,18 @@ class ThresholdNode(NodeBase):
         self.inputs = [
             ImageInput(),
             SliderInput(
-                "Threshold", maximum=100, default=50, step=0.1, controls_step=1
+                "Threshold",
+                maximum=100,
+                default=50,
+                step=0.1,
+                controls_step=1,
             ),
             SliderInput(
-                "Maximum Value", maximum=100, default=100, step=0.1, controls_step=1
+                "Maximum Value",
+                maximum=100,
+                default=100,
+                step=0.1,
+                controls_step=1,
             ),
             ThresholdInput(),
         ]
@@ -205,7 +218,11 @@ class AdaptiveThresholdNode(NodeBase):
         self.inputs = [
             ImageInput(),
             SliderInput(
-                "Maximum Value", maximum=100, default=100, step=0.1, controls_step=1
+                "Maximum Value",
+                maximum=100,
+                default=100,
+                step=0.1,
+                controls_step=1,
             ),
             AdaptiveMethodInput(),
             AdaptiveThresholdInput(),

--- a/backend/src/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/src/nodes/properties/inputs/numeric_inputs.py
@@ -42,6 +42,7 @@ class NumberInput(BaseInput):
         unit: Union[str, None] = None,
         number_type: str = "any",
         note_expression: Union[str, None] = None,
+        hide_trailing_zeros: bool = True,
     ):
         super().__init__(f"number::{number_type}", label, has_handle=True)
         # Step is for the actual increment.
@@ -54,6 +55,7 @@ class NumberInput(BaseInput):
         self.maximum = maximum
         self.unit = unit
         self.note_expression = note_expression
+        self.hide_trailing_zeros = hide_trailing_zeros
 
     def toDict(self):
         return {
@@ -66,6 +68,7 @@ class NumberInput(BaseInput):
             "step": self.step,
             "controlsStep": self.controls_step,
             "unit": self.unit,
+            "hideTrailingZeros": self.hide_trailing_zeros,
         }
 
     def make_optional(self):
@@ -90,6 +93,7 @@ class SliderInput(NumberInput):
         unit: Union[str, None] = None,
         note_expression: Union[str, None] = None,
         ends: Tuple[Union[str, None], Union[str, None]] = (None, None),
+        hide_trailing_zeros: bool = False,
     ):
         super().__init__(
             label,
@@ -101,6 +105,7 @@ class SliderInput(NumberInput):
             unit=unit,
             note_expression=note_expression,
             number_type="slider",
+            hide_trailing_zeros=hide_trailing_zeros,
         )
         self.ends = ends
         self.slider_step = (

--- a/src/renderer/components/inputs/NumberInput.tsx
+++ b/src/renderer/components/inputs/NumberInput.tsx
@@ -39,11 +39,15 @@ const NumericalInput = memo(
 
         // TODO: make sure this is always a number
         const [input, setInput] = useInputData<number>(inputId);
-        const [inputString, setInputString] = useState(String(input));
+        const [inputString, setInputString] = useState(String(input ?? def));
 
         useEffect(() => {
             const asNumber = parseFloat(inputString);
-            if (!Number.isNaN(asNumber) && !areApproximatelyEqual(asNumber, input!)) {
+            if (
+                !Number.isNaN(asNumber) &&
+                input !== undefined &&
+                !areApproximatelyEqual(asNumber, input)
+            ) {
                 setInputString(String(input));
             }
         }, [input]);

--- a/src/renderer/components/inputs/NumberInput.tsx
+++ b/src/renderer/components/inputs/NumberInput.tsx
@@ -14,6 +14,7 @@ interface NumericalInputProps extends InputProps {
     max?: number | null;
     def: number;
     unit?: string | null;
+    hideTrailingZeros: boolean;
 }
 
 const NumericalInput = memo(
@@ -28,6 +29,7 @@ const NumericalInput = memo(
         step,
         controlsStep,
         unit,
+        hideTrailingZeros,
         isLocked,
     }: NumericalInputProps) => {
         const isInputLocked = useContextSelector(GlobalVolatileContext, (c) => c.isNodeInputLocked)(
@@ -51,6 +53,7 @@ const NumericalInput = memo(
                 <AdvancedNumberInput
                     controlsStep={controlsStep}
                     defaultValue={def}
+                    hideTrailingZeros={hideTrailingZeros}
                     inputString={inputString}
                     isDisabled={isLocked || isInputLocked}
                     max={max ?? Infinity}

--- a/src/renderer/components/inputs/SliderInput.tsx
+++ b/src/renderer/components/inputs/SliderInput.tsx
@@ -9,7 +9,7 @@ import {
     VStack,
 } from '@chakra-ui/react';
 import { memo, useEffect, useState } from 'react';
-import { AdvancedNumberInput } from './elements/AdvanceNumberInput';
+import { AdvancedNumberInput, getPrecision } from './elements/AdvanceNumberInput';
 import { InputProps } from './props';
 
 interface SliderInputProps extends InputProps {
@@ -24,6 +24,7 @@ interface SliderInputProps extends InputProps {
     accentColor: string;
     ends: [string | null, string | null];
     noteExpression?: string;
+    hideTrailingZeros: boolean;
 }
 
 const tryEvaluate = (expression: string, args: Record<string, unknown>): string | undefined => {
@@ -52,6 +53,7 @@ const SliderInput = memo(
         ends,
         noteExpression,
         accentColor,
+        hideTrailingZeros,
         isLocked,
     }: SliderInputProps) => {
         const [input, setInput] = useInputData<number>(inputId);
@@ -59,15 +61,19 @@ const SliderInput = memo(
         const [sliderValue, setSliderValue] = useState(input ?? def);
         const [showTooltip, setShowTooltip] = useState(false);
 
+        const precision = Math.max(getPrecision(offset), getPrecision(step));
+        const precisionOutput = (val: number) =>
+            hideTrailingZeros ? String(val) : val.toFixed(precision);
+
         useEffect(() => {
             setSliderValue(input ?? def);
             if (!Number.isNaN(input)) {
-                setInputString(String(input));
+                setInputString(input === undefined ? String(input) : precisionOutput(input));
             }
         }, [input]);
 
         const onSliderChange = (sliderInput: number) => {
-            setInputString(String(sliderInput));
+            setInputString(precisionOutput(sliderInput));
             setSliderValue(sliderInput);
         };
 
@@ -111,7 +117,7 @@ const SliderInput = memo(
                             borderRadius={8}
                             color="white"
                             isOpen={showTooltip}
-                            label={`${sliderValue}${unit ?? ''}`}
+                            label={`${precisionOutput(sliderValue)}${unit ?? ''}`}
                             placement="top"
                             px={2}
                             py={1}
@@ -124,6 +130,7 @@ const SliderInput = memo(
                         small
                         controlsStep={controlsStep}
                         defaultValue={def}
+                        hideTrailingZeros={hideTrailingZeros}
                         inputString={inputString}
                         isDisabled={isLocked}
                         max={max}

--- a/src/renderer/components/inputs/SliderInput.tsx
+++ b/src/renderer/components/inputs/SliderInput.tsx
@@ -68,7 +68,7 @@ const SliderInput = memo(
         useEffect(() => {
             setSliderValue(input ?? def);
             if (!Number.isNaN(input)) {
-                setInputString(input === undefined ? String(input) : precisionOutput(input));
+                setInputString(precisionOutput(input ?? def));
             }
         }, [input]);
 

--- a/src/renderer/components/inputs/elements/AdvanceNumberInput.tsx
+++ b/src/renderer/components/inputs/elements/AdvanceNumberInput.tsx
@@ -16,7 +16,7 @@ const clamp = (value: number, min?: number | null, max?: number | null): number 
     return value;
 };
 
-const getPrecision = (n: number) => {
+export const getPrecision = (n: number) => {
     // eslint-disable-next-line no-param-reassign
     n %= 1;
     if (areApproximatelyEqual(n, 0)) return 0;
@@ -30,6 +30,7 @@ interface AdvancedNumberInputProps {
     offset: number;
     step: number;
     controlsStep: number;
+    hideTrailingZeros: boolean;
 
     defaultValue: number;
     isDisabled?: boolean;
@@ -48,6 +49,7 @@ export const AdvancedNumberInput = memo(
         offset,
         step,
         controlsStep,
+        hideTrailingZeros,
 
         defaultValue,
         isDisabled,
@@ -72,7 +74,7 @@ export const AdvancedNumberInput = memo(
                 // Make sure the input value has been altered so onChange gets correct value if adjustment needed
                 setImmediate(() => {
                     setInput(value);
-                    setInputString(String(value));
+                    setInputString(hideTrailingZeros ? String(value) : value.toFixed(precision));
                 });
             }
         };


### PR DESCRIPTION
Always displaying full precision on sliders is standard behavior in image editors, and let's users know that decimals are allowed (especially since our sliders increment by 1). Currently, number displays always remove trailing zeros. This PR makes showing/hiding trailing zeros an option for Number/SliderInput with the former defaulting to hide and the latter to true.