### PR TITLE
Add control to multi-select keys

### DIFF
--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -318,6 +318,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
                 edges={displayEdges}
                 maxZoom={8}
                 minZoom={0.125}
+                multiSelectionKeyCode={useMemo(() => ['Control', 'Meta'], [])}
                 nodeTypes={nodeTypes}
                 nodes={displayNodes}
                 snapGrid={useMemoArray<[number, number]>([snapToGridAmount, snapToGridAmount])}


### PR DESCRIPTION
Apparently, we've been able to do this already by holding down the windows button (since that's command on mac), but I added control to the allowed keys for that