### PR TITLE
Improved types

### DIFF
--- a/backend/src/nodes/image_chan_nodes.py
+++ b/backend/src/nodes/image_chan_nodes.py
@@ -80,11 +80,25 @@ class CombineRgbaNode(NodeBase):
         self.outputs = [
             ImageOutput(
                 image_type=expression.Image(
-                    size_as=expression.intersect(
-                        "Input0",
-                        "Input1",
-                        "Input2",
-                        expression.match("Input3", ("Image", "i", "i"), default="any"),
+                    width=expression.intersect(
+                        "Input0.width",
+                        "Input1.width",
+                        "Input2.width",
+                        expression.match(
+                            "Input3",
+                            ("Image", "i", "i.width"),
+                            default="any",
+                        ),
+                    ),
+                    height=expression.intersect(
+                        "Input0.height",
+                        "Input1.height",
+                        "Input2.height",
+                        expression.match(
+                            "Input3",
+                            ("Image", "i", "i.height"),
+                            default="any",
+                        ),
                     ),
                     channels=4,
                 )
@@ -245,7 +259,9 @@ class TransparencyMergeNode(NodeBase):
         self.outputs = [
             ImageOutput(
                 image_type=expression.Image(
-                    size_as=expression.intersect("Input0", "Input1"), channels=4
+                    width=expression.intersect("Input0.width", "Input1.width"),
+                    height=expression.intersect("Input0.height", "Input1.height"),
+                    channels=4,
                 )
             )
         ]

--- a/backend/src/nodes/image_dim_nodes.py
+++ b/backend/src/nodes/image_dim_nodes.py
@@ -49,7 +49,7 @@ class ImResizeByFactorNode(NodeBase):
                                 "round",
                                 expression.fn(
                                     "multiply",
-                                    expression.field("Input0", "width"),
+                                    "Input0.width",
                                     expression.fn("divide", "Input1", 100),
                                 ),
                             ),
@@ -64,7 +64,7 @@ class ImResizeByFactorNode(NodeBase):
                                 "round",
                                 expression.fn(
                                     "multiply",
-                                    expression.field("Input0", "height"),
+                                    "Input0.height",
                                     expression.fn("divide", "Input1", 100),
                                 ),
                             ),
@@ -110,7 +110,7 @@ class ImResizeToResolutionNode(NodeBase):
                 image_type=expression.Image(
                     width="Input1",
                     height="Input2",
-                    channels=expression.field("Input0", "channels"),
+                    channels="Input0.channels",
                 )
             )
         ]
@@ -147,7 +147,7 @@ class TileFillNode(NodeBase):
                 image_type=expression.Image(
                     width="Input1",
                     height="Input2",
-                    channels=expression.field("Input0", "channels"),
+                    channels="Input0.channels",
                 )
             )
         ]
