### PR TITLE
Added gamma adjust node

### DIFF
--- a/backend/src/nodes/image_adj_nodes.py
+++ b/backend/src/nodes/image_adj_nodes.py
@@ -297,3 +297,49 @@ class OpacityNode(NodeBase):
         imgout[:, :, 3] *= opacity
 
         return imgout
+
+
+@NodeFactory.register("chainner:image:gamma")
+class GammaNode(NodeBase):
+    def __init__(self):
+        super().__init__()
+        self.description = "Adjusts the gamma of an image."
+        self.inputs = [
+            ImageInput(),
+            NumberInput(
+                "Gamma",
+                minimum=0.01,
+                maximum=100,
+                default=1,
+                step=0.0001,
+                controls_step=0.1,
+            ),
+            GammaOptionInput(),
+        ]
+        self.outputs = [ImageOutput(image_type="Input0")]
+        self.category = IMAGE_ADJUSTMENT
+        self.name = "Gamma"
+        self.icon = "ImBrightnessContrast"
+        self.sub = "Adjustments"
+
+    def run(self, img: np.ndarray, gamma: float, gamma_option: str) -> np.ndarray:
+        if gamma == 1:
+            # noop
+            return img
+
+        if gamma_option == "normal":
+            pass
+        elif gamma_option == "invert":
+            gamma = 1 / gamma
+        else:
+            assert False, f"Invalid gamma option: {gamma_option}"
+
+        # single-channel grayscale
+        if img.ndim == 2:
+            return img**gamma
+
+        img = img.copy()
+        # apply gamma to the first 3 channels
+        c = get_h_w_c(img)[2]
+        img[:, :, : min(c, 3)] **= gamma
+        return img

--- a/backend/src/nodes/properties/inputs/image_dropdown_inputs.py
+++ b/backend/src/nodes/properties/inputs/image_dropdown_inputs.py
@@ -241,3 +241,14 @@ def TileModeInput():
             },
         ],
     )
+
+
+def GammaOptionInput():
+    return DropDownInput(
+        input_type="GammaOption",
+        label="Gamma Option",
+        options=[
+            {"option": "None", "value": "normal"},
+            {"option": "Invert gamma", "value": "invert"},
+        ],
+    )

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -45,15 +45,15 @@ struct AdaptiveMethod;
 struct AdaptiveThresholdType;
 struct BlendMode;
 struct BorderType;
+struct ColorMode { inputChannels: 1 | 3 | 4, outputChannels: 1 | 3 | 4 }
 struct Colorspace;
 struct FillColor;
 struct FillMethod;
 struct FlipAxis;
+struct GammaOption;
 struct ImageExtension;
 struct InterpolationMode;
-struct Horizontal;
-struct Vertical;
-let Orientation = Horizontal | Vertical;
+struct MathOperation { operation: string }
 struct OverflowMethod;
 struct ReciprocalScalingFactor;
 struct RotateExpandCrop;
@@ -61,8 +61,10 @@ struct RotateInterpolationMode;
 struct ThresholdType;
 struct TileMode;
 struct VideoType;
-struct ColorMode { inputChannels: 1 | 3 | 4, outputChannels: 1 | 3 | 4 }
-struct MathOperation { operation: string }
+
+struct Horizontal;
+struct Vertical;
+let Orientation = Horizontal | Vertical;
 
 // util function for upscaling nodes
 let real = ..;


### PR DESCRIPTION
Resolves #565.

![image](https://user-images.githubusercontent.com/20878432/179401700-53e2ab5d-4b73-4cb5-beed-b2efad8e11cb.png)

---

I'm not sure about the name "Gamma Options." I wanted to add an easy way to invert a given gamma value, so that the user doesn't have to input `1/gamma` themself, which can be very annoying because common the reciprocals of some common gamma values are repeating decimals. E.g. 2.2 is commonly used to convert sRGB to linear RGB and 0.4545454545... is used to convert back to sRGB.