### PR TITLE
Better output types for upscale nodes

### DIFF
--- a/backend/src/nodes/ncnn_nodes.py
+++ b/backend/src/nodes/ncnn_nodes.py
@@ -144,7 +144,20 @@ class NcnnUpscaleImageNode(NodeBase):
             ImageInput(),
             NumberInput("Tile Size Target", default=0, minimum=0, maximum=None),
         ]
-        self.outputs = [ImageOutput()]
+        self.outputs = [
+            ImageOutput(
+                image_type=expression.Image(
+                    channels=expression.named(
+                        "UpscaleChannels",
+                        {
+                            "imageChannels": "Input1.channels",
+                            "inputChannels": 3,
+                            "outputChannels": 3,
+                        },
+                    )
+                )
+            )
+        ]
         self.category = NCNN
         self.name = "Upscale Image"
         self.icon = "NCNN"

--- a/backend/src/nodes/onnx_nodes.py
+++ b/backend/src/nodes/onnx_nodes.py
@@ -92,7 +92,17 @@ class OnnxImageUpscaleNode(NodeBase):
             ImageInput(),
             NumberInput("Tile Size Target", default=0, minimum=0, maximum=None),
         ]
-        self.outputs = [ImageOutput("Upscaled Image")]
+        self.outputs = [
+            ImageOutput(
+                "Upscaled Image",
+                image_type=expression.Image(
+                    channels=expression.named(
+                        "UpscaleChannels",
+                        {"imageChannels": "Input1.channels"},
+                    )
+                ),
+            )
+        ]
 
         self.category = ONNX
         self.name = "Upscale Image"

--- a/backend/src/nodes/pytorch_nodes.py
+++ b/backend/src/nodes/pytorch_nodes.py
@@ -141,7 +141,14 @@ class ImageUpscaleNode(NodeBase):
                 expression.Image(
                     width=expression.fn("multiply", "Input0.scale", "Input1.width"),
                     height=expression.fn("multiply", "Input0.scale", "Input1.height"),
-                    channels=["Input0.outputChannels", "Input1.channels"],
+                    channels=expression.named(
+                        "UpscaleChannels",
+                        {
+                            "imageChannels": "Input1.channels",
+                            "inputChannels": "Input0.inputChannels",
+                            "outputChannels": "Input0.outputChannels",
+                        },
+                    ),
                 ),
             )
         ]


### PR DESCRIPTION
This adds an alias type that correctly calculates the number of output channels of an upscaled image.