### PR TITLE
Fixed output type of "Add Normals" node

### DIFF
--- a/backend/src/nodes/image_filter_nodes.py
+++ b/backend/src/nodes/image_filter_nodes.py
@@ -369,7 +369,15 @@ class NormalAdditionNode(NodeBase):
             ImageOutput(
                 "Normal Map",
                 expression.Image(
-                    size_as=expression.intersect("Input0", "Input2"), channels=3
+                    width=expression.intersect(
+                        expression.field("Input0", "width"),
+                        expression.field("Input2", "width"),
+                    ),
+                    height=expression.intersect(
+                        expression.field("Input0", "height"),
+                        expression.field("Input2", "height"),
+                    ),
+                    channels=3,
                 ),
             ),
         ]


### PR DESCRIPTION
If the node got 2 images with a different number of channels (e.g. `Image { width: 100, height: 100, channels: 3}` and `Image { width: 100, height: 100, channels: 4}`), then the intersection of the two was empty (`never`). This caused the output type of the node to also become `never`.