### PR TITLE
Type errors and some minor type-related changes

### DIFF
--- a/backend/src/nodes/image_chan_nodes.py
+++ b/backend/src/nodes/image_chan_nodes.py
@@ -102,6 +102,8 @@ class CombineRgbaNode(NodeBase):
                     ),
                     channels=4,
                 )
+            ).with_never_reason(
+                "The input channels have different sizes but must all be the same size."
             )
         ]
         self.category = IMAGE_CHANNEL
@@ -263,6 +265,8 @@ class TransparencyMergeNode(NodeBase):
                     height=expression.intersect("Input0.height", "Input1.height"),
                     channels=4,
                 )
+            ).with_never_reason(
+                "The RGB and alpha channels have different sizes but must have the same size."
             )
         ]
         self.category = IMAGE_CHANNEL

--- a/backend/src/nodes/image_dim_nodes.py
+++ b/backend/src/nodes/image_dim_nodes.py
@@ -221,7 +221,7 @@ class BorderCropNode(NodeBase):
                             "Input0.width",
                             expression.fn("add", "Input1", "Input1"),
                         ),
-                        expression.int_interval(min=0, max=None),
+                        expression.int_interval(min=1, max=None),
                     ),
                     height=expression.intersect(
                         expression.fn(
@@ -229,10 +229,12 @@ class BorderCropNode(NodeBase):
                             "Input0.height",
                             expression.fn("add", "Input1", "Input1"),
                         ),
-                        expression.int_interval(min=0, max=None),
+                        expression.int_interval(min=1, max=None),
                     ),
                     channels_as="Input0",
                 )
+            ).with_never_reason(
+                "The cropped area would result in image with no width or no height."
             )
         ]
         self.category = IMAGE_DIMENSION
@@ -274,7 +276,7 @@ class EdgeCropNode(NodeBase):
                             "Input0.width",
                             expression.fn("add", "Input2", "Input3"),
                         ),
-                        expression.int_interval(min=0, max=None),
+                        expression.int_interval(min=1, max=None),
                     ),
                     height=expression.intersect(
                         expression.fn(
@@ -282,10 +284,12 @@ class EdgeCropNode(NodeBase):
                             "Input0.height",
                             expression.fn("add", "Input1", "Input4"),
                         ),
-                        expression.int_interval(min=0, max=None),
+                        expression.int_interval(min=1, max=None),
                     ),
                     channels_as="Input0",
                 )
+            ).with_never_reason(
+                "The cropped area would result in image with no width or no height."
             )
         ]
         self.category = IMAGE_DIMENSION

--- a/backend/src/nodes/image_filter_nodes.py
+++ b/backend/src/nodes/image_filter_nodes.py
@@ -373,6 +373,8 @@ class NormalAdditionNode(NodeBase):
                     height=expression.intersect("Input0.height", "Input2.height"),
                     channels=3,
                 ),
+            ).with_never_reason(
+                "The given normal maps have different sizes but must be the same size."
             ),
         ]
         self.category = IMAGE_FILTER

--- a/backend/src/nodes/properties/outputs/base_output.py
+++ b/backend/src/nodes/properties/outputs/base_output.py
@@ -1,3 +1,4 @@
+from typing import Union
 from .. import expression
 
 
@@ -10,16 +11,22 @@ class BaseOutput:
         self.output_type = output_type
         self.label = label
         self.id = None
+        self.never_reason: Union[str, None] = None
 
     def toDict(self):
         return {
             "id": self.id,
             "type": self.output_type,
             "label": self.label,
+            "neverReason": self.never_reason,
         }
 
     def with_id(self, output_id: int):
         self.id = output_id
+        return self
+
+    def with_never_reason(self, reason: str):
+        self.never_reason = reason
         return self
 
     def __repr__(self):

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -51,6 +51,10 @@ export interface Input {
 export interface Output {
     readonly id: number;
     readonly type: ExpressionJson;
+    /**
+     * A likely reason as to why the (generic) type expression might evaluate to `never`.
+     */
+    readonly neverReason?: string | null;
     readonly label: string;
 }
 

--- a/src/common/types/function.ts
+++ b/src/common/types/function.ts
@@ -396,6 +396,9 @@ export class FunctionInstance {
                     definition.typeDefinitions,
                     genericParameters
                 );
+                if (type.type === 'never') {
+                    outputErrors.push({ outputId: id });
+                }
             } else {
                 type = definition.outputDefaults.get(id)!;
             }