@@ -218,7 +218,7 @@ class BorderCropNode(NodeBase):
                     width=expression.intersect(
                         expression.fn(
                             "subtract",
-                            expression.field("Input0", "width"),
+                            "Input0.width",
                             expression.fn("add", "Input1", "Input1"),
                         ),
                         expression.int_interval(min=0, max=None),
@@ -226,7 +226,7 @@ class BorderCropNode(NodeBase):
                     height=expression.intersect(
                         expression.fn(
                             "subtract",
-                            expression.field("Input0", "height"),
+                            "Input0.height",
                             expression.fn("add", "Input1", "Input1"),
                         ),
                         expression.int_interval(min=0, max=None),
@@ -271,7 +271,7 @@ class EdgeCropNode(NodeBase):
                     width=expression.intersect(
                         expression.fn(
                             "subtract",
-                            expression.field("Input0", "width"),
+                            "Input0.width",
                             expression.fn("add", "Input2", "Input3"),
                         ),
                         expression.int_interval(min=0, max=None),
@@ -279,7 +279,7 @@ class EdgeCropNode(NodeBase):
                     height=expression.intersect(
                         expression.fn(
                             "subtract",
-                            expression.field("Input0", "height"),
+                            "Input0.height",
                             expression.fn("add", "Input1", "Input4"),
                         ),
                         expression.int_interval(min=0, max=None),
@@ -365,11 +365,9 @@ class GetDimensionsNode(NodeBase):
             ImageInput(),
         ]
         self.outputs = [
-            NumberOutput("Width", output_type=expression.field("Input0", "width")),
-            NumberOutput("Height", output_type=expression.field("Input0", "height")),
-            NumberOutput(
-                "Channels", output_type=expression.field("Input0", "channels")
-            ),
+            NumberOutput("Width", output_type="Input0.width"),
+            NumberOutput("Height", output_type="Input0.height"),
+            NumberOutput("Channels", output_type="Input0.channels"),
         ]
         self.category = IMAGE_DIMENSION
         self.name = "Get Dimensions"

--- a/backend/src/nodes/image_filter_nodes.py
+++ b/backend/src/nodes/image_filter_nodes.py
@@ -369,14 +369,8 @@ class NormalAdditionNode(NodeBase):
             ImageOutput(
                 "Normal Map",
                 expression.Image(
-                    width=expression.intersect(
-                        expression.field("Input0", "width"),
-                        expression.field("Input2", "width"),
-                    ),
-                    height=expression.intersect(
-                        expression.field("Input0", "height"),
-                        expression.field("Input2", "height"),
-                    ),
+                    width=expression.intersect("Input0.width", "Input2.width"),
+                    height=expression.intersect("Input0.height", "Input2.height"),
                     channels=3,
                 ),
             ),

--- a/backend/src/nodes/image_util_nodes.py
+++ b/backend/src/nodes/image_util_nodes.py
@@ -36,21 +36,9 @@ class ImBlend(NodeBase):
         self.outputs = [
             ImageOutput(
                 image_type=expression.Image(
-                    width=expression.fn(
-                        "max",
-                        expression.field("Input0", "width"),
-                        expression.field("Input1", "width"),
-                    ),
-                    height=expression.fn(
-                        "max",
-                        expression.field("Input0", "height"),
-                        expression.field("Input1", "height"),
-                    ),
-                    channels=expression.fn(
-                        "max",
-                        expression.field("Input0", "channels"),
-                        expression.field("Input1", "channels"),
-                    ),
+                    width=expression.fn("max", "Input0.width", "Input1.width"),
+                    height=expression.fn("max", "Input0.height", "Input1.height"),
+                    channels=expression.fn("max", "Input0.channels", "Input1.channels"),
                 )
             ),
         ]
@@ -246,7 +234,7 @@ class ColorConvertNode(NodeBase):
             ImageOutput(
                 image_type=expression.Image(
                     size_as="Input0",
-                    channels=expression.field("Input1", "outputChannels"),
+                    channels="Input1.outputChannels",
                 )
             )
         ]
@@ -278,12 +266,12 @@ class BorderMakeNode(NodeBase):
                 image_type=expression.Image(
                     width=expression.fn(
                         "add",
-                        expression.field("Input0", "width"),
+                        "Input0.width",
                         expression.fn("multiply", "Input2", 2),
                     ),
                     height=expression.fn(
                         "add",
-                        expression.field("Input0", "height"),
+                        "Input0.height",
                         expression.fn("multiply", "Input2", 2),
                     ),
                 )
@@ -400,14 +388,8 @@ class FlipNode(NodeBase):
         self.outputs = [
             ImageOutput(
                 image_type=expression.Image(
-                    width=[
-                        expression.field("Input0", "width"),
-                        expression.field("Input0", "height"),
-                    ],
-                    height=[
-                        expression.field("Input0", "width"),
-                        expression.field("Input0", "height"),
-                    ],
+                    width=["Input0.width", "Input0.height"],
+                    height=["Input0.width", "Input0.height"],
                     channels_as="Input0",
                 )
             )

--- a/backend/src/nodes/pytorch_nodes.py
+++ b/backend/src/nodes/pytorch_nodes.py
@@ -139,20 +139,9 @@ class ImageUpscaleNode(NodeBase):
             ImageOutput(
                 "Upscaled Image",
                 expression.Image(
-                    width=expression.fn(
-                        "multiply",
-                        expression.field("Input0", "scale"),
-                        expression.field("Input1", "width"),
-                    ),
-                    height=expression.fn(
-                        "multiply",
-                        expression.field("Input0", "scale"),
-                        expression.field("Input1", "height"),
-                    ),
-                    channels=[
-                        expression.field("Input0", "outputChannels"),
-                        expression.field("Input1", "channels"),
-                    ],
+                    width=expression.fn("multiply", "Input0.scale", "Input1.width"),
+                    height=expression.fn("multiply", "Input0.scale", "Input1.height"),
+                    channels=["Input0.outputChannels", "Input1.channels"],
                 ),
             )
         ]
@@ -518,9 +507,7 @@ class GetModelDimensions(NodeBase):
         super().__init__()
         self.description = """Returns the scale of a PyTorch model."""
         self.inputs = [ModelInput()]
-        self.outputs = [
-            NumberOutput("Scale", output_type=expression.field("Input0", "scale"))
-        ]
+        self.outputs = [NumberOutput("Scale", output_type="Input0.scale")]
 
         self.category = PYTORCH
         self.name = "Get Model Scale"

--- a/src/common/types/json.ts
+++ b/src/common/types/json.ts
@@ -175,8 +175,14 @@ export const fromJson = (e: ExpressionJson): Expression => {
             case 'string':
                 return StringType.instance;
             default:
-                return new NamedExpression(e);
+                break;
         }
+
+        const field = /^(\w+)\.(\w+)$/.exec(e);
+        if (field) {
+            return new FieldAccessExpression(new NamedExpression(field[1]), field[2]);
+        }
+        return new NamedExpression(e);
     }
 
     if (Array.isArray(e)) {


### PR DESCRIPTION
This PR includes 2 changes:

1. I  added a little "parsing." Basically, you can access fields now with a `.` on the python side, e.g. `"Input0.width"`. This simplified a lot of types.
2. `CombineRgbaNode` and `TransparencyMergeNode` had a problem with intersections. Same problem as #503.