### PR TITLE
Fixed output type of Flip node

### DIFF
--- a/backend/src/nodes/image_util_nodes.py
+++ b/backend/src/nodes/image_util_nodes.py
@@ -377,15 +377,7 @@ class FlipNode(NodeBase):
             ImageInput("Image"),
             FlipAxisInput(),
         ]
-        self.outputs = [
-            ImageOutput(
-                image_type=expression.Image(
-                    width=["Input0.width", "Input0.height"],
-                    height=["Input0.width", "Input0.height"],
-                    channels_as="Input0",
-                )
-            )
-        ]
+        self.outputs = [ImageOutput(image_type="Input0")]
         self.category = IMAGE_UTILITY
         self.name = "Flip"
         self.icon = "MdFlip"


### PR DESCRIPTION
When you flip an image, its width and height stays the same. So image output type is the same as the input type.