### PR TITLE
Allow dragging already placed nodes into iterators

### DIFF
--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -215,7 +215,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
     }, [nodes, edges]);
 
     const onNodeDragStop = useCallback(
-        (event: React.MouseEvent, _node: Node<NodeData>, nNodes: Node<NodeData>[]) => {
+        (event: React.MouseEvent, _node: Node<NodeData> | null, nNodes: Node<NodeData>[]) => {
             const newNodes: Node<NodeData>[] = [];
             const edgesToRemove: Edge[] = [];
             const allIterators = nodes.filter((n) => n.type === 'iterator');
@@ -290,10 +290,12 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
         ]
     );
 
-    const onSelectionDragStop = useCallback(() => {
-        addNodeChanges();
-        addEdgeChanges();
-    }, [addNodeChanges, addEdgeChanges]);
+    const onSelectionDragStop = useCallback(
+        (event: React.MouseEvent, nNodes: Node<NodeData>[]) => {
+            onNodeDragStop(event, null, nNodes);
+        },
+        [onNodeDragStop]
+    );
 
     const onNodesDelete = useCallback(
         (toDelete: readonly Node<NodeData>[]) => {

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -165,7 +165,6 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
         changeEdges,
         setSetNodes,
         setSetEdges,
-        updateIteratorBounds,
     } = useContext(GlobalContext);
 
     const useSnapToGrid = useContextSelector(SettingsContext, (c) => c.useSnapToGrid);
@@ -273,7 +272,6 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
             nodes,
             changeEdges,
             edges,
-            updateIteratorBounds,
         ]
     );
 

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -6,6 +6,7 @@ import ReactFlow, {
     Background,
     BackgroundVariant,
     Controls,
+    CoordinateExtent,
     Edge,
     EdgeTypes,
     Node,
@@ -164,6 +165,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
         changeEdges,
         setSetNodes,
         setSetEdges,
+        updateIteratorBounds,
     } = useContext(GlobalContext);
 
     const useSnapToGrid = useContextSelector(SettingsContext, (c) => c.useSnapToGrid);
@@ -212,10 +214,68 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
         return [displayNodes, displayEdges, isSnapToGrid && snapToGridAmount];
     }, [nodes, edges]);
 
-    const onNodeDragStop = useCallback(() => {
-        addNodeChanges();
-        addEdgeChanges();
-    }, [addNodeChanges, addEdgeChanges]);
+    const onNodeDragStop = useCallback(
+        (event: React.MouseEvent, node: Node<NodeData>) => {
+            if (!node.parentNode && node.type === 'regularNode') {
+                const allIterators = nodes.filter((n) => n.type === 'iterator');
+                const iterInBounds = allIterators.find(
+                    (iterator) =>
+                        iterator.position.x + (iterator.data.iteratorSize?.offsetLeft ?? 0) <
+                            node.position.x &&
+                        iterator.position.y + (iterator.data.iteratorSize?.offsetTop ?? 0) <
+                            node.position.y &&
+                        iterator.position.x + (iterator.width ?? 0) >
+                            node.position.x + (node.width ?? 0) &&
+                        iterator.position.y + (iterator.height ?? 0) >
+                            node.position.y + (node.height ?? 0)
+                );
+                if (iterInBounds) {
+                    const {
+                        offsetTop = 0,
+                        offsetLeft = 0,
+                        width = 0,
+                        height = 0,
+                    } = iterInBounds.data.iteratorSize ?? {};
+                    const wBound = width - (node.width ?? 0) + offsetLeft;
+                    const hBound = height - (node.height ?? 0) + offsetTop;
+                    const newNode = {
+                        ...node,
+                        data: { ...node.data, parentNode: iterInBounds.id },
+                        parentNode: iterInBounds.id,
+                        extent: [
+                            [offsetLeft, offsetTop],
+                            [wBound, hBound],
+                        ] as CoordinateExtent,
+                        position: {
+                            x: node.position.x - iterInBounds.position.x,
+                            y: node.position.y - iterInBounds.position.y,
+                        },
+                    };
+                    const edgesToRemove = edges.filter(
+                        (e) =>
+                            e.source === node.id &&
+                            nodes.find((n) => n.id === e.target)?.parentNode !== iterInBounds.id
+                    );
+                    changeNodes((oldNodes) => [
+                        ...oldNodes.filter((n) => n.id !== node.id),
+                        newNode,
+                    ]);
+                    changeEdges((oldEdges) => oldEdges.filter((e) => !edgesToRemove.includes(e)));
+                }
+            }
+            addNodeChanges();
+            addEdgeChanges();
+        },
+        [
+            addNodeChanges,
+            addEdgeChanges,
+            changeNodes,
+            nodes,
+            changeEdges,
+            edges,
+            updateIteratorBounds,
+        ]
+    );
 
     const onSelectionDragStop = useCallback(() => {
         addNodeChanges();

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -265,14 +265,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
             addNodeChanges();
             addEdgeChanges();
         },
-        [
-            addNodeChanges,
-            addEdgeChanges,
-            changeNodes,
-            nodes,
-            changeEdges,
-            edges,
-        ]
+        [addNodeChanges, addEdgeChanges, changeNodes, nodes, changeEdges, edges]
     );
 
     const onSelectionDragStop = useCallback(() => {

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -165,6 +165,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
         changeEdges,
         setSetNodes,
         setSetEdges,
+        updateIteratorBounds,
     } = useContext(GlobalContext);
 
     const useSnapToGrid = useContextSelector(SettingsContext, (c) => c.useSnapToGrid);
@@ -265,7 +266,15 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
             addNodeChanges();
             addEdgeChanges();
         },
