### PR TITLE
Added "Copy File Name" and "Copy Full File Path" content menu entries

### DIFF
--- a/src/renderer/components/inputs/FileInput.tsx
+++ b/src/renderer/components/inputs/FileInput.tsx
@@ -9,11 +9,11 @@ import {
     Tooltip,
     VStack,
 } from '@chakra-ui/react';
-import { shell } from 'electron';
+import { clipboard, shell } from 'electron';
 import path from 'path';
 import { DragEvent, memo, useEffect } from 'react';
 import { BsFileEarmarkPlus } from 'react-icons/bs';
-import { MdFolder } from 'react-icons/md';
+import { MdContentCopy, MdFolder } from 'react-icons/md';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { FileInputKind } from '../../../common/common-types';
 import { ipcRenderer } from '../../../common/safeIpc';
@@ -195,6 +195,29 @@ const FileInput = memo(
                     }}
                 >
                     Open in File Explorer
+                </MenuItem>
+                <MenuDivider />
+                <MenuItem
+                    icon={<MdContentCopy />}
+                    isDisabled={!filePath}
+                    onClick={() => {
+                        if (filePath) {
+                            clipboard.writeText(path.parse(filePath).name);
+                        }
+                    }}
+                >
+                    Copy File Name
+                </MenuItem>
+                <MenuItem
+                    icon={<MdContentCopy />}
+                    isDisabled={!filePath}
+                    onClick={() => {
+                        if (filePath) {
+                            clipboard.writeText(filePath);
+                        }
+                    }}
+                >
+                    Copy Full File Path
                 </MenuItem>
             </MenuList>
         ));


### PR DESCRIPTION
As per Kim's suggestion, although I'm still waiting for feedback on the exact behavior of "Copy File Name".