--- a/src/common/types/function.ts
+++ b/src/common/types/function.ts
@@ -3,7 +3,7 @@ import { Input, InputSchemaValue, NodeSchema, Output } from '../common-types';
 import { EMPTY_MAP, topologicalSort } from '../util';
 import { evaluate } from './evaluate';
 import { Expression } from './expression';
-import { intersect } from './intersection';
+import { intersect, isDisjointWith } from './intersection';
 import { fromJson } from './json';
 import { TypeDefinitions } from './typedef';
 import { NonNeverType, Type } from './types';
@@ -424,8 +424,6 @@ export class FunctionInstance {
         if (!iType) throw new Error(`Invalid input id ${inputId}`);
 
         // we say that types A is assignable to type B if they are not disjoint
-        const overlap = intersect(type, iType);
-
-        return overlap.type !== 'never';
+        return !isDisjointWith(type, iType);
     }
 }

--- a/src/common/types/intersection.ts
+++ b/src/common/types/intersection.ts
@@ -202,3 +202,5 @@ export const intersect = (...types: Type[]): Type => {
 
     return performIntersection(items);
 };
+
+export const isDisjointWith = (a: Type, b: Type): boolean => intersect(a, b).type === 'never';

--- a/src/common/types/util.ts
+++ b/src/common/types/util.ts
@@ -3,11 +3,11 @@ import { Expression } from './expression';
 import {
     IntIntervalType,
     IntervalType,
-    NumberPrimitive,
     NumericLiteralType,
     StringLiteralType,
     StructType,
     Type,
+    UnionType,
     WithUnderlying,
 } from './types';
 
@@ -110,14 +110,18 @@ export const isStringLiteral = (type: Type): type is StringLiteralType => {
     return type.type === 'literal' && type.underlying === 'string';
 };
 