-        [addNodeChanges, addEdgeChanges, changeNodes, nodes, changeEdges, edges]
+        [
+            addNodeChanges,
+            addEdgeChanges,
+            changeNodes,
+            nodes,
+            changeEdges,
+            edges,
+            updateIteratorBounds,
+        ]
     );
 
     const onSelectionDragStop = useCallback(() => {

--- a/src/renderer/hooks/useNodeMenu.tsx
+++ b/src/renderer/hooks/useNodeMenu.tsx
@@ -1,5 +1,6 @@
 import { CloseIcon, CopyIcon, DeleteIcon, LockIcon, UnlockIcon } from '@chakra-ui/icons';
 import { MenuItem, MenuList } from '@chakra-ui/react';
+import { BsLayerForward } from 'react-icons/bs';
 import { MdPlayArrow, MdPlayDisabled } from 'react-icons/md';
 import { useContext } from 'use-context-selector';
 import { NodeData } from '../../common/common-types';
@@ -16,9 +17,10 @@ export const useNodeMenu = (
     useDisabled: UseDisabled,
     { canLock = true }: UseNodeMenuOptions = {}
 ): UseContextMenu => {
-    const { id, isLocked = false } = data;
+    const { id, isLocked = false, parentNode } = data;
 
-    const { removeNodeById, clearNode, duplicateNode, toggleNodeLock } = useContext(GlobalContext);
+    const { removeNodeById, clearNode, duplicateNode, toggleNodeLock, releaseNodeFromParent } =
+        useContext(GlobalContext);
     const { isDirectlyDisabled, canDisable, toggleDirectlyDisabled } = useDisabled;
 
     return useContextMenu(() => (
@@ -66,6 +68,16 @@ export const useNodeMenu = (
             >
                 Delete
             </MenuItem>
+            {parentNode && (
+                <MenuItem
+                    icon={<BsLayerForward />}
+                    onClick={() => {
+                        releaseNodeFromParent(id);
+                    }}
+                >
+                    Release
+                </MenuItem>
+            )}
         </MenuList>
     ));
 };


### PR DESCRIPTION
Probably shouldn't merge this for 0.10 since it could introduce new bugs I didn't catch, but for 0.10.1 this should be a welcomed feature. (unless we wanna delay 0.10 a little more, which we could do)

I know iterators are going away relatively soon (hopefully) but this should still add convenience.

Also, closes #395 I guess