### PR TITLE
Fix pane context menu node search typeState bug for inputs

### DIFF
--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -99,7 +99,8 @@ export const usePaneNodeSearchMenu = (
                         });
                     }
                     case 'target': {
-                        const sourceFn = typeState.functions.get(connectingFrom.nodeId);
+                        const sourceNode = getNode(connectingFrom.nodeId) as Node<NodeData>;
+                        const sourceFn = functionDefinitions.get(sourceNode.data.schemaId);
 
                         if (!sourceFn) {
                             return false;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34788790/177247798-889416c7-7003-498a-84b7-f6430b8ab089.png)

I had noticed that the Image Stack node wasn't finding any nodes for the B/C/D inputs in the pane context menu. I fixed it by using the function definitions rather than the typestate when finding nodes based on inputs. I assume this has something to do with the type state being incomplete for these connections, and it'll be fine to leave it for outputs as those we actually would want to be type-narrowed in the future based on calculated types.

![image](https://user-images.githubusercontent.com/34788790/177247861-45d6f23c-fd70-44f7-89ab-48f6a2b3bbc5.png)