+export type IntNumberType =
+    | NumericLiteralType
+    | IntIntervalType
+    | UnionType<NumericLiteralType | IntIntervalType>;
 export const isImage = (
     type: Type
 ): type is StructType & {
     readonly name: 'Image';
     readonly fields: readonly [
-        { readonly name: 'width'; readonly type: NumberPrimitive },
-        { readonly name: 'height'; readonly type: NumberPrimitive },
-        { readonly name: 'channels'; readonly type: NumberPrimitive }
+        { readonly name: 'width'; readonly type: IntNumberType },
+        { readonly name: 'height'; readonly type: IntNumberType },
+        { readonly name: 'channels'; readonly type: IntNumberType }
     ];
 } => {
     return type.type === 'struct' && type.name === 'Image' && type.fields.length === 3;

--- a/src/common/types/util.ts
+++ b/src/common/types/util.ts
@@ -3,6 +3,7 @@ import { Expression } from './expression';
 import {
     IntIntervalType,
     IntervalType,
+    NumberPrimitive,
     NumericLiteralType,
     StringLiteralType,
     StructType,
@@ -107,4 +108,17 @@ export const isNumericLiteral = (type: Type): type is NumericLiteralType => {
 };
 export const isStringLiteral = (type: Type): type is StringLiteralType => {
     return type.type === 'literal' && type.underlying === 'string';
+};
+
+export const isImage = (
+    type: Type
+): type is StructType & {
+    readonly name: 'Image';
+    readonly fields: readonly [
+        { readonly name: 'width'; readonly type: NumberPrimitive },
+        { readonly name: 'height'; readonly type: NumberPrimitive },
+        { readonly name: 'channels'; readonly type: NumberPrimitive }
+    ];
+} => {
+    return type.type === 'struct' && type.name === 'Image' && type.fields.length === 3;
 };

--- a/src/renderer/components/TypeTag.tsx
+++ b/src/renderer/components/TypeTag.tsx
@@ -1,7 +1,7 @@
 import { Tag, useColorModeValue } from '@chakra-ui/react';
 import { memo } from 'react';
 import { Type } from '../../common/types/types';
-import { isNumericLiteral } from '../../common/types/util';
+import { isImage, isNumericLiteral } from '../../common/types/util';
 
 const getColorMode = (channels: number) => {
     switch (channels) {
@@ -21,7 +21,7 @@ const getTypeText = (type: Type): string[] => {
 
     const tags: string[] = [];
     if (type.type === 'struct') {
-        if (type.name === 'Image' && type.fields.length === 3) {
+        if (isImage(type)) {
             const [width, height, channels] = type.fields;
             if (isNumericLiteral(width.type) && isNumericLiteral(height.type)) {
                 tags.push(`${width.type.toString()}x${height.type.toString()}`);

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -3,7 +3,7 @@ import React, { memo, useMemo } from 'react';
 import { Connection, Handle, Node, Position, useReactFlow } from 'react-flow-renderer';
 import { useContext } from 'use-context-selector';
 import { NodeData } from '../../../common/common-types';
-import { intersect } from '../../../common/types/intersection';
+import { isDisjointWith } from '../../../common/types/intersection';
 import { Type } from '../../../common/types/types';
 import { parseHandle } from '../../../common/util';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
@@ -93,10 +93,7 @@ const InputContainer = memo(
                 target: id,
                 targetHandle: `${id}-${inputId}`,
             });
-            if (
-                connectionIsValid &&
-                intersect(connectingFromType, definitionType).type !== 'never'
-            ) {
+            if (connectionIsValid && !isDisjointWith(connectingFromType, definitionType)) {
                 return true;
             }
             return false;

--- a/src/renderer/components/node/IteratorHelperNode.tsx
+++ b/src/renderer/components/node/IteratorHelperNode.tsx
@@ -34,6 +34,10 @@ const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodeProps) =>
     const schema = schemata.get(schemaId);
     const { inputs, outputs, icon, category, name } = schema;
 
+    const functionInstance = useContextSelector(GlobalVolatileContext, (c) =>
+        c.typeState.functions.get(id)
+    );
+
     const regularBorderColor = useColorModeValue('gray.100', 'gray.800');
     const accentColor = getAccentColor(category);
     const borderColor = useMemo(
@@ -44,7 +48,9 @@ const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodeProps) =>
     const [validity, setValidity] = useState(VALID);
     useEffect(() => {
         if (inputs.length) {
-            setValidity(checkNodeValidity({ id, inputs, inputData, edges: getEdges() }));
+            setValidity(
+                checkNodeValidity({ id, schema, inputData, edges: getEdges(), functionInstance })
+            );
         }
     }, [inputData, edgeChanges, getEdges]);
 

--- a/src/renderer/components/node/IteratorHelperNode.tsx
+++ b/src/renderer/components/node/IteratorHelperNode.tsx
@@ -60,7 +60,7 @@ const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodeProps) =>
                 })
             );
         }
-    }, [inputData, edgeChanges, getEdges]);
+    }, [inputData, edgeChanges, getEdges, functionInstance, typeDefinitions]);
 
     const disabledStatus = useMemo(
         () => getDisabledStatus(data, effectivelyDisabledNodes),

--- a/src/renderer/components/node/IteratorHelperNode.tsx
+++ b/src/renderer/components/node/IteratorHelperNode.tsx
@@ -4,7 +4,7 @@ import { useReactFlow } from 'react-flow-renderer';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { EdgeData, NodeData } from '../../../common/common-types';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
-import checkNodeValidity, { VALID } from '../../helpers/checkNodeValidity';
+import { VALID, checkNodeValidity } from '../../helpers/checkNodeValidity';
 import { shadeColor } from '../../helpers/colorTools';
 import { DisabledStatus, getDisabledStatus } from '../../helpers/disabled';
 import getAccentColor from '../../helpers/getNodeAccentColors';

--- a/src/renderer/components/node/IteratorHelperNode.tsx
+++ b/src/renderer/components/node/IteratorHelperNode.tsx
@@ -24,7 +24,8 @@ const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodeProps) =>
         GlobalVolatileContext,
         (c) => c.effectivelyDisabledNodes
     );
-    const { schemata, updateIteratorBounds, setHoveredNode } = useContext(GlobalContext);
+    const { schemata, updateIteratorBounds, setHoveredNode, typeDefinitions } =
+        useContext(GlobalContext);
     const { getEdges } = useReactFlow<NodeData, EdgeData>();
 
     const { id, inputData, isLocked, parentNode, schemaId, animated = false } = data;
@@ -49,7 +50,14 @@ const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodeProps) =>
     useEffect(() => {
         if (inputs.length) {
             setValidity(
-                checkNodeValidity({ id, schema, inputData, edges: getEdges(), functionInstance })
+                checkNodeValidity({
+                    id,
+                    schema,
+                    inputData,
+                    edges: getEdges(),
+                    functionInstance,
+                    typeDefinitions,
+                })
             );
         }
     }, [inputData, edgeChanges, getEdges]);

