### PR TITLE
Executor improvements

### DIFF
--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -4,11 +4,30 @@ import asyncio
 import functools
 import os
 import uuid
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, TypedDict
+from typing_extensions import NotRequired
 
 from sanic.log import logger
 
 from nodes.node_factory import NodeFactory
+
+
+class UsableData(TypedDict):
+    id: str
+    schemaId: str
+    inputs: list
+    outputs: list
+    child: bool
+    children: NotRequired[List[str]]
+    nodeType: str
+    percent: NotRequired[int | float]
+    hasSideEffects: bool
+
+
+class NodeExecutionError(Exception):
+    def __init__(self, node: UsableData, cause: str):
+        super().__init__(cause)
+        self.node = node
 
 
 class Executor:
@@ -18,11 +37,11 @@ class Executor:
 
     def __init__(
         self,
-        nodes: Dict,
-        loop,
+        nodes: Dict[str, UsableData],
+        loop: asyncio.AbstractEventLoop,
         queue: asyncio.Queue,
-        existing_cache: Dict,
-        parent_executor=None,
+        existing_cache: Dict[str, Any],
+        parent_executor: Optional[Executor] = None,
     ):
         self.execution_id = uuid.uuid4().hex
         self.nodes = nodes
@@ -38,7 +57,15 @@ class Executor:
 
         self.parent_executor = parent_executor
 
-    async def process(self, node: Dict) -> Any:
+    async def process(self, node: UsableData) -> Any:
+        try:
+            return await self.__process(node)
+        except NodeExecutionError:
+            raise
+        except Exception as e:
+            raise NodeExecutionError(node, str(e)) from e
+
+    async def __process(self, node: UsableData) -> Any:
         """Process a single node"""
         logger.debug(f"node: {node}")
         node_id = node["id"]
@@ -91,8 +118,8 @@ class Executor:
 
         if node["nodeType"] == "iterator":
             logger.info("this is where an iterator would run")
-            sub_nodes = {}
-            for child in node["children"]:
+            sub_nodes: Dict[str, UsableData] = {}
+            for child in node["children"]:  # type: ignore
                 sub_nodes[child] = self.nodes[child]
             sub_nodes_ids = sub_nodes.keys()
             for v in sub_nodes.copy().values():
@@ -142,7 +169,6 @@ class Executor:
         for node in self.nodes.values():
             if self.killed:
                 break
-            print(node["hasSideEffects"])
             if (node["hasSideEffects"]) and not node["child"]:
                 output_nodes.append(node)
         # Run each of the output nodes through processing

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -5,7 +5,6 @@ import functools
 import os
 import uuid
 from typing import Any, Dict, List, Optional, TypedDict
-from typing_extensions import NotRequired
 
 from sanic.log import logger
 
@@ -18,9 +17,9 @@ class UsableData(TypedDict):
     inputs: list
     outputs: list
     child: bool
-    children: NotRequired[List[str]]
+    children: List[str]
     nodeType: str
-    percent: NotRequired[int | float]
+    percent: int | float
     hasSideEffects: bool
 
 

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -5,8 +5,13 @@ export interface BackendSuccessResponse {
     message: string;
     exception?: never;
 }
+export interface BackendExceptionSource {
+    nodeId: string;
+    schemaId: SchemaId;
+}
 export interface BackendExceptionResponse {
     message: string;
+    source?: BackendExceptionSource | null;
     exception: string;
 }
 export type BackendNodesResponse = NodeSchema[];

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -132,7 +132,7 @@ export interface UsableData {
     outputs: (InputValue | EdgeHandle | null)[];
     child: boolean;
     children?: string[];
-    nodeType: string | undefined;
+    nodeType: string;
     percent?: number;
     hasSideEffects: boolean;
 }

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -90,6 +90,12 @@ const convertToUsableFormat = (
         const { schemaId, inputData } = data;
         const schema = schemata.get(schemaId);
 
+        if (!nodeType) {
+            throw new Error(
+                `Expected all nodes to have a node type, but ${schema.name} (id: ${schemaId}) node did not.`
+            );
+        }
+
         // Node
         result[id] = {
             schemaId,
@@ -177,12 +183,23 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
         'execution-error',
         (data) => {
             if (data) {
-                sendAlert(AlertType.ERROR, null, data.exception);
+                let errorSource = '';
+                if (data.source) {
+                    const schema = schemata.get(data.source.schemaId);
+                    let { name } = schema;
+                    if (schemata.schemata.filter((s) => s.name === name).length > 1) {
+                        // make the name unique using the category of the schema
+                        name = `${schema.category} ${schema.name}`;
+                    }
+                    errorSource = `An error occurred in a ${name} node:\n\n`;
+                }
+
+                sendAlert(AlertType.ERROR, null, errorSource + data.exception);
                 unAnimate();
                 setStatus(ExecutionStatus.READY);
             }
         },
-        [setStatus, unAnimate]
+        [setStatus, unAnimate, schemata]
     );
 
     const updateNodeFinish = useThrottledCallback<BackendEventSourceListener<'node-finish'>>(
@@ -300,7 +317,7 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
                     isFp16,
                 });
                 if (response.exception) {
-                    sendAlert(AlertType.ERROR, null, response.exception);
+                    // no need to alert here, because the error has already been handled by the queue
                     unAnimate();
                     setStatus(ExecutionStatus.READY);
                 }

--- a/src/renderer/hooks/useBackendEventSource.ts
+++ b/src/renderer/hooks/useBackendEventSource.ts
@@ -5,6 +5,7 @@ import {
     useEventSourceListener,
 } from '@react-nano/use-event-source';
 import log from 'electron-log';
+import { BackendExceptionSource } from '../../common/Backend';
 
 export type BackendEventSource = EventSource & { readonly __backend?: never };
 
@@ -16,7 +17,11 @@ export const useBackendEventSource = (
 
 export interface BackendEventMap {
     finish: { message: string };
-    'execution-error': { message: string; exception: string };
+    'execution-error': {
+        message: string;
+        source?: BackendExceptionSource | null;
+        exception: string;
+    };
     'node-finish': { finished: string[] };
     'iterator-progress-update': { percent: number; iteratorId: string; running?: string[] };
 }


### PR DESCRIPTION
This PR makes 3 functional changes:

1. Executor errors will no longer be shown twice (causing alerts to overlap). The python executor sends an error out via SSEs and via the return JSON of the `/run` call. I simply made it so that the returned JSON doesn't cause alerts.
2. The `nodeType` property is now required in the interface between frontend and backend. An exception will be thrown in the frontend if a node doesn't have a `nodeType`.
3. Executions errors send via SSE and return JSON will now optionally include information about which node caused the error. This is used to create better error messages, which fixes #450. This is done via a new custom exception type.

    ![image](https://user-images.githubusercontent.com/20878432/179314015-13c38b3b-7528-47bc-b155-1b7f31384403.png)

    Obviously, we could do better. We know exactly which node caused the error, but that's harder to communicate to users.

I also added a few more type annotations in the backend here and there.