### PR TITLE
Guaranteed linear worst-case search predicate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "react-hotkeys-hook": "^3.4.6",
         "react-icons": "^4.4.0",
         "react-markdown": "^8.0.3",
+        "rregex": "^1.5.1",
         "scheduler": "^0.22.0",
         "semver": "^7.3.7",
         "systeminformation": "^5.11.16",
@@ -21473,6 +21474,11 @@
       "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
       "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
     },
+    "node_modules/rregex": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/rregex/-/rregex-1.5.1.tgz",
+      "integrity": "sha512-jt4xOJrLz05utn5tPnupM9+dIPH1O7PQnWQ+7xQoiNOZmvNBbEhEiXHO0Di7NOQPApSI0HmcfGoztukrKBj43g=="
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -41191,6 +41197,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
       "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
+    },
+    "rregex": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/rregex/-/rregex-1.5.1.tgz",
+      "integrity": "sha512-jt4xOJrLz05utn5tPnupM9+dIPH1O7PQnWQ+7xQoiNOZmvNBbEhEiXHO0Di7NOQPApSI0HmcfGoztukrKBj43g=="
     },
     "run-async": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "react-hotkeys-hook": "^3.4.6",
     "react-icons": "^4.4.0",
     "react-markdown": "^8.0.3",
+    "rregex": "^1.5.1",
     "scheduler": "^0.22.0",
     "semver": "^7.3.7",
     "systeminformation": "^5.11.16",


### PR DESCRIPTION
I replaced JavaScript's regex engine with [Rust's regex crate](https://docs.rs/regex/latest/regex/). This regex engine guarantees linear execution time, so it's always fast. To actually use the crate, I add [`rregex`](https://www.npmjs.com/package/rregex) as a dependency which is just some wasm bindings for the crate.

I used Rust's regex crate because I have previously used it and know that the library is battle-tested and mature. I initially wanted to use [re2](https://www.npmjs.com/package/re2), because it's more commonly used, but could neither get `re2` nor [`re2-wasm`](https://www.npmjs.com/package/re2-wasm) to work.