--- a/src/renderer/components/node/IteratorNode.tsx
+++ b/src/renderer/components/node/IteratorNode.tsx
@@ -31,7 +31,7 @@ const IteratorNodeWrapper = memo(({ data, selected }: IteratorNodeProps) => (
 
 const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => {
     const edgeChanges = useContextSelector(GlobalVolatileContext, (c) => c.edgeChanges);
-    const { schemata } = useContext(GlobalContext);
+    const { schemata, typeDefinitions } = useContext(GlobalContext);
     const { getEdges } = useReactFlow<NodeData, EdgeData>();
 
     const {
@@ -72,6 +72,7 @@ const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => {
                     inputData,
                     edges: getEdges(),
                     functionInstance,
+                    typeDefinitions,
                 })
             );
         }

--- a/src/renderer/components/node/IteratorNode.tsx
+++ b/src/renderer/components/node/IteratorNode.tsx
@@ -76,7 +76,7 @@ const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => {
                 })
             );
         }
-    }, [inputData, edgeChanges, functionInstance]);
+    }, [inputData, edgeChanges, functionInstance, typeDefinitions]);
 
     const iteratorBoxRef = useRef<HTMLDivElement | null>(null);
 

--- a/src/renderer/components/node/IteratorNode.tsx
+++ b/src/renderer/components/node/IteratorNode.tsx
@@ -4,7 +4,7 @@ import { useReactFlow } from 'react-flow-renderer';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { EdgeData, NodeData } from '../../../common/common-types';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
-import checkNodeValidity, { VALID } from '../../helpers/checkNodeValidity';
+import { VALID, checkNodeValidity } from '../../helpers/checkNodeValidity';
 import { shadeColor } from '../../helpers/colorTools';
 import { DisabledStatus } from '../../helpers/disabled';
 import getAccentColor from '../../helpers/getNodeAccentColors';

--- a/src/renderer/components/node/IteratorNode.tsx
+++ b/src/renderer/components/node/IteratorNode.tsx
@@ -48,7 +48,12 @@ const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => {
 
     // We get inputs and outputs this way in case something changes with them in the future
     // This way, we have to do less in the migration file
-    const { inputs, outputs, icon, category, name } = schemata.get(schemaId);
+    const schema = schemata.get(schemaId);
+    const { inputs, outputs, icon, category, name } = schema;
+
+    const functionInstance = useContextSelector(GlobalVolatileContext, (c) =>
+        c.typeState.functions.get(id)
+    );
 
     const regularBorderColor = useColorModeValue('gray.100', 'gray.800');
     const accentColor = getAccentColor(category);
@@ -63,13 +68,14 @@ const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => {
             setValidity(
                 checkNodeValidity({
                     id,
-                    inputs,
+                    schema,
                     inputData,
                     edges: getEdges(),
+                    functionInstance,
                 })
             );
         }
-    }, [inputData, edgeChanges]);
+    }, [inputData, edgeChanges, functionInstance]);
 
     const iteratorBoxRef = useRef<HTMLDivElement | null>(null);
 

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -85,7 +85,7 @@ const Node = memo(({ data, selected }: NodeProps) => {
                 })
             );
         }
-    }, [inputData, edgeChanges, functionInstance]);
+    }, [inputData, edgeChanges, functionInstance, typeDefinitions]);
 
     const targetRef = useRef<HTMLDivElement>(null);
     const [checkedSize, setCheckedSize] = useState(false);

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -6,7 +6,7 @@ import { useContext, useContextSelector } from 'use-context-selector';
 import { EdgeData, Input, NodeData } from '../../../common/common-types';
 import { AlertBoxContext } from '../../contexts/AlertBoxContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
