### PR TITLE
Added types for input ids and output ids

### DIFF
--- a/src/common/SchemaMap.ts
+++ b/src/common/SchemaMap.ts
@@ -1,5 +1,5 @@
 import log from 'electron-log';
-import { InputData, InputValue, NodeSchema, SchemaId } from './common-types';
+import { InputData, InputId, InputValue, NodeSchema, SchemaId } from './common-types';
 
 const BLANK_SCHEMA: NodeSchema = {
     inputs: [],
@@ -38,7 +38,7 @@ export class SchemaMap {
     }
 
     getDefaultInput(schemaId: SchemaId): InputData {
-        const defaultData: Record<number, InputValue> = {};
+        const defaultData: Record<InputId, InputValue> = {};
         const { inputs } = this.get(schemaId);
         inputs.forEach((input) => {
             if (input.def || input.def === 0) {

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -17,6 +17,8 @@ export interface IteratorSize extends Size {
 }
 
 export type SchemaId = string & { readonly __schemaId: never };
+export type InputId = number & { readonly __inputId: never };
+export type OutputId = number & { readonly __outputId: never };
 
 export type InputValue = InputSchemaValue | undefined;
 export type InputSchemaValue = string | number;
@@ -36,7 +38,7 @@ export type InputKind =
     | 'generic';
 export type FileInputKind = 'image' | 'pth' | 'pt' | 'video' | 'bin' | 'param' | 'onnx';
 export interface Input {
-    readonly id: number;
+    readonly id: InputId;
     readonly type: ExpressionJson;
     readonly kind: InputKind;
     readonly label: string;
@@ -49,7 +51,7 @@ export interface Input {
     readonly filetypes?: string[];
 }
 export interface Output {
-    readonly id: number;
+    readonly id: OutputId;
     readonly type: ExpressionJson;
     /**
      * A likely reason as to why the (generic) type expression might evaluate to `never`.
@@ -58,7 +60,7 @@ export interface Output {
     readonly label: string;
 }
 
-export type InputData = Readonly<Record<number, InputValue>>;
+export type InputData = Readonly<Record<InputId, InputValue>>;
 
 export interface NodeSchema {
     readonly name: string;

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -2,6 +2,7 @@ import { constants } from 'fs';
 import fs from 'fs/promises';
 import { LocalStorage } from 'node-localstorage';
 import { v4 as uuid4, v5 as uuid5 } from 'uuid';
+import type { InputId, OutputId } from './common-types';
 
 export const EMPTY_ARRAY: readonly never[] = [];
 export const EMPTY_SET: ReadonlySet<never> = new Set<never>();
@@ -22,16 +23,18 @@ export const assertType: <T>(_: T) => void = noop;
 
 export const deepCopy = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
 
-export interface ParsedHandle {
+export interface ParsedHandle<Id extends InputId | OutputId = InputId | OutputId> {
     nodeId: string;
-    inOutId: number;
+    inOutId: Id;
 }
-export const parseHandle = (handle: string): ParsedHandle => {
+const parseHandle = (handle: string): ParsedHandle => {
     return {
         nodeId: handle.substring(0, 36), // uuid
-        inOutId: Number(handle.substring(37)),
+        inOutId: Number(handle.substring(37)) as InputId | OutputId,
     };
 };
+export const parseSourceHandle = parseHandle as (handle: string) => ParsedHandle<OutputId>;
+export const parseTargetHandle = parseHandle as (handle: string) => ParsedHandle<InputId>;
 
 export const getLocalStorage = (): Storage => {
     const storage = (global as Record<string, unknown>).customLocalStorage;

--- a/src/renderer/components/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge.tsx
@@ -5,7 +5,7 @@ import { TbUnlink } from 'react-icons/tb';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { useDebouncedCallback } from 'use-debounce';
 import { EdgeData, NodeData } from '../../common/common-types';
-import { parseHandle } from '../../common/util';
+import { parseSourceHandle } from '../../common/util';
 import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { SettingsContext } from '../contexts/SettingsContext';
 import { shadeColor } from '../helpers/colorTools';
@@ -60,7 +60,7 @@ export const CustomEdge = memo(
 
         const [isHovered, setIsHovered] = useState(false);
 
-        const { inOutId } = useMemo(() => parseHandle(sourceHandleId!), [sourceHandleId]);
+        const { inOutId } = useMemo(() => parseSourceHandle(sourceHandleId!), [sourceHandleId]);
         const type = functionDefinitions
             .get(parentNode.data.schemaId)!
             .outputDefaults.get(inOutId)!;

--- a/src/renderer/components/inputs/FileInput.tsx
+++ b/src/renderer/components/inputs/FileInput.tsx
@@ -15,7 +15,7 @@ import { DragEvent, memo, useEffect } from 'react';
 import { BsFileEarmarkPlus } from 'react-icons/bs';
 import { MdContentCopy, MdFolder } from 'react-icons/md';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { FileInputKind } from '../../../common/common-types';
+import { FileInputKind, InputId } from '../../../common/common-types';
 import { ipcRenderer } from '../../../common/safeIpc';
 import { checkFileExists } from '../../../common/util';
 import { AlertBoxContext } from '../../contexts/AlertBoxContext';
@@ -56,7 +56,7 @@ export const FileInput = memo(
         // the file inputs directly
         if (label.toUpperCase().includes('NCNN') && label.toLowerCase().includes('bin')) {
             // eslint-disable-next-line react-hooks/rules-of-hooks
-            const [paramFilePath] = useInputData<string>(inputId - 1);
+            const [paramFilePath] = useInputData<string>((inputId - 1) as InputId);
             // eslint-disable-next-line react-hooks/rules-of-hooks
             useEffect(() => {
                 (async () => {
@@ -72,7 +72,7 @@ export const FileInput = memo(
         }
         if (label.toUpperCase().includes('NCNN') && label.toLowerCase().includes('param')) {
             // eslint-disable-next-line react-hooks/rules-of-hooks
-            const [binFilePath] = useInputData<string>(inputId + 1);
+            const [binFilePath] = useInputData<string>((inputId + 1) as InputId);
             // eslint-disable-next-line react-hooks/rules-of-hooks
             useEffect(() => {
                 (async () => {

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -2,10 +2,10 @@ import { Box, Center, HStack, Tag, Text, chakra, useColorModeValue } from '@chak
 import React, { memo, useMemo } from 'react';
 import { Connection, Handle, Node, Position, useReactFlow } from 'react-flow-renderer';
 import { useContext } from 'use-context-selector';
-import { NodeData } from '../../../common/common-types';
+import { InputId, NodeData } from '../../../common/common-types';
 import { isDisjointWith } from '../../../common/types/intersection';
 import { Type } from '../../../common/types/types';
-import { parseHandle } from '../../../common/util';
+import { parseSourceHandle, parseTargetHandle } from '../../../common/util';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { SettingsContext } from '../../contexts/SettingsContext';
 import { getTypeAccentColors } from '../../helpers/getTypeAccentColors';
@@ -13,7 +13,7 @@ import { noContextMenu } from '../../hooks/useContextMenu';
 
 interface InputContainerProps {
     id: string;
-    inputId: number;
+    inputId: InputId;
     label?: string;
     hasHandle: boolean;
     definitionType: Type;
@@ -62,7 +62,7 @@ export const InputContainer = memo(
         const { getEdges, getNode } = useReactFlow();
         const edges = useMemo(() => getEdges(), [edgeChanges]);
         const connectedEdge = edges.find(
-            (e) => e.target === id && parseHandle(e.targetHandle!).inOutId === inputId
+            (e) => e.target === id && parseTargetHandle(e.targetHandle!).inOutId === inputId
         );
         const isConnected = !!connectedEdge;
         const [connectingFromType] = useConnectingFromType;
@@ -109,10 +109,10 @@ export const InputContainer = memo(
         const parentTypeColor = useMemo(() => {
             if (connectedEdge) {
                 const parentNode: Node<NodeData> = getNode(connectedEdge.source)! as Node<NodeData>;
-                const parentInOutId = parseHandle(connectedEdge.sourceHandle!).inOutId;
+                const parentOutputId = parseSourceHandle(connectedEdge.sourceHandle!).inOutId;
                 const parentType = functionDefinitions
                     .get(parentNode.data.schemaId)!
-                    .outputDefaults.get(parentInOutId)!;
+                    .outputDefaults.get(parentOutputId)!;
                 return getTypeAccentColors(parentType, typeDefinitions, isDarkMode)[0];
             }
             return null;

--- a/src/renderer/components/inputs/previews/ImagePreview.tsx
+++ b/src/renderer/components/inputs/previews/ImagePreview.tsx
@@ -3,7 +3,7 @@ import { Center, HStack, Image, Spinner, Tag, Text, VStack } from '@chakra-ui/re
 import { memo, useEffect, useState } from 'react';
 import { useContext } from 'use-context-selector';
 import { getBackend } from '../../../../common/Backend';
-import { SchemaId } from '../../../../common/common-types';
+import { OutputId, SchemaId } from '../../../../common/common-types';
 import { NamedExpression, NamedExpressionField } from '../../../../common/types/expression';
 import { NumericLiteralType, StringLiteralType } from '../../../../common/types/types';
 import { checkFileExists, visitByType } from '../../../../common/util';
@@ -103,7 +103,7 @@ export const ImagePreview = memo(({ path, schemaId, id }: ImagePreviewProps) => 
             if (state.type === 'image') {
                 setManualOutputType(
                     id,
-                    0,
+                    0 as OutputId,
                     new NamedExpression('Image', [
                         new NamedExpressionField(
                             'width',
@@ -121,7 +121,7 @@ export const ImagePreview = memo(({ path, schemaId, id }: ImagePreviewProps) => 
                 );
                 setManualOutputType(
                     id,
-                    1,
+                    1 as OutputId,
                     new NamedExpression('Directory', [
                         new NamedExpressionField(
                             'path',
@@ -129,11 +129,11 @@ export const ImagePreview = memo(({ path, schemaId, id }: ImagePreviewProps) => 
                         ),
                     ])
                 );
-                setManualOutputType(id, 2, new StringLiteralType(state.image.name));
+                setManualOutputType(id, 2 as OutputId, new StringLiteralType(state.image.name));
             } else {
-                setManualOutputType(id, 0, undefined);
-                setManualOutputType(id, 1, undefined);
-                setManualOutputType(id, 2, undefined);
+                setManualOutputType(id, 0 as OutputId, undefined);
+                setManualOutputType(id, 1 as OutputId, undefined);
+                setManualOutputType(id, 2 as OutputId, undefined);
             }
         }
     }, [id, schemaId, state]);

--- a/src/renderer/components/inputs/previews/TorchModelPreview.tsx
+++ b/src/renderer/components/inputs/previews/TorchModelPreview.tsx
@@ -3,7 +3,7 @@ import { Center, Spinner, Tag, Text, Wrap, WrapItem } from '@chakra-ui/react';
 import { memo, useEffect, useState } from 'react';
 import { useContext } from 'use-context-selector';
 import { getBackend } from '../../../../common/Backend';
-import { SchemaId } from '../../../../common/common-types';
+import { OutputId, SchemaId } from '../../../../common/common-types';
 import { NamedExpression, NamedExpressionField } from '../../../../common/types/expression';
 import { NumericLiteralType, StringLiteralType } from '../../../../common/types/types';
 import { checkFileExists, visitByType } from '../../../../common/util';
@@ -102,7 +102,7 @@ export const TorchModelPreview = memo(({ path, schemaId, id }: TorchModelPreview
             if (state.type === 'model') {
                 setManualOutputType(
                     id,
-                    0,
+                    0 as OutputId,
                     new NamedExpression('PyTorchModel', [
                         new NamedExpressionField(
                             'scale',
@@ -118,10 +118,10 @@ export const TorchModelPreview = memo(({ path, schemaId, id }: TorchModelPreview
                         ),
                     ])
                 );
-                setManualOutputType(id, 1, new StringLiteralType(state.model.name));
+                setManualOutputType(id, 1 as OutputId, new StringLiteralType(state.model.name));
             } else {
-                setManualOutputType(id, 0, undefined);
-                setManualOutputType(id, 1, undefined);
+                setManualOutputType(id, 0 as OutputId, undefined);
+                setManualOutputType(id, 1 as OutputId, undefined);
             }
         }
     }, [id, state]);

--- a/src/renderer/components/inputs/props.ts
+++ b/src/renderer/components/inputs/props.ts
@@ -1,9 +1,9 @@
-import { InputData, InputSchemaValue, SchemaId } from '../../../common/common-types';
+import { InputData, InputId, InputSchemaValue, SchemaId } from '../../../common/common-types';
 import { Type } from '../../../common/types/types';
 
 export interface InputProps {
     readonly id: string;
-    readonly inputId: number;
+    readonly inputId: InputId;
     readonly inputData: InputData;
     readonly isLocked: boolean;
     readonly label: string;
@@ -12,6 +12,6 @@ export interface InputProps {
     readonly definitionType: Type;
     readonly hasHandle: boolean;
     readonly useInputData: <T extends InputSchemaValue>(
-        inputId: number
+        inputId: InputId
     ) => readonly [T | undefined, (value: T) => void, () => void];
 }

--- a/src/renderer/components/node/NodeInputs.tsx
+++ b/src/renderer/components/node/NodeInputs.tsx
@@ -5,6 +5,7 @@ import { useContext } from 'use-context-selector';
 import {
     Input,
     InputData,
+    InputId,
     InputKind,
     InputSchemaValue,
     SchemaId,
@@ -102,7 +103,7 @@ export const NodeInputs = memo(
             useContext(GlobalContext);
 
         const useInputData = useCallback(
-            <T extends InputSchemaValue>(inputId: number) =>
+            <T extends InputSchemaValue>(inputId: InputId) =>
                 // eslint-disable-next-line react-hooks/rules-of-hooks
                 useInputDataContext<T>(id, inputId, inputData),
             [useInputDataContext, id, inputData]

--- a/src/renderer/components/outputs/GenericOutput.tsx
+++ b/src/renderer/components/outputs/GenericOutput.tsx
@@ -1,6 +1,7 @@
 import { Center, Flex, Spacer, Text } from '@chakra-ui/react';
 import { memo } from 'react';
 import { useContextSelector } from 'use-context-selector';
+import { OutputId } from '../../../common/common-types';
 import { Type } from '../../../common/types/types';
 import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { TypeTag } from '../TypeTag';
@@ -9,7 +10,7 @@ import { OutputContainer } from './OutputContainer';
 interface GenericOutputProps {
     id: string;
     label: string;
-    outputId: number;
+    outputId: OutputId;
     definitionType: Type;
 }
 

--- a/src/renderer/components/outputs/OutputContainer.tsx
+++ b/src/renderer/components/outputs/OutputContainer.tsx
@@ -2,9 +2,10 @@ import { Box, Center, HStack, chakra, useColorModeValue } from '@chakra-ui/react
 import React, { memo, useMemo } from 'react';
 import { Connection, Handle, Position, useReactFlow } from 'react-flow-renderer';
 import { useContext } from 'use-context-selector';
+import { OutputId } from '../../../common/common-types';
 import { isDisjointWith } from '../../../common/types/intersection';
 import { Type } from '../../../common/types/types';
-import { parseHandle } from '../../../common/util';
+import { parseSourceHandle } from '../../../common/util';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { SettingsContext } from '../../contexts/SettingsContext';
 import { getTypeAccentColors } from '../../helpers/getTypeAccentColors';
@@ -12,7 +13,7 @@ import { noContextMenu } from '../../hooks/useContextMenu';
 
 interface OutputContainerProps {
     hasHandle: boolean;
-    outputId: number;
+    outputId: OutputId;
     id: string;
     definitionType: Type;
 }
@@ -58,7 +59,7 @@ export const OutputContainer = memo(
         const { getEdges } = useReactFlow();
         const edges = useMemo(() => getEdges(), [edgeChanges]);
         const isConnected = !!edges.find(
-            (e) => e.source === id && parseHandle(e.sourceHandle!).inOutId === outputId
+            (e) => e.source === id && parseSourceHandle(e.sourceHandle!).inOutId === outputId
         );
         const [connectingFromType] = useConnectingFromType;
         const [connectingFrom] = useConnectingFrom;

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -3,10 +3,17 @@ import { Edge, Node, useReactFlow } from 'react-flow-renderer';
 import { createContext, useContext } from 'use-context-selector';
 import { useThrottledCallback } from 'use-debounce';
 import { getBackend } from '../../common/Backend';
-import { EdgeData, EdgeHandle, NodeData, UsableData } from '../../common/common-types';
+import {
+    EdgeData,
+    EdgeHandle,
+    InputId,
+    NodeData,
+    OutputId,
+    UsableData,
+} from '../../common/common-types';
 import { ipcRenderer } from '../../common/safeIpc';
 import { SchemaMap } from '../../common/SchemaMap';
-import { ParsedHandle, parseHandle } from '../../common/util';
+import { ParsedHandle, parseSourceHandle, parseTargetHandle } from '../../common/util';
 import { checkNodeValidity } from '../helpers/checkNodeValidity';
 import { getEffectivelyDisabledNodes } from '../helpers/disabled';
 import { useAsyncEffect } from '../hooks/useAsyncEffect';
@@ -59,15 +66,18 @@ const convertToUsableFormat = (
         return { id: handle.nodeId, index };
     };
 
-    type Handles = Record<string, Record<number, EdgeHandle | undefined> | undefined>;
-    const inputHandles: Handles = {};
-    const outputHandles: Handles = {};
+    type Handles<I extends InputId | OutputId> = Record<
+        string,
+        Record<I, EdgeHandle | undefined> | undefined
+    >;
+    const inputHandles: Handles<InputId> = {};
+    const outputHandles: Handles<OutputId> = {};
     edges.forEach((element) => {
         const { sourceHandle, targetHandle } = element;
         if (!sourceHandle || !targetHandle) return;
 
-        const sourceH = parseHandle(sourceHandle);
-        const targetH = parseHandle(targetHandle);
+        const sourceH = parseSourceHandle(sourceHandle);
+        const targetH = parseTargetHandle(targetHandle);
 
         (inputHandles[targetH.nodeId] ??= {})[targetH.inOutId] = convertHandle(sourceH, 'output');
         (outputHandles[sourceH.nodeId] ??= {})[sourceH.inOutId] = convertHandle(targetH, 'input');

--- a/src/renderer/helpers/TypeState.ts
+++ b/src/renderer/helpers/TypeState.ts
@@ -1,5 +1,5 @@
 import { Edge, Node } from 'react-flow-renderer';
-import { EdgeData, NodeData, SchemaId } from '../../common/common-types';
+import { EdgeData, InputId, NodeData, OutputId, SchemaId } from '../../common/common-types';
 import { EvaluationError } from '../../common/types/evaluate';
 import { FunctionDefinition, FunctionInstance } from '../../common/types/function';
 import {
@@ -9,7 +9,7 @@ import {
     StructType,
     Type,
 } from '../../common/types/types';
-import { EMPTY_MAP, parseHandle } from '../../common/util';
+import { EMPTY_MAP, parseSourceHandle } from '../../common/util';
 
 export class TypeState {
     readonly functions: ReadonlyMap<string, FunctionInstance>;
@@ -29,7 +29,7 @@ export class TypeState {
     static create(
         nodesMap: ReadonlyMap<string, Node<NodeData>>,
         edges: readonly Edge<EdgeData>[],
-        outputNarrowing: ReadonlyMap<string, ReadonlyMap<number, Type>>,
+        outputNarrowing: ReadonlyMap<string, ReadonlyMap<OutputId, Type>>,
         functionDefinitions: ReadonlyMap<SchemaId, FunctionDefinition>
     ): TypeState {
         // eslint-disable-next-line no-param-reassign
@@ -40,10 +40,10 @@ export class TypeState {
         const functions = new Map<string, FunctionInstance>();
         const evaluationErrors = new Map<string, EvaluationError>();
 
-        const getSourceType = (id: string, inputId: number): NonNeverType | undefined => {
+        const getSourceType = (id: string, inputId: InputId): NonNeverType | undefined => {
             const edge = byTargetHandle.get(`${id}-${inputId}`);
             if (edge && edge.sourceHandle) {
-                const sourceHandle = parseHandle(edge.sourceHandle);
+                const sourceHandle = parseSourceHandle(edge.sourceHandle);
                 const sourceNode = nodesMap.get(sourceHandle.nodeId);
                 if (sourceNode) {
                     // eslint-disable-next-line @typescript-eslint/no-use-before-define

--- a/src/renderer/helpers/checkNodeValidity.ts
+++ b/src/renderer/helpers/checkNodeValidity.ts
@@ -7,7 +7,7 @@ import { isDisjointWith } from '../../common/types/intersection';
 import { TypeDefinitions } from '../../common/types/typedef';
 import { IntIntervalType, NumericLiteralType, Type } from '../../common/types/types';
 import { IntNumberType, isImage } from '../../common/types/util';
-import { parseHandle } from '../../common/util';
+import { parseTargetHandle } from '../../common/util';
 
 export type Validity =
     | { readonly isValid: true }
@@ -91,7 +91,7 @@ export const checkNodeValidity = ({
 }: CheckNodeValidityOptions): Validity => {
     const targetedInputs = edges
         .filter((e) => e.target === id && e.targetHandle)
-        .map((e) => parseHandle(e.targetHandle!).inOutId);
+        .map((e) => parseTargetHandle(e.targetHandle!).inOutId);
 
     const missingInputs = schema.inputs.filter((input) => {
         // optional inputs can't be missing

--- a/src/renderer/helpers/dataTransfer.ts
+++ b/src/renderer/helpers/dataTransfer.ts
@@ -1,7 +1,7 @@
 import log from 'electron-log';
 import { extname } from 'path';
 import { XYPosition } from 'react-flow-renderer';
-import { SchemaId } from '../../common/common-types';
+import { InputId, SchemaId } from '../../common/common-types';
 import { ipcRenderer } from '../../common/safeIpc';
 import { openSaveFile } from '../../common/SaveFile';
 import { SchemaMap } from '../../common/SchemaMap';
@@ -105,7 +105,7 @@ const openImageFileProcessor: DataTransferProcessor = (
             position: getNodePosition(100, 100),
             data: {
                 schemaId: LOAD_IMAGE_ID,
-                inputData: { 0: path },
+                inputData: { [0 as InputId]: path },
             },
             nodeType: schema.nodeType,
         });


### PR DESCRIPTION
This adds branded types for input ids and output ids. This means that TS now validates that we use them correctly and don't accidentally mix them up.

These types are not only better at documenting API than `number`, they also find bugs. Case in point: `usePaneNodeSearchMenu` incorrectly used input ids as indexes into `NodeSchema.inputs` arrays. This has been fixed.

I also "added" 2 new util functions: `parseSourceHandle` and `parseTargetHandle`. These functions are the same as `parseHandle` but with a different return type.

Apart from this and the bug fix, this is a pure type PR. Only types have been changed.