### PR TITLE
Added support for runtime type narrowing of nullable inputs

### DIFF
--- a/src/common/types/function.ts
+++ b/src/common/types/function.ts
@@ -89,6 +89,8 @@ export class FunctionDefinition {
 
     readonly inputDataLiterals: Set<number>;
 
+    readonly inputNullable: Set<number>;
+
     readonly inputOptions: ReadonlyMap<number, ReadonlyMap<string | number, Type>>;
 
     readonly defaultInstance: FunctionInstance;
@@ -131,6 +133,7 @@ export class FunctionDefinition {
                 })
                 .map((i) => i.id)
         );
+        this.inputNullable = new Set(schema.inputs.filter((i) => i.optional).map((i) => i.id));
 
         this.inputOptions = evaluateInputOptions(schema, definitions);
 

--- a/src/renderer/helpers/TypeState.ts
+++ b/src/renderer/helpers/TypeState.ts
@@ -2,7 +2,7 @@ import { Edge, Node } from 'react-flow-renderer';
 import { EdgeData, NodeData } from '../../common/common-types';
 import { EvaluationError } from '../../common/types/evaluate';
 import { FunctionDefinition, FunctionInstance } from '../../common/types/function';
-import { NumericLiteralType, StringLiteralType, Type } from '../../common/types/types';
+import { NumericLiteralType, StringLiteralType, StructType, Type } from '../../common/types/types';
 import { parseHandle } from '../../common/util';
 
 export class TypeState {
@@ -75,25 +75,27 @@ export class TypeState {
                             return edgeSource;
                         }
 
-                        if (definition.inputDataLiterals.has(id)) {
-                            const inputValue = n.data.inputData[id];
-                            if (inputValue !== undefined) {
+                        const inputValue = n.data.inputData[id];
+
+                        if (inputValue !== undefined) {
+                            if (definition.inputDataLiterals.has(id)) {
                                 if (typeof inputValue === 'number') {
                                     return new NumericLiteralType(inputValue);
                                 }
                                 return new StringLiteralType(inputValue);
                             }
-                        }
 
-                        const optionTypes = definition.inputOptions.get(id);
-                        if (optionTypes) {
-                            const inputValue = n.data.inputData[id];
-                            if (inputValue !== undefined) {
+                            const optionTypes = definition.inputOptions.get(id);
+                            if (optionTypes) {
                                 const currentOption = optionTypes.get(inputValue);
                                 if (currentOption) {
                                     return currentOption;
                                 }
                             }
+                        }
+
+                        if (inputValue === undefined && definition.inputNullable.has(id)) {
+                            return new StructType('null');
                         }
 
                         return undefined;


### PR DESCRIPTION
This PR makes it so that optional inputs with a set value get set to the `null` type.

![image](https://user-images.githubusercontent.com/20878432/175661157-b131851d-fe81-4e22-b2d3-163adddf1cdc.png)


This doesn't bring us any benefits right now, but it will pave the way for conditional types and other type-related features.