### PR TITLE
Fixed generated search pattern

### DIFF
--- a/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
+++ b/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
@@ -36,7 +36,7 @@ const createSearchPredicate = (query: string): ((name: string) => boolean) => {
         `^${[...query]
             .map((char) => {
                 const hex = `\\u{${char.codePointAt(0)!.toString(16)}}`;
-                return `(?:[^${hex}]+(?:(?<![a-z])|(?<=[a-z])(?![a-z])))?${hex}`;
+                return `(?:.+(?:(?<![a-z])|(?<=[a-z])(?![a-z])))?${hex}`;
             })
             .join('')}`,
         'iu'


### PR DESCRIPTION
Fixes #451.

The problem was that I originally intended the search regex to be a DFA. However, I made the regex more complex in #366 which means that the old way of ensuring a DFA is no longer correct. The fix is to remove my method of creating a DFA. This means that the generated regex new have polynomial worst-case runtime (with an arbitrarily large exponent), but that is a risk I am willing to take.