-import checkNodeValidity, { VALID } from '../../helpers/checkNodeValidity';
+import { VALID, checkNodeValidity } from '../../helpers/checkNodeValidity';
 import { shadeColor } from '../../helpers/colorTools';
 import { getSingleFileWithExtension } from '../../helpers/dataTransfer';
 import { DisabledStatus } from '../../helpers/disabled';

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -60,6 +60,10 @@ const Node = memo(({ data, selected }: NodeProps) => {
     const schema = schemata.get(schemaId);
     const { inputs, outputs, icon, category, name } = schema;
 
+    const functionInstance = useContextSelector(GlobalVolatileContext, (c) =>
+        c.typeState.functions.get(id)
+    );
+
     const regularBorderColor = useColorModeValue('gray.200', 'gray.800');
     const accentColor = getAccentColor(category);
     const borderColor = useMemo(
@@ -70,9 +74,11 @@ const Node = memo(({ data, selected }: NodeProps) => {
     const [validity, setValidity] = useState(VALID);
     useEffect(() => {
         if (inputs.length) {
-            setValidity(checkNodeValidity({ id, inputs, inputData, edges: getEdges() }));
+            setValidity(
+                checkNodeValidity({ id, schema, inputData, edges: getEdges(), functionInstance })
+            );
         }
-    }, [inputData, edgeChanges]);
+    }, [inputData, edgeChanges, functionInstance]);
 
     const targetRef = useRef<HTMLDivElement>(null);
     const [checkedSize, setCheckedSize] = useState(false);

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -49,7 +49,7 @@ interface NodeProps {
 const Node = memo(({ data, selected }: NodeProps) => {
     const { sendToast } = useContext(AlertBoxContext);
     const edgeChanges = useContextSelector(GlobalVolatileContext, (c) => c.edgeChanges);
-    const { schemata, updateIteratorBounds, setHoveredNode, useInputData } =
+    const { schemata, updateIteratorBounds, setHoveredNode, useInputData, typeDefinitions } =
         useContext(GlobalContext);
     const { getEdges } = useReactFlow<NodeData, EdgeData>();
 
@@ -75,7 +75,14 @@ const Node = memo(({ data, selected }: NodeProps) => {
     useEffect(() => {
         if (inputs.length) {
             setValidity(
-                checkNodeValidity({ id, schema, inputData, edges: getEdges(), functionInstance })
+                checkNodeValidity({
+                    id,
+                    schema,
+                    inputData,
+                    edges: getEdges(),
+                    functionInstance,
+                    typeDefinitions,
+                })
             );
         }
     }, [inputData, edgeChanges, functionInstance]);

--- a/src/renderer/components/outputs/OutputContainer.tsx
+++ b/src/renderer/components/outputs/OutputContainer.tsx
@@ -2,7 +2,7 @@ import { Box, Center, HStack, chakra, useColorModeValue } from '@chakra-ui/react
 import React, { memo, useMemo } from 'react';
 import { Connection, Handle, Position, useReactFlow } from 'react-flow-renderer';
 import { useContext } from 'use-context-selector';
-import { intersect } from '../../../common/types/intersection';
+import { isDisjointWith } from '../../../common/types/intersection';
 import { Type } from '../../../common/types/types';
 import { parseHandle } from '../../../common/util';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
@@ -85,10 +85,7 @@ const OutputContainer = memo(
                 target: connectingFrom.nodeId,
                 targetHandle: connectingFrom.handleId,
             });
-            if (
-                connectionIsValid &&
-                intersect(connectingFromType, definitionType).type !== 'never'
-            ) {
+            if (connectionIsValid && !isDisjointWith(connectingFromType, definitionType)) {
                 return true;
             }
             return false;

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -114,7 +114,8 @@ export const ExecutionContext = createContext<Readonly<ExecutionContextValue>>(
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>) => {
-    const { schemata, useAnimate, setIteratorPercent, typeStateRef } = useContext(GlobalContext);
+    const { schemata, useAnimate, setIteratorPercent, typeStateRef, typeDefinitions } =
+        useContext(GlobalContext);
     const { useIsCpu, useIsFp16, port } = useContext(SettingsContext);
     const { sendAlert } = useContext(AlertBoxContext);
 
@@ -260,6 +261,7 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
                     edges,
                     schema,
                     functionInstance,
+                    typeDefinitions,
                 });
                 if (validity.isValid) return [];
 

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -114,7 +114,7 @@ export const ExecutionContext = createContext<Readonly<ExecutionContextValue>>(
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>) => {
-    const { schemata, useAnimate, setIteratorPercent } = useContext(GlobalContext);
+    const { schemata, useAnimate, setIteratorPercent, typeStateRef } = useContext(GlobalContext);
     const { useIsCpu, useIsFp16, port } = useContext(SettingsContext);
     const { sendAlert } = useContext(AlertBoxContext);
 
@@ -251,12 +251,15 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
             setStatus(ExecutionStatus.READY);
         } else {
             const invalidNodes = nodes.flatMap((node) => {
-                const { inputs, category, name } = schemata.get(node.data.schemaId);
+                const functionInstance = typeStateRef.current.functions.get(node.data.id);
+                const schema = schemata.get(node.data.schemaId);
+                const { category, name } = schema;
                 const validity = checkNodeValidity({
                     id: node.id,
                     inputData: node.data.inputData,
                     edges,
-                    inputs,
+                    schema,
+                    functionInstance,
                 });
                 if (validity.isValid) return [];
 

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -7,7 +7,7 @@ import { EdgeData, EdgeHandle, NodeData, UsableData } from '../../common/common-
 import { ipcRenderer } from '../../common/safeIpc';
 import { SchemaMap } from '../../common/SchemaMap';
 import { ParsedHandle, parseHandle } from '../../common/util';
-import checkNodeValidity from '../helpers/checkNodeValidity';
+import { checkNodeValidity } from '../helpers/checkNodeValidity';
 import { getEffectivelyDisabledNodes } from '../helpers/disabled';
 import { useAsyncEffect } from '../hooks/useAsyncEffect';
 import {

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -1,6 +1,6 @@
 import log from 'electron-log';
 import { dirname } from 'path';
-import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
     Connection,
     Edge,
@@ -112,6 +112,7 @@ interface Global {
     setManualOutputType: (nodeId: string, outputId: number, type: Expression | undefined) => void;
     functionDefinitions: Map<SchemaId, FunctionDefinition>;
     typeDefinitions: TypeDefinitions;
+    typeStateRef: Readonly<React.MutableRefObject<TypeState>>;
 }
 
 export interface NodeProto {
@@ -264,6 +265,7 @@ export const GlobalProvider = memo(
         );
 
         const [typeState, setTypeState] = useState(TypeState.empty);
+        const typeStateRef = useRef(typeState);
         useEffect(() => {
             const timerId = setTimeout(() => {
                 const nodeMap = new Map(getNodes().map((n) => [n.id, n]));
@@ -284,6 +286,7 @@ export const GlobalProvider = memo(
                     functionDefinitions
                 );
                 setTypeState(types);
+                typeStateRef.current = types;
             }, 100);
             return () => clearTimeout(timerId);
         }, [nodeChanges, edgeChanges, manualOutputTypes, functionDefinitions]);
@@ -981,6 +984,7 @@ export const GlobalProvider = memo(
             setManualOutputType,
             functionDefinitions,
             typeDefinitions,
+            typeStateRef,
         });
 
         return (

--- a/src/renderer/helpers/TypeState.ts
+++ b/src/renderer/helpers/TypeState.ts
@@ -2,7 +2,13 @@ import { Edge, Node } from 'react-flow-renderer';
 import { EdgeData, NodeData, SchemaId } from '../../common/common-types';
 import { EvaluationError } from '../../common/types/evaluate';
 import { FunctionDefinition, FunctionInstance } from '../../common/types/function';
-import { NumericLiteralType, StringLiteralType, StructType, Type } from '../../common/types/types';
+import {
+    NonNeverType,
+    NumericLiteralType,
+    StringLiteralType,
+    StructType,
+    Type,
+} from '../../common/types/types';
 import { EMPTY_MAP, parseHandle } from '../../common/util';
 
 export class TypeState {
@@ -33,9 +39,8 @@ export class TypeState {
 
         const functions = new Map<string, FunctionInstance>();
         const evaluationErrors = new Map<string, EvaluationError>();
-        const edgesToCheck: [nodeId: string, inputId: number][] = [];
 
-        const getSourceType = (id: string, inputId: number): Type | undefined => {
+        const getSourceType = (id: string, inputId: number): NonNeverType | undefined => {
             const edge = byTargetHandle.get(`${id}-${inputId}`);
             if (edge && edge.sourceHandle) {
                 const sourceHandle = parseHandle(edge.sourceHandle);
@@ -61,13 +66,9 @@ export class TypeState {
             try {
                 instance = FunctionInstance.fromPartialInputs(
                     definition,
-                    (id): Type | undefined => {
+                    (id): NonNeverType | undefined => {
                         const edgeSource = getSourceType(n.id, id);
                         if (edgeSource) {
-                            if (edgeSource.type !== 'never') {
-                                // we want to check non-trivial edges
-                                edgesToCheck.push([n.id, id]);
-                            }
                             return edgeSource;
                         }
 

--- a/src/renderer/helpers/checkNodeValidity.ts
+++ b/src/renderer/helpers/checkNodeValidity.ts
@@ -1,6 +1,9 @@
 import { Edge } from 'react-flow-renderer';
 import { EdgeData, InputData, NodeSchema } from '../../common/common-types';
+import { evaluate } from '../../common/types/evaluate';
+import { IntersectionExpression, NamedExpression } from '../../common/types/expression';
 import { FunctionInstance } from '../../common/types/function';
+import { TypeDefinitions } from '../../common/types/typedef';
 import { parseHandle } from '../../common/util';
 
 export type Validity =
@@ -15,6 +18,7 @@ export interface CheckNodeValidityOptions {
     inputData: InputData;
     edges: readonly Edge<EdgeData>[];
     functionInstance: FunctionInstance | undefined;
+    typeDefinitions: TypeDefinitions;
 }
 export const checkNodeValidity = ({
     id,
@@ -22,6 +26,7 @@ export const checkNodeValidity = ({
     inputData,
     edges,
     functionInstance,
+    typeDefinitions,
 }: CheckNodeValidityOptions): Validity => {
     const targetedInputs = edges
         .filter((e) => e.target === id && e.targetHandle)

--- a/src/renderer/helpers/checkNodeValidity.ts
+++ b/src/renderer/helpers/checkNodeValidity.ts
@@ -128,15 +128,15 @@ export const checkNodeValidity = ({
                 }
             }
         }
-        for (const { outputId } of functionInstance.outputErrors) {
-            const output = schema.inputs.find((o) => o.id === outputId)!;
 
-            if (output) {
-                return {
-                    isValid: false,
-                    reason: `Some inputs are incompatible with each other.`,
-                };
-            }
+        // eslint-disable-next-line no-unreachable-loop
+        for (const { outputId } of functionInstance.outputErrors) {
+            const output = schema.outputs.find((o) => o.id === outputId)!;
+
+            return {
+                isValid: false,
+                reason: `Some inputs are incompatible with each other. ${output.neverReason ?? ''}`,
+            };
         }
     }
 

--- a/src/renderer/helpers/checkNodeValidity.ts
+++ b/src/renderer/helpers/checkNodeValidity.ts
@@ -1,5 +1,6 @@
 import { Edge } from 'react-flow-renderer';
-import { EdgeData, Input, InputData } from '../../common/common-types';
+import { EdgeData, InputData, NodeSchema } from '../../common/common-types';
+import { FunctionInstance } from '../../common/types/function';
 import { parseHandle } from '../../common/util';
 
 export type Validity =
@@ -10,21 +11,23 @@ export const VALID: Validity = { isValid: true };
 
 export interface CheckNodeValidityOptions {
     id: string;
-    inputs: Input[];
+    schema: NodeSchema;
     inputData: InputData;
     edges: readonly Edge<EdgeData>[];
+    functionInstance: FunctionInstance | undefined;
 }
 export const checkNodeValidity = ({
     id,
-    inputs,
+    schema,
     inputData,
     edges,
+    functionInstance,
 }: CheckNodeValidityOptions): Validity => {
     const targetedInputs = edges
         .filter((e) => e.target === id && e.targetHandle)
         .map((e) => parseHandle(e.targetHandle!).inOutId);
 
-    const missingInputs = inputs.filter((input) => {
+    const missingInputs = schema.inputs.filter((input) => {
         // optional inputs can't be missing
         if (input.optional) return false;
 

--- a/src/renderer/helpers/checkNodeValidity.ts
+++ b/src/renderer/helpers/checkNodeValidity.ts
@@ -8,17 +8,18 @@ export type Validity =
 
 export const VALID: Validity = { isValid: true };
 
-const checkNodeValidity = ({
-    id,
-    inputs,
-    inputData,
-    edges,
-}: {
+export interface CheckNodeValidityOptions {
     id: string;
     inputs: Input[];
     inputData: InputData;
     edges: readonly Edge<EdgeData>[];
-}): Validity => {
+}
+export const checkNodeValidity = ({
+    id,
+    inputs,
+    inputData,
+    edges,
+}: CheckNodeValidityOptions): Validity => {
     const targetedInputs = edges
         .filter((e) => e.target === id && e.targetHandle)
         .map((e) => parseHandle(e.targetHandle!).inOutId);
@@ -47,5 +48,3 @@ const checkNodeValidity = ({
     }
     return VALID;
 };
-
-export default checkNodeValidity;

--- a/src/renderer/helpers/getTypeAccentColors.ts
+++ b/src/renderer/helpers/getTypeAccentColors.ts
@@ -1,6 +1,6 @@
 import { evaluate } from '../../common/types/evaluate';
 import { NamedExpression } from '../../common/types/expression';
-import { intersect } from '../../common/types/intersection';
+import { isDisjointWith } from '../../common/types/intersection';
 import { TypeDefinitions } from '../../common/types/typedef';
 import { NumberType, StringType, Type } from '../../common/types/types';
 
@@ -20,7 +20,7 @@ const colorList = (typeDefinitions: TypeDefinitions) => [
 export default (inputType: Type, typeDefinitions: TypeDefinitions, isDarkMode = true): string[] => {
     const colors: string[] = [];
     for (const { type, color } of colorList(typeDefinitions)) {
-        if (intersect(type, inputType).type !== 'never') {
+        if (!isDisjointWith(type, inputType)) {
             colors.push(color);
         }
     }

--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -16,7 +16,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Node, OnConnectStartParams, useReactFlow } from 'react-flow-renderer';
 import { useContext } from 'use-context-selector';
 import { NodeData, NodeSchema } from '../../common/common-types';
-import { intersect } from '../../common/types/intersection';
+import { isDisjointWith } from '../../common/types/intersection';
 import { Type } from '../../common/types/types';
 import { assertNever, createUniqueId, parseHandle } from '../../common/util';
 import { IconFactory } from '../components/CustomIcons';
@@ -91,9 +91,8 @@ export const usePaneNodeSearchMenu = (
                         }
 
                         return [...targetTypes.inputDefaults].some(([number, type]) => {
-                            const overlap = intersect(type, sourceType);
                             return (
-                                overlap.type !== 'never' &&
+                                !isDisjointWith(type, sourceType) &&
                                 schemata.get(node.schemaId).inputs[number].hasHandle
                             );
                         });
@@ -120,8 +119,7 @@ export const usePaneNodeSearchMenu = (
                         }
 
                         return [...targetTypes.outputDefaults].some(([, type]) => {
-                            const overlap = intersect(type, sourceType);
-                            return overlap.type !== 'never';
+                            return !isDisjointWith(type, sourceType);
                         });
                     }
                     default:
@@ -169,9 +167,8 @@ export const usePaneNodeSearchMenu = (
                     case 'source': {
                         const firstPossibleTarget = [...targetTypes.inputDefaults].find(
                             ([inputId, type]) => {
-                                const overlap = intersect(type, connectingFromType);
                                 return (
-                                    overlap.type !== 'never' &&
+                                    !isDisjointWith(type, connectingFromType) &&
                                     schemata.get(schema.schemaId).inputs[inputId].hasHandle
                                 );
                             }
@@ -189,8 +186,7 @@ export const usePaneNodeSearchMenu = (
                     case 'target': {
                         const firstPossibleTarget = [...targetTypes.outputDefaults].find(
                             ([, type]) => {
-                                const overlap = intersect(type, connectingFromType);
-                                return overlap.type !== 'never';
+                                return !isDisjointWith(type, connectingFromType);
                             }
                         );
                         if (firstPossibleTarget) {


### PR DESCRIPTION
The main feature is that I added type errors. I already shared examples on Discord, so I won't do so here. Type errors work as follows:

- When an output type evaluates to `never`, the node will become invalid. An appropriate reason will be given if available. Otherwise, a generic "Some inputs are incompatible with each other." message will be displayed.
- When an incompatible type is assigned to an input, the node will only become invalid if we can describe the mismatch. This is to prevent users getting cryptic type errors. This might sound like a limitation (and it is), but it isn't important. Users can't connect invalid types, so only generic inputs can cause these errors, and we currently have 1 generic input and I don't expect there to be much more in the near future.

Minor changes:
- I added a `isDisjointWith` method for types. No more `intersect(a, b).type === "never"`.
- I added a small util method to tell whether a type is an `Image` struct.
- A lot of types in the function definitions must never be `never`. I changed some types to ensure this guarantee, which uncovered a bit of unused code (branches with conditions that can never become true).