### PR TITLE
Refactored usePaneNodeSearchMenu

### DIFF
--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -13,10 +13,11 @@ import {
     useColorModeValue,
     useToken,
 } from '@chakra-ui/react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { Node, OnConnectStartParams, useReactFlow } from 'react-flow-renderer';
 import { useContext } from 'use-context-selector';
-import { NodeData, NodeSchema } from '../../common/common-types';
+import { NodeData, NodeSchema, SchemaId } from '../../common/common-types';
+import { FunctionDefinition } from '../../common/types/function';
 import { isDisjointWith } from '../../common/types/intersection';
 import { Type } from '../../common/types/types';
 import {
@@ -31,200 +32,22 @@ import { GlobalContext, GlobalVolatileContext, NodeProto } from '../contexts/Glo
 import { interpolateColor } from '../helpers/colorTools';
 import { getNodeAccentColor } from '../helpers/getNodeAccentColor';
 import { getMatchingNodes, getNodesByCategory } from '../helpers/nodeSearchFuncs';
+import { TypeState } from '../helpers/TypeState';
 import { useContextMenu } from './useContextMenu';
 import { useNodeFavorites } from './useNodeFavorites';
 
-interface UsePaneNodeSearchMenuValue {
-    readonly onConnectStart: (event: React.MouseEvent, handle: OnConnectStartParams) => void;
-    readonly onConnectStop: (event: MouseEvent) => void;
-    readonly onPaneContextMenu: (event: React.MouseEvent) => void;
+interface MenuProps {
+    onSelect: (schema: NodeSchema) => void;
+    schemata: readonly NodeSchema[];
+    favorites: ReadonlySet<SchemaId>;
 }
 
-interface Position {
-    readonly x: number;
-    readonly y: number;
-}
-
-export const usePaneNodeSearchMenu = (
-    wrapperRef: React.RefObject<HTMLDivElement>
-): UsePaneNodeSearchMenuValue => {
-    const { createNode, createConnection, typeState, useConnectingFromType, useConnectingFrom } =
-        useContext(GlobalVolatileContext);
-    const { closeContextMenu } = useContext(ContextMenuContext);
-    const { schemata, functionDefinitions } = useContext(GlobalContext);
-
-    const [connectingFrom, setConnectingFrom] = useState<OnConnectStartParams | null>(null);
-    const [, setGlobalConnectingFromType] = useConnectingFromType;
-    const [, setGlobalConnectingFrom] = useConnectingFrom;
-    const [connectingFromType, setConnectingFromType] = useState<Type | null>(null);
-
-    const [isStoppedOnPane, setIsStoppedOnPane] = useState(false);
-    const { getNode, project } = useReactFlow();
-
-    const [mousePosition, setMousePosition] = useState<Position>({ x: 0, y: 0 });
-
+const Menu = memo(({ onSelect, schemata, favorites }: MenuProps) => {
     const [searchQuery, setSearchQuery] = useState('');
-    const matchingNodes = useMemo(
-        () =>
-            getMatchingNodes(searchQuery, schemata.schemata).filter((node) => {
-                if (
-                    !connectingFrom ||
-                    !connectingFromType ||
-                    !connectingFrom.nodeId ||
-                    !connectingFrom.handleId ||
-                    !connectingFrom.handleType
-                ) {
-                    return true;
-                }
-                switch (connectingFrom.handleType) {
-                    case 'source': {
-                        const sourceFn = typeState.functions.get(connectingFrom.nodeId);
 
-                        if (!sourceFn) {
-                            return false;
-                        }
-
-                        const { inOutId } = parseSourceHandle(connectingFrom.handleId);
-                        const sourceType = sourceFn.outputs.get(inOutId);
-
-                        if (!sourceType) {
-                            return false;
-                        }
-
-                        const targetTypes = functionDefinitions.get(node.schemaId);
-
-                        if (!targetTypes) {
-                            return false;
-                        }
-
-                        return [...targetTypes.inputDefaults].some(([inputId, type]) => {
-                            return (
-                                !isDisjointWith(type, sourceType) &&
-                                schemata.get(node.schemaId).inputs.find((i) => i.id === inputId)
-                                    ?.hasHandle
-                            );
-                        });
-                    }
-                    case 'target': {
-                        const sourceNode = getNode(connectingFrom.nodeId) as Node<NodeData>;
-                        const sourceFn = functionDefinitions.get(sourceNode.data.schemaId);
-
-                        if (!sourceFn) {
-                            return false;
-                        }
-
-                        const { inOutId } = parseTargetHandle(connectingFrom.handleId);
-                        const sourceType = sourceFn.inputDefaults.get(inOutId);
-
-                        if (!sourceType) {
-                            return false;
-                        }
-
-                        const targetTypes = functionDefinitions.get(node.schemaId);
-
-                        if (!targetTypes) {
-                            return false;
-                        }
-
-                        return [...targetTypes.outputDefaults].some(([, type]) => {
-                            return !isDisjointWith(type, sourceType);
-                        });
-                    }
-                    default:
-                        assertNever(connectingFrom.handleType);
-                }
-                return true;
-            }),
-        [connectingFrom, connectingFromType, searchQuery, schemata.schemata]
-    );
-    const byCategories = useMemo(() => getNodesByCategory(matchingNodes), [matchingNodes]);
-
-    const { favorites } = useNodeFavorites();
-
-    useEffect(() => {
-        setSearchQuery('');
-    }, [connectingFrom]);
-
-    const onPaneContextMenuNodeClick = useCallback(
-        (schema: NodeSchema, position: Position) => {
-            const reactFlowBounds = wrapperRef.current!.getBoundingClientRect();
-            const { x, y } = position;
-            const projPosition = project({
-                x: x - reactFlowBounds.left,
-                y: y - reactFlowBounds.top,
-            });
-            const nodeId = createUniqueId();
-            const nodeToMake: NodeProto = {
-                id: nodeId,
-                position: projPosition,
-                data: {
-                    schemaId: schema.schemaId,
-                },
-                nodeType: schema.nodeType,
-            };
-            createNode(nodeToMake);
-            const targetTypes = functionDefinitions.get(schema.schemaId);
-            if (
-                isStoppedOnPane &&
-                connectingFrom &&
-                targetTypes &&
-                connectingFromType &&
-                connectingFrom.handleType
-            ) {
-                switch (connectingFrom.handleType) {
-                    case 'source': {
-                        const firstPossibleTarget = [...targetTypes.inputDefaults].find(
-                            ([inputId, type]) => {
-                                return (
-                                    !isDisjointWith(type, connectingFromType) &&
-                                    schemata
-                                        .get(schema.schemaId)
-                                        .inputs.find((i) => i.id === inputId)?.hasHandle
-                                );
-                            }
-                        );
-                        if (firstPossibleTarget) {
-                            createConnection({
-                                source: connectingFrom.nodeId,
-                                sourceHandle: connectingFrom.handleId,
-                                target: nodeId,
-                                targetHandle: `${nodeId}-${firstPossibleTarget[0]}`,
-                            });
-                        }
-                        break;
-                    }
-                    case 'target': {
-                        const firstPossibleTarget = [...targetTypes.outputDefaults].find(
-                            ([, type]) => {
-                                return !isDisjointWith(type, connectingFromType);
-                            }
-                        );
-                        if (firstPossibleTarget) {
-                            createConnection({
-                                source: nodeId,
-                                sourceHandle: `${nodeId}-${firstPossibleTarget[0]}`,
-                                target: connectingFrom.nodeId,
-                                targetHandle: connectingFrom.handleId,
-                            });
-                        }
-                        break;
-                    }
-                    default:
-                        assertNever(connectingFrom.handleType);
-                }
-            }
-
-            setConnectingFrom(null);
-            closeContextMenu();
-        },
-        [
-            connectingFrom,
-            createConnection,
-            createNode,
-            schemata,
-            connectingFromType,
-            isStoppedOnPane,
-        ]
+    const byCategories = useMemo(
+        () => getNodesByCategory(getMatchingNodes(searchQuery, schemata)),
+        [searchQuery, schemata]
     );
 
     const [gray200, gray800] = useToken('colors', ['gray.200', 'gray.800']) as string[];
@@ -234,7 +57,7 @@ export const usePaneNodeSearchMenu = (
     const inputColor = useColorModeValue('gray.500', 'gray.300');
     const hoverColor = useColorModeValue('black', 'white');
 
-    const menu = useContextMenu(() => (
+    return (
         <MenuList
             bgColor={menuBgColor}
             borderWidth={0}
@@ -281,8 +104,8 @@ export const usePaneNodeSearchMenu = (
                 overflowY="scroll"
                 p={1}
             >
-                {[...byCategories].length > 0 ? (
-                    [...byCategories].map(([category, categoryNodes]) => {
+                {byCategories.size > 0 ? (
+                    [...byCategories].map(([category, categorySchemata]) => {
                         const accentColor = getNodeAccentColor(category);
                         const gradL = interpolateColor(accentColor, menuBgColor, 0.95);
                         const gradR = menuBgColor;
@@ -302,8 +125,8 @@ export const usePaneNodeSearchMenu = (
                                     />
                                     <Text fontSize="xs">{category}</Text>
                                 </HStack>
-                                {[...categoryNodes].map((node) => {
-                                    const isFavorite = favorites.has(node.schemaId);
+                                {[...categorySchemata].map((schema) => {
+                                    const isFavorite = favorites.has(schema.schemaId);
                                     return (
                                         <HStack
                                             _hover={{
@@ -311,25 +134,25 @@ export const usePaneNodeSearchMenu = (
                                             }}
                                             bgGradient={`linear(to-r, ${gradL}, ${gradR})`}
                                             borderRadius="md"
-                                            key={node.schemaId}
+                                            key={schema.schemaId}
                                             mx={1}
                                             my={0.5}
                                             px={2}
                                             py={0.5}
                                             onClick={() => {
                                                 setSearchQuery('');
-                                                onPaneContextMenuNodeClick(node, mousePosition);
+                                                onSelect(schema);
                                             }}
                                         >
                                             <IconFactory
                                                 accentColor="gray.500"
-                                                icon={node.icon}
+                                                icon={schema.icon}
                                             />
                                             <Text
                                                 h="full"
                                                 verticalAlign="middle"
                                             >
-                                                {node.name}
+                                                {schema.name}
                                             </Text>
                                             (
                                             {isFavorite && (
@@ -362,7 +185,205 @@ export const usePaneNodeSearchMenu = (
                 )}
             </Box>
         </MenuList>
-    ));
+    );
+});
+
+const canConnectWith = (
+    connectingFrom: OnConnectStartParams,
+    schema: NodeSchema,
+    typeState: TypeState,
+    functionDefinitions: ReadonlyMap<SchemaId, FunctionDefinition>,
+    getNode: (id: string) => Node<NodeData> | undefined
+): boolean => {
+    if (!connectingFrom.nodeId || !connectingFrom.handleId || !connectingFrom.handleType) {
+        return true;
+    }
+    switch (connectingFrom.handleType) {
+        case 'source': {
+            const sourceFn = typeState.functions.get(connectingFrom.nodeId);
+            if (!sourceFn) {
+                return false;
+            }
+
+            const { inOutId } = parseSourceHandle(connectingFrom.handleId);
+            const sourceType = sourceFn.outputs.get(inOutId);
+            if (!sourceType) {
+                return false;
+            }
+
+            const targetTypes = functionDefinitions.get(schema.schemaId);
+            if (!targetTypes) {
+                return false;
+            }
+
+            return [...targetTypes.inputDefaults].some(([inputId, type]) => {
+                return (
+                    !isDisjointWith(type, sourceType) &&
+                    schema.inputs.find((i) => i.id === inputId)?.hasHandle
+                );
+            });
+        }
+        case 'target': {
+            const sourceNode = getNode(connectingFrom.nodeId);
+            if (!sourceNode) {
+                return false;
+            }
+            const sourceFn = functionDefinitions.get(sourceNode.data.schemaId);
+            if (!sourceFn) {
+                return false;
+            }
+
+            const { inOutId } = parseTargetHandle(connectingFrom.handleId);
+            const sourceType = sourceFn.inputDefaults.get(inOutId);
+            if (!sourceType) {
+                return false;
+            }
+
+            const targetTypes = functionDefinitions.get(schema.schemaId);
+            if (!targetTypes) {
+                return false;
+            }
+
+            return [...targetTypes.outputDefaults].some(([, type]) => {
+                return !isDisjointWith(type, sourceType);
+            });
+        }
+        default:
+            assertNever(connectingFrom.handleType);
+    }
+    return true;
+};
+
+interface UsePaneNodeSearchMenuValue {
+    readonly onConnectStart: (event: React.MouseEvent, handle: OnConnectStartParams) => void;
+    readonly onConnectStop: (event: MouseEvent) => void;
+    readonly onPaneContextMenu: (event: React.MouseEvent) => void;
+}
+
+interface Position {
+    readonly x: number;
+    readonly y: number;
+}
+
+export const usePaneNodeSearchMenu = (
+    wrapperRef: React.RefObject<HTMLDivElement>
+): UsePaneNodeSearchMenuValue => {
+    const { createNode, createConnection, typeState, useConnectingFromType, useConnectingFrom } =
+        useContext(GlobalVolatileContext);
+    const { closeContextMenu } = useContext(ContextMenuContext);
+    const { schemata, functionDefinitions } = useContext(GlobalContext);
+
+    const { favorites } = useNodeFavorites();
+
+    const [connectingFrom, setConnectingFrom] = useState<OnConnectStartParams | null>(null);
+    const [, setGlobalConnectingFromType] = useConnectingFromType;
+    const [, setGlobalConnectingFrom] = useConnectingFrom;
+    const [connectingFromType, setConnectingFromType] = useState<Type | null>(null);
+
+    const [isStoppedOnPane, setIsStoppedOnPane] = useState(false);
+    const { getNode, project } = useReactFlow();
+
+    const [mousePosition, setMousePosition] = useState<Position>({ x: 0, y: 0 });
+
+    const matchingSchemata = useMemo(
+        () =>
+            schemata.schemata.filter((schema) => {
+                return (
+                    !connectingFrom ||
+                    !connectingFromType ||
+                    canConnectWith(connectingFrom, schema, typeState, functionDefinitions, getNode)
+                );
+            }),
+        [connectingFrom, connectingFromType, schemata, typeState, functionDefinitions, getNode]
+    );
+
+    const onSchemaSelect = useCallback(
+        (schema: NodeSchema) => {
+            const reactFlowBounds = wrapperRef.current!.getBoundingClientRect();
+            const { x, y } = mousePosition;
+            const projPosition = project({
+                x: x - reactFlowBounds.left,
+                y: y - reactFlowBounds.top,
+            });
+            const nodeId = createUniqueId();
+            const nodeToMake: NodeProto = {
+                id: nodeId,
+                position: projPosition,
+                data: {
+                    schemaId: schema.schemaId,
+                },
+                nodeType: schema.nodeType,
+            };
+            createNode(nodeToMake);
+            const targetTypes = functionDefinitions.get(schema.schemaId);
+            if (
+                isStoppedOnPane &&
+                connectingFrom &&
+                targetTypes &&
+                connectingFromType &&
+                connectingFrom.handleType
+            ) {
+                switch (connectingFrom.handleType) {
+                    case 'source': {
+                        const firstPossibleTarget = [...targetTypes.inputDefaults].find(
+                            ([inputId, type]) => {
+                                return (
+                                    !isDisjointWith(type, connectingFromType) &&
+                                    schema.inputs.find((i) => i.id === inputId)?.hasHandle
+                                );
+                            }
+                        );
+                        if (firstPossibleTarget) {
+                            createConnection({
+                                source: connectingFrom.nodeId,
+                                sourceHandle: connectingFrom.handleId,
+                                target: nodeId,
+                                targetHandle: `${nodeId}-${firstPossibleTarget[0]}`,
+                            });
+                        }
+                        break;
+                    }
+                    case 'target': {
+                        const firstPossibleTarget = [...targetTypes.outputDefaults].find(
+                            ([, type]) => {
+                                return !isDisjointWith(type, connectingFromType);
+                            }
+                        );
+                        if (firstPossibleTarget) {
+                            createConnection({
+                                source: nodeId,
+                                sourceHandle: `${nodeId}-${firstPossibleTarget[0]}`,
+                                target: connectingFrom.nodeId,
+                                targetHandle: connectingFrom.handleId,
+                            });
+                        }
+                        break;
+                    }
+                    default:
+                        assertNever(connectingFrom.handleType);
+                }
+            }
+
+            setConnectingFrom(null);
+            closeContextMenu();
+        },
+        [
+            connectingFrom,
+            createConnection,
+            createNode,
+            connectingFromType,
+            isStoppedOnPane,
+            mousePosition,
+        ]
+    );
+
+    const menuProps: MenuProps = {
+        onSelect: onSchemaSelect,
+        schemata: matchingSchemata,
+        favorites,
+    };
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    const menu = useContextMenu(() => <Menu {...menuProps} />, Object.values(menuProps));
 
     useEffect(() => {
         if (connectingFrom && connectingFrom.handleId && connectingFrom.nodeId) {
@@ -441,10 +462,9 @@ export const usePaneNodeSearchMenu = (
                 y: event.pageY,
             });
             setConnectingFrom(null);
-            setSearchQuery('');
             menu.onContextMenu(event);
         },
-        [setConnectingFrom, menu, setMousePosition, setSearchQuery]
+        [setConnectingFrom, menu, setMousePosition]
     );
 
     useEffect(() => {


### PR DESCRIPTION
Fixes #480.

While my primary intention was to fix #480, I also did a bit of refactoring while I was at it.

The main change is that the elements inside `useContextMenu`'s render function are now its own component. This means that the component can now hold the search query state, which fixes the bug. Turns out, this also automatically resets the search query when the context menu is closed, so the code even got a little simpler.

