### PR TITLE
Remove migration numer from test snapshots

### DIFF
--- a/tests/common/SaveFile.test.ts
+++ b/tests/common/SaveFile.test.ts
@@ -15,6 +15,7 @@ for (const file of fs.readdirSync(dataDir)) {
     test(`Write save file ${file}`, async () => {
         const json = SaveFile.stringify(await SaveFile.read(filePath), '');
         const obj = JSON.parse(json) as RawSaveFile;
+        delete obj.migration;
         obj.timestamp = '';
         expect(obj).toMatchSnapshot();
     });

--- a/tests/common/__snapshots__/SaveFile.test.ts.snap
+++ b/tests/common/__snapshots__/SaveFile.test.ts.snap
@@ -1803,7 +1803,6 @@ Object {
       "zoom": 1,
     },
   },
-  "migration": 11,
   "timestamp": "",
   "version": "",
 }
@@ -1873,7 +1872,6 @@ Object {
       "zoom": 1,
     },
   },
-  "migration": 11,
   "timestamp": "",
   "version": "",
 }
@@ -1976,7 +1974,6 @@ Object {
       "zoom": 1,
     },
   },
-  "migration": 11,
   "timestamp": "",
   "version": "",
 }
@@ -2138,7 +2135,6 @@ Object {
       "zoom": 1,
     },
   },
-  "migration": 11,
   "timestamp": "",
   "version": "",
 }
@@ -2280,7 +2276,6 @@ Object {
       "zoom": 1,
     },
   },
-  "migration": 11,
   "timestamp": "",
   "version": "",
 }
@@ -2513,7 +2508,6 @@ Object {
       "zoom": 1,
     },
   },
-  "migration": 11,
   "timestamp": "",
   "version": "",
 }
@@ -2632,7 +2626,6 @@ Object {
       "zoom": 1,
     },
   },
-  "migration": 11,
   "timestamp": "",
   "version": "",
 }
@@ -2763,7 +2756,6 @@ Object {
       "zoom": 1,
     },
   },
-  "migration": 11,
   "timestamp": "",
   "version": "",
 }
@@ -2799,7 +2791,6 @@ Object {
       "zoom": 1,
     },
   },
-  "migration": 11,
   "timestamp": "",
   "version": "",
 }
@@ -3156,7 +3147,6 @@ Object {
       "zoom": 1,
     },
   },
-  "migration": 11,
   "timestamp": "",
   "version": "",
 }
@@ -3292,7 +3282,6 @@ Object {
       "zoom": 1,
     },
   },
-  "migration": 11,
   "timestamp": "",
   "version": "",
 }
@@ -3330,7 +3319,6 @@ Object {
       "zoom": 1,
     },
   },
-  "migration": 11,
   "timestamp": "",
   "version": "",
 }
@@ -3520,7 +3508,6 @@ Object {
       "zoom": 1,
     },
   },
-  "migration": 11,
   "timestamp": "",
   "version": "",
 }
@@ -3602,7 +3589,6 @@ Object {
       "zoom": 1,
     },
   },
-  "migration": 11,
   "timestamp": "",
   "version": "",
 }


### PR DESCRIPTION
When adding a new migration, these numbers always change which just creates noise.