### PR TITLE
Use `ReadonlyMap` for `functionDefinitions`

### DIFF
--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -118,7 +118,7 @@ interface Global {
     setHoveredNode: SetState<string | null | undefined>;
     setZoom: SetState<number>;
     setManualOutputType: (nodeId: string, outputId: OutputId, type: Expression | undefined) => void;
-    functionDefinitions: Map<SchemaId, FunctionDefinition>;
+    functionDefinitions: ReadonlyMap<SchemaId, FunctionDefinition>;
     typeDefinitions: TypeDefinitions;
     typeStateRef: Readonly<React.MutableRefObject<TypeState>>;
     releaseNodeFromParent: (id: string) => void;


### PR DESCRIPTION
The type of `functionDefinitions` was supposed to be immutable, but I used the wrong map type.