### PR TITLE
Input and outputs can now reference other inputs and outputs

### DIFF
--- a/backend/src/nodes/image_util_nodes.py
+++ b/backend/src/nodes/image_util_nodes.py
@@ -227,7 +227,7 @@ class ColorConvertNode(NodeBase):
             "Also can convert to different channel-spaces."
         )
         self.inputs = [
-            ImageInput(),
+            ImageInput(image_type=expression.Image(channels="Input1.inputChannels")),
             ColorModeInput(),
         ]
         self.outputs = [

--- a/src/common/types/function.ts
+++ b/src/common/types/function.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
-import { InputSchemaValue, NodeSchema } from '../common-types';
-import { EMPTY_MAP } from '../util';
+import { Input, InputSchemaValue, NodeSchema, Output } from '../common-types';
+import { EMPTY_MAP, topologicalSort } from '../util';
 import { evaluate } from './evaluate';
 import { Expression } from './expression';
 import { intersect } from './intersection';
@@ -9,26 +9,143 @@ import { TypeDefinitions } from './typedef';
 import { Type } from './types';
 import { getReferences } from './util';
 
-const getParamName = (inputId: number) => `Input${inputId}`;
+const getParamRefs = (
+    expression: Expression,
+    param: 'Input' | 'Output',
+    valid: ReadonlySet<number>
+): Set<number> => {
+    const refs = new Set<number>();
+    for (const ref of getReferences(expression)) {
+        if (ref.startsWith(param)) {
+            const rest = ref.slice(param.length);
+            if (/^\d+$/.test(rest)) {
+                const id = Number(rest);
+                if (valid.has(id)) {
+                    refs.add(id);
+                }
+            }
+        }
+    }
+    return refs;
+};
 
-const evaluateInputOutput = (
+const getInputParamName = (inputId: number) => `Input${inputId}` as const;
+const getOutputParamName = (outputId: number) => `Output${outputId}` as const;
+
+const createGenericParametersFromInputs = (
+    inputs: ReadonlyMap<number, Type>
+): Map<string, Type> => {
+    const parameters = new Map<string, Type>();
+    for (const [id, type] of inputs) {
+        parameters.set(getInputParamName(id), type);
+    }
+    return parameters;
+};
+
+interface InputInfo {
+    expression: Expression;
+    inputRefs: Set<number>;
+    input: Input;
+}
+const evaluateInputs = (
     schema: NodeSchema,
-    type: 'input' | 'output',
-    definitions: TypeDefinitions,
-    genericParameters?: ReadonlyMap<string, Type>
-): Map<number, Type> => {
-    const result = new Map<number, Type>();
-    for (const i of schema[`${type}s`]) {
+    definitions: TypeDefinitions
+): { ordered: InputInfo[]; defaults: Map<number, Type> } => {
+    const inputIds = new Set(schema.inputs.map((i) => i.id));
+
+    const infos = new Map<number, InputInfo>();
+    for (const input of schema.inputs) {
+        const expression = fromJson(input.type);
+        infos.set(input.id, {
+            expression,
+            inputRefs: getParamRefs(expression, 'Input', inputIds),
+            input,
+        });
+    }
+
+    const ordered = topologicalSort(infos.values(), (node) =>
+        [...node.inputRefs].map((ref) => infos.get(ref)!)
+    );
+    if (!ordered) {
+        throw new Error(
+            `The types of the inputs of ${schema.name} (id: ${schema.schemaId}) has a cyclic dependency.` +
+                ` Carefully review the uses for 'Input*' variables in the input types of that node.`
+        );
+    }
+    ordered.reverse();
+
+    const defaults = new Map<number, Type>();
+    const genericParameters = new Map<string, Type>();
+    for (const { expression, input } of ordered) {
         try {
-            result.set(i.id, evaluate(fromJson(i.type), definitions, genericParameters));
+            const type = evaluate(expression, definitions, genericParameters);
+            defaults.set(input.id, type);
+            genericParameters.set(getInputParamName(input.id), type);
         } catch (error) {
             throw new Error(
-                `Unable to evaluate type of ${schema.name} (id: ${schema.schemaId}) > ${i.label} (id: ${i.id})` +
+                `Unable to evaluate input type of ${schema.name} (id: ${schema.schemaId}) > ${input.label} (id: ${input.id})` +
                     `: ${String(error)}`
             );
         }
     }
-    return result;
+
+    return { ordered, defaults };
+};
+
+interface OutputInfo {
+    expression: Expression;
+    inputRefs: Set<number>;
+    outputRefs: Set<number>;
+    output: Output;
+}
+const evaluateOutputs = (
+    schema: NodeSchema,
+    definitions: TypeDefinitions,
+    inputDefaults: ReadonlyMap<number, Type>
+): { ordered: OutputInfo[]; defaults: Map<number, Type> } => {
+    const inputIds = new Set(inputDefaults.keys());
+    const outputIds = new Set(schema.outputs.map((i) => i.id));
+
+    const infos = new Map<number, OutputInfo>();
+    for (const output of schema.outputs) {
+        const expression = fromJson(output.type);
+        infos.set(output.id, {
+            expression,
+            // Collecting input references isn't necessary for the evaluation, but they will be
+            // needed by `FunctionDefinition`'s constructor, so we collect them here while we're
+            // at it.
+            inputRefs: getParamRefs(expression, 'Input', inputIds),
+            outputRefs: getParamRefs(expression, 'Output', outputIds),
+            output,
+        });
+    }
+
+    const ordered = topologicalSort(infos.values(), (node) =>
+        [...node.outputRefs].map((ref) => infos.get(ref)!)
+    );
+    if (!ordered) {
+        throw new Error(
+            `The types of the output of ${schema.name} (id: ${schema.schemaId}) has a cyclic dependency.` +
+                ` Carefully review the uses for 'Output*' variables in that node.`
+        );
+    }
+    ordered.reverse();
+
+    const defaults = new Map<number, Type>();
+    const genericParameters = createGenericParametersFromInputs(inputDefaults);
+    for (const { expression, output } of ordered) {
+        try {
+            const type = evaluate(expression, definitions, genericParameters);
+            defaults.set(output.id, type);
+            genericParameters.set(getOutputParamName(output.id), type);
+        } catch (error) {
+            throw new Error(
+                `Unable to evaluate output type of ${schema.name} (id: ${schema.schemaId}) > ${output.label} (id: ${output.id})` +
+                    `: ${String(error)}`
+            );
+        }
+    }
+    return { ordered, defaults };
 };
 
 const evaluateInputOptions = (
@@ -62,27 +179,25 @@ const evaluateInputOptions = (
     return result;
 };
 
-const createGenericParametersFromInputs = (
-    inputs: ReadonlyMap<number, Type>
-): Map<string, Type> => {
-    const parameters = new Map<string, Type>();
-    for (const [id, type] of inputs) {
-        parameters.set(getParamName(id), type);
-    }
-    return parameters;
-};
-
 export class FunctionDefinition {
-    readonly inputs: ReadonlyMap<number, Type>;
+    readonly inputDefaults: ReadonlyMap<number, Type>;
+
+    readonly inputExpressions: ReadonlyMap<number, Expression>;
+
+    readonly inputGenerics: ReadonlySet<number>;
+
+    readonly inputEvaluationOrder: readonly number[];
 
     readonly outputDefaults: ReadonlyMap<number, Type>;
 
     readonly outputExpressions: ReadonlyMap<number, Expression>;
 
-    readonly genericOutputs: ReadonlySet<number>;
+    readonly outputGenerics: ReadonlySet<number>;
+
+    readonly outputEvaluationOrder: readonly number[];
 
     get isGeneric() {
-        return this.genericOutputs.size > 0;
+        return this.inputGenerics.size > 0 || this.outputGenerics.size > 0;
     }
 
     readonly typeDefinitions: TypeDefinitions;
@@ -98,29 +213,31 @@ export class FunctionDefinition {
     private constructor(schema: NodeSchema, definitions: TypeDefinitions) {
         this.typeDefinitions = definitions;
 
-        this.inputs = evaluateInputOutput(schema, 'input', definitions);
-        this.outputDefaults = evaluateInputOutput(
-            schema,
-            'output',
-            definitions,
-            createGenericParametersFromInputs(this.inputs)
+        // inputs
+        const inputs = evaluateInputs(schema, definitions);
+        this.inputDefaults = inputs.defaults;
+        this.inputExpressions = new Map(
+            inputs.ordered.map(({ expression, input }) => [input.id, expression])
         );
-        this.outputExpressions = new Map(schema.outputs.map((o) => [o.id, fromJson(o.type)]));
-
-        const genericParameters = new Set([...this.inputs.keys()].map(getParamName));
-        this.genericOutputs = new Set(
-            [...this.outputExpressions]
-                .filter(([, expression]) => {
-                    for (const name of getReferences(expression)) {
-                        if (genericParameters.has(name)) {
-                            return true;
-                        }
-                    }
-                    return false;
-                })
-                .map(([id]) => id)
+        this.inputGenerics = new Set(
+            inputs.ordered.filter((i) => i.inputRefs.size > 0).map(({ input }) => input.id)
         );
+        this.inputEvaluationOrder = inputs.ordered.map(({ input }) => input.id);
 
+        // outputs
+        const outputs = evaluateOutputs(schema, definitions, this.inputDefaults);
+        this.outputDefaults = outputs.defaults;
+        this.outputExpressions = new Map(
+            outputs.ordered.map(({ expression, output }) => [output.id, expression])
+        );
+        this.outputGenerics = new Set(
+            outputs.ordered
+                .filter((i) => i.inputRefs.size > 0 || i.outputRefs.size > 0)
+                .map(({ output }) => output.id)
+        );
+        this.outputEvaluationOrder = outputs.ordered.map(({ output }) => output.id);
+
+        // input literal values
         this.inputDataLiterals = new Set(
             schema.inputs
                 .filter((i) => {
@@ -134,7 +251,6 @@ export class FunctionDefinition {
                 .map((i) => i.id)
         );
         this.inputNullable = new Set(schema.inputs.filter((i) => i.optional).map((i) => i.id));
-
         this.inputOptions = evaluateInputOptions(schema, definitions);
 
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
@@ -164,13 +280,17 @@ export class FunctionInstance {
     }
 
     static fromDefinition(definition: FunctionDefinition): FunctionInstance {
-        return new FunctionInstance(definition, definition.inputs, definition.outputDefaults);
+        return new FunctionInstance(
+            definition,
+            definition.inputDefaults,
+            definition.outputDefaults
+        );
     }
 
     static fromPartialInputs(
         definition: FunctionDefinition,
         partialInputs: ReadonlyMap<number, Type> | ((inputId: number) => Type | undefined),
-        neverDefaultsToDefaultOutput: boolean,
+        neverIsDefault: boolean,
         outputNarrowing: ReadonlyMap<number, Type> = EMPTY_MAP
     ): FunctionInstance {
         if (typeof partialInputs === 'object') {
@@ -180,33 +300,52 @@ export class FunctionInstance {
             partialInputs = (id) => map.get(id);
         }
 
+        // evaluate inputs
         const inputs = new Map<number, Type>();
-        for (const [id, definitionType] of definition.inputs) {
-            const assignedType = partialInputs(id);
-
-            if (!assignedType) {
-                inputs.set(id, definitionType);
+        const genericParameters = new Map<string, Type>();
+        for (const id of definition.inputEvaluationOrder) {
+            let type: Type;
+            if (definition.inputGenerics.has(id)) {
+                type = evaluate(
+                    definition.inputExpressions.get(id)!,
+                    definition.typeDefinitions,
+                    genericParameters
+                );
             } else {
-                inputs.set(id, intersect(assignedType, definitionType));
+                type = definition.inputDefaults.get(id)!;
             }
+
+            const assignedType = partialInputs(id);
+            if (assignedType) {
+                type = intersect(assignedType, type);
+            }
+
+            if (neverIsDefault && type.type === 'never') {
+                // If the output type is never, then there is some error with the input.
+                // However, we don't have the means to communicate this error yet, so we'll just
+                // ignore it for now.
+                type = definition.inputDefaults.get(id)!;
+            }
+
+            inputs.set(id, type);
+            genericParameters.set(getInputParamName(id), type);
         }
 
         // we don't need to evaluate the outputs of if they aren't generic
-        if (!definition.isGeneric && outputNarrowing.size === 0) {
+        if (definition.outputGenerics.size === 0 && outputNarrowing.size === 0) {
             return new FunctionInstance(definition, inputs, definition.outputDefaults);
         }
 
-        // evaluate generic outputs
-        const genericParameters = new Map<string, Type>();
-        for (const [id, type] of inputs) {
-            genericParameters.set(getParamName(id), type);
-        }
-
+        // evaluate outputs
         const outputs = new Map<number, Type>();
-        for (const [id, expression] of definition.outputExpressions) {
-            let type;
-            if (definition.genericOutputs.has(id)) {
-                type = evaluate(expression, definition.typeDefinitions, genericParameters);
+        for (const id of definition.outputEvaluationOrder) {
+            let type: Type;
+            if (definition.outputGenerics.has(id)) {
+                type = evaluate(
+                    definition.outputExpressions.get(id)!,
+                    definition.typeDefinitions,
+                    genericParameters
+                );
             } else {
                 type = definition.outputDefaults.get(id)!;
             }
@@ -216,21 +355,22 @@ export class FunctionInstance {
                 type = intersect(narrowing, type);
             }
 
-            if (neverDefaultsToDefaultOutput && type.type === 'never') {
+            if (neverIsDefault && type.type === 'never') {
                 // If the output type is never, then there is some error with the input.
-                // However, we don't have the means to communicate this error yet, so we''ll just
+                // However, we don't have the means to communicate this error yet, so we'll just
                 // ignore it for now.
                 type = definition.outputDefaults.get(id)!;
             }
 
             outputs.set(id, type);
+            genericParameters.set(getOutputParamName(id), type);
         }
 
         return new FunctionInstance(definition, inputs, outputs);
     }
 
     canAssign(inputId: number, type: Type): boolean {
-        const iType = this.definition.inputs.get(inputId);
+        const iType = this.definition.inputDefaults.get(inputId);
         if (!iType) throw new Error(`Invalid input id ${inputId}`);
 
         // we say that types A is assignable to type B if they are not disjoint

--- a/src/renderer/components/node/NodeInputs.tsx
+++ b/src/renderer/components/node/NodeInputs.tsx
@@ -106,7 +106,7 @@ const NodeInputs = memo(
             [useInputDataContext, id, inputData]
         );
 
-        const functions = functionDefinitions.get(schemaId)!.inputs;
+        const functions = functionDefinitions.get(schemaId)!.inputDefaults;
 
         return (
             <>

--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -90,7 +90,7 @@ export const usePaneNodeSearchMenu = (
                             return false;
                         }
 
-                        return [...targetTypes.inputs].some(([number, type]) => {
+                        return [...targetTypes.inputDefaults].some(([number, type]) => {
                             const overlap = intersect(type, sourceType);
                             return (
                                 overlap.type !== 'never' &&
@@ -107,7 +107,7 @@ export const usePaneNodeSearchMenu = (
                         }
 
                         const { inOutId } = parseHandle(connectingFrom.handleId);
-                        const sourceType = sourceFn.inputs.get(inOutId);
+                        const sourceType = sourceFn.inputDefaults.get(inOutId);
 
                         if (!sourceType) {
                             return false;
@@ -167,7 +167,7 @@ export const usePaneNodeSearchMenu = (
             ) {
                 switch (connectingFrom.handleType) {
                     case 'source': {
-                        const firstPossibleTarget = [...targetTypes.inputs].find(
+                        const firstPossibleTarget = [...targetTypes.inputDefaults].find(
                             ([inputId, type]) => {
                                 const overlap = intersect(type, connectingFromType);
                                 return (
@@ -367,7 +367,7 @@ export const usePaneNodeSearchMenu = (
                     case 'target': {
                         const targetType = functionDefinitions
                             .get(node.data.schemaId)
-                            ?.inputs.get(inOutId);
+                            ?.inputDefaults.get(inOutId);
                         setConnectingFromType(targetType ?? null);
                         setGlobalConnectingFromType(targetType ?? null);
                         break;


### PR DESCRIPTION
I allowed inputs and reference other inputs and outputs to reference other outputs. 

Sometimes the types of inputs depend on each other. The best example is the "Change Colorspace" node. If the user selects the "RGB -> Gray" conversion, then the input image must be a grayscale image. This dependency can now be expressed by directly referencing the depended upon input.

Outputs referencing each other isn't as useful (it doesn't make the type system more powerful), but it can be convenient, so I added that as well. (It's basically the same as inputs implementation-wise.)

---

Also, we should probably think about handling `never`. When an input or output becomes `never`, we know that some inputs are incompatible with each other or the node.