### PR TITLE
Allow previews to error

### DIFF
--- a/backend/src/nodes/image_nodes.py
+++ b/backend/src/nodes/image_nodes.py
@@ -44,9 +44,11 @@ class ImReadNode(NodeBase):
         self.name = "Load Image"
         self.icon = "BsFillImageFill"
         self.sub = "Input & Output"
-        self.result = []
+        self.result = None
 
     def get_extra_data(self) -> Dict:
+        assert self.result is not None
+
         img = self.result[0]
         h, w, c = get_h_w_c(img)
 

--- a/backend/src/nodes/pytorch_nodes.py
+++ b/backend/src/nodes/pytorch_nodes.py
@@ -89,6 +89,8 @@ class LoadModelNode(NodeBase):
         self.model = None  # Defined in run
 
     def get_extra_data(self) -> Dict:
+        assert self.model is not None
+
         # TODO: Figure out how to make types for this
         if "SRVGG" in self.model.model_type:  # type: ignore
             size = [f"{self.model.num_feat}nf", f"{self.model.num_conv}nc"]  # type: ignore

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -23,6 +23,16 @@ export interface BackendRunIndividualRequest {
     schemaId: string;
 }
 
+export type BackendResult<T> = BackendSuccess<T> | BackendError;
+export interface BackendSuccess<T> {
+    success: true;
+    data: T;
+}
+export interface BackendError {
+    success: false;
+    error: string;
+}
+
 /**
  * A wrapper to communicate with the backend.
  *
@@ -71,7 +81,7 @@ export class Backend {
     /**
      * Runs a single node
      */
