### PR TITLE
Remember node selector panel collapse state

### DIFF
--- a/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
+++ b/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
@@ -22,9 +22,10 @@ import {
 import { motion } from 'framer-motion';
 import { memo, useMemo, useState } from 'react';
 import { BsCaretDownFill, BsCaretLeftFill, BsCaretRightFill, BsCaretUpFill } from 'react-icons/bs';
-import { useContext } from 'use-context-selector';
+import { useContext, useContextSelector } from 'use-context-selector';
 import { SchemaMap } from '../../../common/SchemaMap';
 import { DependencyContext } from '../../contexts/DependencyContext';
+import { SettingsContext } from '../../contexts/SettingsContext';
 import {
     getMatchingNodes,
     getNodesByCategory,
@@ -48,7 +49,10 @@ const NodeSelector = memo(({ schemata, height }: NodeSelectorProps) => {
     const matchingNodes = getMatchingNodes(searchQuery, schemata.schemata);
     const byCategories = useMemo(() => getNodesByCategory(matchingNodes), [matchingNodes]);
 
-    const [collapsed, setCollapsed] = useState<boolean>(false);
+    const [collapsed, setCollapsed] = useContextSelector(
+        SettingsContext,
+        (c) => c.useNodeSelectorCollapsed
+    );
 
     const { favorites } = useNodeFavorites();
     const favoriteNodes = useMemo(() => {

--- a/src/renderer/contexts/SettingsContext.tsx
+++ b/src/renderer/contexts/SettingsContext.tsx
@@ -25,6 +25,7 @@ interface Settings {
         readonly SchemaId[],
         React.Dispatch<React.SetStateAction<readonly SchemaId[]>>
     ];
+    useNodeSelectorCollapsed: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
 
     // Port
     port: number;
@@ -58,6 +59,9 @@ export const SettingsProvider = memo(
         const useNodeFavorites = useMemoArray(
             useLocalStorage<readonly SchemaId[]>('node-favorites', [])
         );
+        const useNodeSelectorCollapsed = useMemoArray(
+            useLocalStorage('node-selector-collapsed', false)
+        );
 
         const contextValue = useMemoObject<Settings>({
             // Globals
@@ -72,6 +76,7 @@ export const SettingsProvider = memo(
 
             // Node
             useNodeFavorites,
+            useNodeSelectorCollapsed,
 
             // Port
             port,


### PR DESCRIPTION
With the new context node selector pane, I don't use the node selector panel anymore, but it still opens every time I restart/reload Chainner. Just like favorite nodes, the node selector collapse state is now a setting.