### PR TITLE
Correctly sort nodes in node selectors

### DIFF
--- a/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
+++ b/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
@@ -30,6 +30,7 @@ import {
     getMatchingNodes,
     getNodesByCategory,
     getSubcategories,
+    sortSchemata,
 } from '../../helpers/nodeSearchFuncs';
 import { useNodeFavorites } from '../../hooks/useNodeFavorites';
 import { FavoritesAccordionItem } from './FavoritesAccordionItem';
@@ -45,7 +46,7 @@ export const NodeSelector = memo(({ schemata }: NodeSelectorProps) => {
 
     const [searchQuery, setSearchQuery] = useState('');
 
-    const matchingNodes = getMatchingNodes(searchQuery, schemata.schemata);
+    const matchingNodes = getMatchingNodes(searchQuery, sortSchemata(schemata.schemata));
     const byCategories = useMemo(() => getNodesByCategory(matchingNodes), [matchingNodes]);
 
     const [collapsed, setCollapsed] = useContextSelector(

--- a/src/renderer/helpers/nodeSearchFuncs.ts
+++ b/src/renderer/helpers/nodeSearchFuncs.ts
@@ -23,8 +23,21 @@ export const createSearchPredicate = (query: string): ((name: string) => boolean
     return (name) => pattern.isMatch(name);
 };
 
-export const compareIgnoreCase = (a: string, b: string): number => {
+const compareIgnoreCase = (a: string, b: string): number => {
     return a.toUpperCase().localeCompare(b.toUpperCase());
+};
+
+export const sortSchemata = (schemata: readonly NodeSchema[]): NodeSchema[] => {
+    const categories = new Map([...new Set(schemata.map((s) => s.category))].map((c, i) => [c, i]));
+    return [...schemata].sort((a, b) => {
+        const categoryCompare =
+            (categories.get(a.category) ?? 0) - (categories.get(b.category) ?? 0);
+        return (
+            categoryCompare ||
+            compareIgnoreCase(a.subcategory, b.subcategory) ||
+            compareIgnoreCase(a.name, b.name)
+        );
+    });
 };
 
 export const byCategory = (nodes: readonly NodeSchema[]): Map<string, NodeSchema[]> => {
@@ -39,21 +52,14 @@ export const byCategory = (nodes: readonly NodeSchema[]): Map<string, NodeSchema
 
 /**
  * Returns a map that maps for sub category name to all nodes of that sub category.
- *
- * The nodes per subcategory are sorted by name.
  */
 export const getSubcategories = (nodes: readonly NodeSchema[]) => {
     const map = new Map<string, NodeSchema[]>();
-    [...nodes]
-        .sort(
-            (a, b) =>
-                compareIgnoreCase(a.subcategory, b.subcategory) || compareIgnoreCase(a.name, b.name)
-        )
-        .forEach((n) => {
-            const list = map.get(n.subcategory) ?? [];
-            map.set(n.subcategory, list);
-            list.push(n);
-        });
+    nodes.forEach((n) => {
+        const list = map.get(n.subcategory) ?? [];
+        map.set(n.subcategory, list);
+        list.push(n);
+    });
     return map;
 };
 

--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -31,7 +31,7 @@ import { ContextMenuContext } from '../contexts/ContextMenuContext';
 import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { interpolateColor } from '../helpers/colorTools';
 import { getNodeAccentColor } from '../helpers/getNodeAccentColor';
-import { getMatchingNodes, getNodesByCategory } from '../helpers/nodeSearchFuncs';
+import { getMatchingNodes, getNodesByCategory, sortSchemata } from '../helpers/nodeSearchFuncs';
 import { TypeState } from '../helpers/TypeState';
 import { useContextMenu } from './useContextMenu';
 import { useNodeFavorites } from './useNodeFavorites';
@@ -46,7 +46,7 @@ const Menu = memo(({ onSelect, schemata, favorites }: MenuProps) => {
     const [searchQuery, setSearchQuery] = useState('');
 
     const byCategories = useMemo(
-        () => getNodesByCategory(getMatchingNodes(searchQuery, schemata)),
+        () => getNodesByCategory(getMatchingNodes(searchQuery, sortSchemata(schemata))),
         [searchQuery, schemata]
     );
 


### PR DESCRIPTION
Sorting was implemented in `getSubcategories` which was only used by the node selector panel's main categories. So favorites and all nodes in the context selector were unsorted.

I add a `sortSchemata` method to fix this.