### PR TITLE
More reliable dark mode setting

### DIFF
--- a/src/renderer/contexts/SettingsContext.tsx
+++ b/src/renderer/contexts/SettingsContext.tsx
@@ -15,6 +15,7 @@ interface Settings {
         setSnapToGridAmount: React.Dispatch<React.SetStateAction<number>>
     ];
     useStartupTemplate: readonly [string, React.Dispatch<React.SetStateAction<string>>];
+    useIsDarkMode: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
 
     // Node Settings
     useNodeFavorites: readonly [
@@ -39,6 +40,7 @@ export const SettingsProvider = memo(
         const [snapToGridAmount, setSnapToGridAmount] = useLocalStorage('snap-to-grid-amount', 15);
         const [isDisHwAccel, setIsDisHwAccel] = useLocalStorage('disable-hw-accel', false);
         const [startupTemplate, setStartupTemplate] = useLocalStorage('startup-template', '');
+        const [isDarkMode, setIsDarkMode] = useLocalStorage('use-dark-mode', true);
 
         const useIsCpu = useMemo(() => [isCpu, setIsCpu] as const, [isCpu, setIsCpu]);
         const useIsFp16 = useMemo(() => [isFp16, setIsFp16] as const, [isFp16, setIsFp16]);
@@ -64,6 +66,10 @@ export const SettingsProvider = memo(
             () => [startupTemplate, setStartupTemplate] as const,
             [startupTemplate, setStartupTemplate]
         );
+        const useIsDarkMode = useMemo(
+            () => [isDarkMode, setIsDarkMode] as const,
+            [isDarkMode, setIsDarkMode]
+        );
 
         // Node Settings
         const [favorites, setFavorites] = useLocalStorage<readonly string[]>('node-favorites', []);
@@ -82,6 +88,7 @@ export const SettingsProvider = memo(
                 useSnapToGrid,
                 useDisHwAccel,
                 useStartupTemplate,
+                useIsDarkMode,
 
                 // Node
                 useNodeFavorites,
@@ -96,6 +103,7 @@ export const SettingsProvider = memo(
                 useSnapToGrid,
                 useDisHwAccel,
                 useStartupTemplate,
+                useIsDarkMode,
                 useNodeFavorites,
                 port,
             ]

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -6,7 +6,7 @@ import { Theme, extendTheme } from '@chakra-ui/react';
 // 2. Add your color mode config
 const config = {
     initialColorMode: 'dark',
-    // useSystemColorMode: true,
+    useSystemColorMode: false,
 } as const;
 
 const colors = {


### PR DESCRIPTION
Fixes two things:
- Removes the code that made it back in that was causing a settings problem for fp16 and cpu
- fixes dark mode by using our storage for the setting. This has a side effect of making the transition from dark to light more abrupt unfortunately, but it should function properly now instead of relying on however chakra stores it