### PR TITLE
Added small type tag

### DIFF
--- a/src/common/types/util.ts
+++ b/src/common/types/util.ts
@@ -4,6 +4,7 @@ import {
     IntIntervalType,
     IntervalType,
     NumericLiteralType,
+    StringLiteralType,
     StructType,
     Type,
     WithUnderlying,
@@ -93,4 +94,11 @@ export const interval = (min: number, max: number) => {
 export const intInterval = (min: number, max: number) => {
     if (min === max) return new NumericLiteralType(min);
     return new IntIntervalType(min, max);
+};
+
+export const isNumericLiteral = (type: Type): type is NumericLiteralType => {
+    return type.type === 'literal' && type.underlying === 'number';
+};
+export const isStringLiteral = (type: Type): type is StringLiteralType => {
+    return type.type === 'literal' && type.underlying === 'string';
 };

--- a/src/renderer/components/TypeTag.tsx
+++ b/src/renderer/components/TypeTag.tsx
@@ -1,0 +1,53 @@
+import { Tag, useColorModeValue } from '@chakra-ui/react';
+import { memo } from 'react';
+import { Type } from '../../common/types/types';
+import { isNumericLiteral } from '../../common/types/util';
+
+const getTypeText = (type: Type): string | undefined => {
+    if (isNumericLiteral(type)) return type.toString();
+
+    if (type.type === 'struct') {
+        if (type.name === 'Image' && type.fields.length === 3) {
+            const [width, height /* , _channels */] = type.fields;
+            if (isNumericLiteral(width.type) && isNumericLiteral(height.type)) {
+                return `${width.type.toString()}x${height.type.toString()}`;
+            }
+        }
+    }
+    return undefined;
+};
+
+export interface TypeTagProps {
+    type: Type;
+}
+
+export const TypeTag = memo(({ type }: TypeTagProps) => {
+    const text = getTypeText(type);
+
+    const tagColor = useColorModeValue('gray.400', 'gray.750');
+    const tagFontColor = useColorModeValue('gray.700', 'gray.400');
+
+    return (
+        // eslint-disable-next-line react/jsx-no-useless-fragment
+        <>
+            {text && (
+                <Tag
+                    bgColor={tagColor}
+                    color={tagFontColor}
+                    fontSize="x-small"
+                    height="15px"
+                    lineHeight="auto"
+                    minHeight="auto"
+                    minWidth="auto"
+                    ml={1}
+                    px={1}
+                    py={0}
+                    size="sm"
+                    variant="subtle"
+                >
+                    {text}
+                </Tag>
+            )}
+        </>
+    );
+});

--- a/src/renderer/components/outputs/GenericOutput.tsx
+++ b/src/renderer/components/outputs/GenericOutput.tsx
@@ -1,6 +1,9 @@
-import { Text } from '@chakra-ui/react';
+import { Flex, Spacer, Text } from '@chakra-ui/react';
 import { memo } from 'react';
+import { useContextSelector } from 'use-context-selector';
 import { Type } from '../../../common/types/types';
+import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
+import { TypeTag } from '../TypeTag';
 import OutputContainer from './OutputContainer';
 
 interface GenericOutputProps {
@@ -11,6 +14,10 @@ interface GenericOutputProps {
 }
 
 const GenericOutput = memo(({ label, id, outputId, definitionType }: GenericOutputProps) => {
+    const type = useContextSelector(GlobalVolatileContext, (c) =>
+        c.typeState.functions.get(id)?.outputs.get(outputId)
+    );
+
     return (
         <OutputContainer
             hasHandle
@@ -18,15 +25,19 @@ const GenericOutput = memo(({ label, id, outputId, definitionType }: GenericOutp
             id={id}
             outputId={outputId}
         >
-            <Text
-                marginInlineEnd="0.5rem"
-                mb={-1}
-                mt={-1}
-                textAlign="right"
-                w="full"
-            >
-                {label}
-            </Text>
+            <Flex w="full">
+                <Spacer />
+                {type && <TypeTag type={type} />}
+                <Text
+                    marginInlineEnd="0.5rem"
+                    mb={-1}
+                    ml={1}
+                    mt={-1}
+                    textAlign="right"
+                >
+                    {label}
+                </Text>
+            </Flex>
         </OutputContainer>
     );
 });


### PR DESCRIPTION
This adds a small tag to some outputs.

Right now, tags are only shows for numbers and images with certain width and height. I also considered strings, but they can be quite long which messes with the layout.

It might also be useful to repeat this information at connected inputs, but that becomes a bit more tricky to layout with the "optional" tag.

Example:
![image](https://user-images.githubusercontent.com/20878432/177343361-30a6c9e8-edb9-4841-8d52-2a6edeb13c7e.png)
