### PR TITLE
Fixed previews not clearing the manual type they set

### DIFF
--- a/src/renderer/components/inputs/FileInput.tsx
+++ b/src/renderer/components/inputs/FileInput.tsx
@@ -110,33 +110,6 @@ const FileInput = memo(
             }
         };
 
-        const preview = () => {
-            switch (fileKind) {
-                case 'image':
-                    return (
-                        <Box mt={2}>
-                            <ImagePreview
-                                id={id}
-                                path={filePath}
-                                schemaId={schemaId}
-                            />
-                        </Box>
-                    );
-                case 'pth':
-                    return (
-                        <Box mt={2}>
-                            <TorchModelPreview
-                                id={id}
-                                path={filePath}
-                                schemaId={schemaId}
-                            />
-                        </Box>
-                    );
-                default:
-                    return null;
-            }
-        };
-
         const onDragOver = (event: DragEvent<HTMLDivElement>) => {
             event.preventDefault();
 
@@ -234,7 +207,26 @@ const FileInput = memo(
                         />
                     </InputGroup>
                 </Tooltip>
-                {filePath && <Box>{preview()}</Box>}
+                <Box>
+                    {fileKind === 'image' && (
+                        <Box mt={2}>
+                            <ImagePreview
+                                id={id}
+                                path={filePath}
+                                schemaId={schemaId}
+                            />
+                        </Box>
+                    )}
+                    {fileKind === 'pth' && (
+                        <Box mt={2}>
+                            <TorchModelPreview
+                                id={id}
+                                path={filePath}
+                                schemaId={schemaId}
+                            />
+                        </Box>
+                    )}
+                </Box>
             </VStack>
         );
     }


### PR DESCRIPTION
Previews are used to narrow the type of images and PyTorch models. They have the responsibility of both setting and resetting the runtime type of images/models. 

However, since the FileInput was only rendering previews when the file path was set, they could not reset the runtime type. This PR makes it so that previews are always rendered.

This fixes the bug and (interestingly) doesn't change the layout. I also "inlined" the `preview` function to simplify the code a bit.