### PR TITLE
Better output type for merge channels node

### DIFF
--- a/backend/src/nodes/image_chan_nodes.py
+++ b/backend/src/nodes/image_chan_nodes.py
@@ -166,7 +166,40 @@ class ChannelMergeRGBANode(NodeBase):
         ]
         self.outputs = [
             ImageOutput(
-                image_type=expression.Image(size_as="Input0", channels=[1, 3, 4])
+                image_type=expression.Image(
+                    size_as="Input0",
+                    channels=expression.match(
+                        expression.fn(
+                            "add",
+                            "Input0.channels",
+                            expression.fn(
+                                "add",
+                                expression.match(
+                                    "Input1",
+                                    ("Image", "i", "i.channels"),
+                                    default=0,
+                                ),
+                                expression.fn(
+                                    "add",
+                                    expression.match(
+                                        "Input2",
+                                        ("Image", "i", "i.channels"),
+                                        default=0,
+                                    ),
+                                    expression.match(
+                                        "Input3",
+                                        ("Image", "i", "i.channels"),
+                                        default=0,
+                                    ),
+                                ),
+                            ),
+                        ),
+                        (1, None, 1),
+                        (2, None, 3),
+                        (3, None, 3),
+                        (expression.int_interval(min=4), None, 4),
+                    ),
+                )
             )
         ]
         self.category = IMAGE_CHANNEL

--- a/backend/src/nodes/image_dim_nodes.py
+++ b/backend/src/nodes/image_dim_nodes.py
@@ -221,7 +221,7 @@ class BorderCropNode(NodeBase):
                             "Input0.width",
                             expression.fn("add", "Input1", "Input1"),
                         ),
-                        expression.int_interval(min=1, max=None),
+                        expression.int_interval(min=1),
                     ),
                     height=expression.intersect(
                         expression.fn(
@@ -229,7 +229,7 @@ class BorderCropNode(NodeBase):
                             "Input0.height",
                             expression.fn("add", "Input1", "Input1"),
                         ),
-                        expression.int_interval(min=1, max=None),
+                        expression.int_interval(min=1),
                     ),
                     channels_as="Input0",
                 )
@@ -276,7 +276,7 @@ class EdgeCropNode(NodeBase):
                             "Input0.width",
                             expression.fn("add", "Input2", "Input3"),
                         ),
-                        expression.int_interval(min=1, max=None),
+                        expression.int_interval(min=1),
                     ),
                     height=expression.intersect(
                         expression.fn(
@@ -284,7 +284,7 @@ class EdgeCropNode(NodeBase):
                             "Input0.height",
                             expression.fn("add", "Input1", "Input4"),
                         ),
-                        expression.int_interval(min=1, max=None),
+                        expression.int_interval(min=1),
                     ),
                     channels_as="Input0",
                 )

--- a/backend/src/nodes/image_util_nodes.py
+++ b/backend/src/nodes/image_util_nodes.py
@@ -418,7 +418,7 @@ class ImageMetricsNode(NodeBase):
         ]
         self.outputs = [
             NumberOutput("MSE", expression.interval(0, 1)),
-            NumberOutput("PSNR", expression.interval(0, float("inf"))),
+            NumberOutput("PSNR", expression.interval(0)),
             NumberOutput("SSIM", expression.interval(0, 1)),
         ]
         self.category = IMAGE_UTILITY

--- a/backend/src/nodes/properties/expression.py
+++ b/backend/src/nodes/properties/expression.py
@@ -119,8 +119,8 @@ def literal(value: Union[str, int, float]) -> ExpressionJson:
 
 
 def interval(
-    min: Union[int, float, None],
-    max: Union[int, float, None],
+    min: Union[int, float, None] = None,
+    max: Union[int, float, None] = None,
 ) -> ExpressionJson:
     return {
         "type": "interval",
@@ -130,8 +130,8 @@ def interval(
 
 
 def int_interval(
-    min: Union[int, float, None],
-    max: Union[int, float, None],
+    min: Union[int, float, None] = None,
+    max: Union[int, float, None] = None,
 ) -> ExpressionJson:
     return {
         "type": "int-interval",


### PR DESCRIPTION
With the new `match`, it's easy to determine the number of output channels of the Merge Channels node. I know that the node is deprecated, but might as well.

I also made the API of `expression.interval` and `expression.int_interval` a bit easier to work with.