-    runIndividual<T = JsonValue>(data: BackendRunIndividualRequest): Promise<T> {
+    runIndividual<T = JsonValue>(data: BackendRunIndividualRequest): Promise<BackendResult<T>> {
         return this.fetchJson('/run/individual', 'POST', data);
     }
 

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -72,7 +72,7 @@ type WithType<S, T extends string> = S extends { readonly type: T } ? S : never;
 export type Visitors<State extends { readonly type: string }, R> = {
     [K in State['type']]: (state: WithType<State, K>) => R;
 };
-export const visitType = <State extends { readonly type: string }, R>(
+export const visitByType = <State extends { readonly type: string }, R>(
     state: State,
     visitors: Visitors<State, R>
 ): R => {

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -67,3 +67,15 @@ export const debounce = (fn: () => void, delay: number): (() => void) => {
 };
 
 export const areApproximatelyEqual = (a: number, b: number): boolean => Math.abs(a - b) < 1e-12;
+
+type WithType<S, T extends string> = S extends { readonly type: T } ? S : never;
+export type Visitors<State extends { readonly type: string }, R> = {
+    [K in State['type']]: (state: WithType<State, K>) => R;
+};
+export const visitType = <State extends { readonly type: string }, R>(
+    state: State,
+    visitors: Visitors<State, R>
+): R => {
+    const v = (visitors as Record<string, unknown>)[state.type] as (state: State) => R;
+    return v(state);
+};

--- a/src/renderer/components/inputs/previews/ImagePreview.tsx
+++ b/src/renderer/components/inputs/previews/ImagePreview.tsx
@@ -3,7 +3,7 @@ import { Center, HStack, Image, Spinner, Tag, Text, VStack } from '@chakra-ui/re
 import { memo, useState } from 'react';
 import { useContext } from 'use-context-selector';
 import { getBackend } from '../../../../common/Backend';
-import { checkFileExists, visitType } from '../../../../common/util';
+import { checkFileExists, visitByType } from '../../../../common/util';
 import { SettingsContext } from '../../../contexts/SettingsContext';
 import { useAsyncEffect } from '../../../hooks/useAsyncEffect';
 
@@ -93,7 +93,7 @@ const ImagePreview = memo(({ path, schemaId, id }: ImagePreviewProps) => {
 
     return (
         <Center w="full">
-            {visitType(state, {
+            {visitByType(state, {
                 clear: () => null,
                 loading: () => <Spinner />,
                 image: ({ image, fileType }) => (

--- a/src/renderer/components/inputs/previews/TorchModelPreview.tsx
+++ b/src/renderer/components/inputs/previews/TorchModelPreview.tsx
@@ -1,9 +1,9 @@
-import { Center, Spinner, Tag, Wrap, WrapItem } from '@chakra-ui/react';
+/* eslint-disable react/no-unstable-nested-components */
+import { Center, Spinner, Tag, Text, Wrap, WrapItem } from '@chakra-ui/react';
 import { memo, useState } from 'react';
 import { useContext } from 'use-context-selector';
 import { getBackend } from '../../../../common/Backend';
-import { checkFileExists } from '../../../../common/util';
-import { AlertBoxContext, AlertType } from '../../../contexts/AlertBoxContext';
+import { checkFileExists, visitType } from '../../../../common/util';
 import { SettingsContext } from '../../../contexts/SettingsContext';
 import { useAsyncEffect } from '../../../hooks/useAsyncEffect';
 
@@ -34,9 +34,16 @@ interface TorchModelPreviewProps {
     schemaId: string;
 }
 
+type State =
+    | { readonly type: 'clear' }
+    | { readonly type: 'loading' }
+    | { readonly type: 'error'; message: string }
+    | { readonly type: 'model'; model: ModelData };
+const CLEAR_STATE: State = { type: 'clear' };
+const LOADING_STATE: State = { type: 'loading' };
+
 const TorchModelPreview = memo(({ path, schemaId, id }: TorchModelPreviewProps) => {
-    const [modelData, setModelData] = useState<ModelData | null>(null);
-    const [isLoading, setIsLoading] = useState(true);
+    const [state, setState] = useState<State>(CLEAR_STATE);
 
     const { useIsCpu, useIsFp16, port } = useContext(SettingsContext);
     const backend = getBackend(port);
@@ -44,74 +51,69 @@ const TorchModelPreview = memo(({ path, schemaId, id }: TorchModelPreviewProps) 
     const [isCpu] = useIsCpu;
     const [isFp16] = useIsFp16;
 
-    const { sendAlert } = useContext(AlertBoxContext);
-
     useAsyncEffect(
         {
-            supplier: async (token) => {
-                token.causeEffect(() => setIsLoading(true));
+            supplier: async (token): Promise<State> => {
+                if (!path) return CLEAR_STATE;
 
-                if (path) {
-                    const fileExists = await checkFileExists(path);
-                    if (fileExists) {
-                        return backend.runIndividual<ModelData | null>({
-                            schemaId,
-                            id,
-                            inputs: [path],
-                            isCpu,
-                            isFp16,
-                        });
-                    }
+                token.causeEffect(() => setState(LOADING_STATE));
+
+                if (!(await checkFileExists(path))) {
+                    return {
+                        type: 'error',
+                        message:
+                            'File does not exist on the system. Please select a different file.',
+                    };
                 }
-                return null;
-            },
-            successEffect: (value) => {
-                const data = value as ModelData;
-                if (data.modelType) {
-                    setModelData(data);
-                } else {
-                    sendAlert({
-                        type: AlertType.ERROR,
-                        message: 'Failed to load model. Model type is probably not supported.',
-                    });
-                }
-            },
-            catchEffect: (error) => {
-                sendAlert({
-                    type: AlertType.ERROR,
-                    title: 'Error',
-                    message: JSON.stringify(error, undefined, 2),
-                    copyToClipboard: true,
+
+                const result = await backend.runIndividual<ModelData>({
+                    schemaId,
+                    id,
+                    inputs: [path],
+                    isCpu,
+                    isFp16,
                 });
+
+                if (!result.success) {
+                    return {
+                        type: 'error',
+                        message: 'Failed to load model. Model type is likely unsupported.',
+                    };
+                }
+
+                return { type: 'model', model: result.data };
             },
-            finallyEffect: () => setIsLoading(false),
+            successEffect: setState,
+            catchEffect: (error) => {
+                setState({ type: 'error', message: String(error) });
+            },
         },
         [path]
     );
 
     return (
         <Center w="full">
-            {isLoading ? (
-                <Spinner />
-            ) : (
-                modelData && (
+            {visitType(state, {
+                clear: () => null,
+                loading: () => <Spinner />,
+                model: ({ model }) => (
                     <Wrap
                         justify="center"
                         maxW={60}
                         spacing={2}
                     >
                         <WrapItem>
-                            <Tag>{modelData.modelType ?? '?'}</Tag>
+                            <Tag>{model.modelType ?? '?'}</Tag>
                         </WrapItem>
                         <WrapItem>
-                            <Tag>{modelData.scale}x</Tag>
+                            <Tag>{model.scale}x</Tag>
                         </WrapItem>
                         <WrapItem>
                             <Tag>
-                                {getColorMode(modelData.inNc)}→{getColorMode(modelData.outNc)}
+                                {getColorMode(model.inNc)}→{getColorMode(model.outNc)}
                             </Tag>
                         </WrapItem>
-                        {modelData.size.map((size) => (
+                        {model.size.map((size) => (
                             <WrapItem key={size}>
                                 <Tag
                                     key={size}
@@ -122,8 +124,9 @@ const TorchModelPreview = memo(({ path, schemaId, id }: TorchModelPreviewProps) 
                             </WrapItem>
                         ))}
                     </Wrap>
-                )
-            )}
+                ),
+                error: ({ message }) => <Text w="200px">{message}</Text>,
+            })}
         </Center>
     );
 });

--- a/src/renderer/components/inputs/previews/TorchModelPreview.tsx
+++ b/src/renderer/components/inputs/previews/TorchModelPreview.tsx
@@ -3,7 +3,7 @@ import { Center, Spinner, Tag, Text, Wrap, WrapItem } from '@chakra-ui/react';
 import { memo, useState } from 'react';
 import { useContext } from 'use-context-selector';
 import { getBackend } from '../../../../common/Backend';
-import { checkFileExists, visitType } from '../../../../common/util';
+import { checkFileExists, visitByType } from '../../../../common/util';
 import { SettingsContext } from '../../../contexts/SettingsContext';
 import { useAsyncEffect } from '../../../hooks/useAsyncEffect';
 
@@ -93,7 +93,7 @@ const TorchModelPreview = memo(({ path, schemaId, id }: TorchModelPreviewProps) 
 
     return (
         <Center w="full">
-            {visitType(state, {
+            {visitByType(state, {
                 clear: () => null,
                 loading: () => <Spinner />,
                 model: ({ model }) => (


### PR DESCRIPTION
This allows calls to `/run/individual` to error.

Since the logic inside the preview got a little unwieldy, I changed how state is managed. Each preview can be in one of 4 states: clear (no input), loading, error, and success (received data). I used a discriminative union (enum) to make this explicit. Unfortunately, JS does not have [Rust-like match](https://doc.rust-lang.org/rust-by-example/flow_control/match/destructuring/destructure_enum.html), so I added a small util method (`visitByType`) that emulates the missing control-flow primitive.