### PR TITLE
Fixed Blend Images output typing

### DIFF
--- a/backend/src/nodes/image_util_nodes.py
+++ b/backend/src/nodes/image_util_nodes.py
@@ -48,7 +48,11 @@ class ImBlend(NodeBase):
                         expression.field("Input0", "height"),
                         expression.field("Input1", "height"),
                     ),
-                    channels=4,
+                    channels=expression.fn(
+                        "max",
+                        expression.field("Input0", "channels"),
+                        expression.field("Input1", "channels"),
+                    ),
                 )
             ),
         ]


### PR DESCRIPTION
The output for Blend Images does not always output a 4-channel image. Like with height and width, it outputs max(input1 channels, input2 channels). For example, if a grayscale and RGB image are inputted into the node, the output will have 3 channels.