### PR TITLE
Add spritesheet iterator

### DIFF
--- a/backend/src/nodes/image_iterator_nodes.py
+++ b/backend/src/nodes/image_iterator_nodes.py
@@ -22,6 +22,9 @@ IMAGE_ITERATOR_NODE_ID = "chainner:image:file_iterator_load"
 VIDEO_ITERATOR_INPUT_NODE_ID = "chainner:image:simple_video_frame_iterator_load"
 VIDEO_ITERATOR_OUTPUT_NODE_ID = "chainner:image:simple_video_frame_iterator_save"
 
+SPRITESHEET_ITERATOR_INPUT_NODE_ID = "chainner:image:spritesheet_iterator_load"
+SPRITESHEET_ITERATOR_OUTPUT_NODE_ID = "chainner:image:spritesheet_iterator_save"
+
 
 @NodeFactory.register(IMAGE_ITERATOR_NODE_ID)
 class ImageFileIteratorLoadImageNode(NodeBase):
@@ -344,3 +347,177 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
         cap.release()
         if writer["out"] is not None:
             writer["out"].release()
+
+
+@NodeFactory.register(SPRITESHEET_ITERATOR_INPUT_NODE_ID)
+class ImageFileIteratorLoadImageNode(NodeBase):
+    def __init__(self):
+        super().__init__()
+        self.description = ""
+        self.inputs = [IteratorInput().make_optional()]
+        self.outputs = [ImageOutput()]
+
+        self.category = IMAGE
+        self.name = "Load Image (Iterator)"
+        self.icon = "MdSubdirectoryArrowRight"
+        self.sub = "Iteration"
+
+        self.type = "iteratorHelper"
+
+    def run(self, img: np.ndarray) -> np.ndarray:
+        return img
+
+
+@NodeFactory.register(SPRITESHEET_ITERATOR_OUTPUT_NODE_ID)
+class ImageFileIteratorAppendImageNode(NodeBase):
+    def __init__(self):
+        super().__init__()
+        self.description = ""
+        self.inputs = [ImageInput()]
+        self.outputs = []
+
+        self.category = IMAGE
+        self.name = "Append Image"
+        self.icon = "CgExtensionAdd"
+        self.sub = "Iteration"
+
+        self.type = "iteratorHelper"
+
+        self.side_effects = True
+
+    def run(self, img: np.ndarray, results: List[np.ndarray]) -> None:
+        results.append(img)
+
+
+@NodeFactory.register("chainner:image:spritesheet_iterator")
+class ImageSpriteSheetIteratorNode(IteratorNodeBase):
+    def __init__(self):
+        super().__init__()
+        self.description = "Iterate over sub-images in a single image spritesheet."
+        self.inputs = [
+            ImageInput("Spritesheet"),
+            NumberInput("Number of rows (vertical)", 1, 1, 1, 1),
+            NumberInput("Number of columns (horizontal)", 1, 1, 1, 1),
+        ]
+        self.outputs = [ImageOutput()]
+        self.category = IMAGE
+        self.name = "Spritesheet Iterator"
+        self.default_nodes = [
+            # TODO: Figure out a better way to do this
+            {
+                "schemaId": SPRITESHEET_ITERATOR_INPUT_NODE_ID,
+            },
+            {
+                "schemaId": SPRITESHEET_ITERATOR_OUTPUT_NODE_ID,
+            },
+        ]
+
+    # pylint: disable=invalid-overridden-method
+    async def run(
+        self,
+        sprite_sheet: np.ndarray,
+        rows: int,
+        columns: int,
+        nodes: Union[dict, None] = None,
+        external_cache: Union[dict, None] = None,
+        loop=None,
+        queue: asyncio.Queue = asyncio.Queue(),
+        iterator_id="",
+        parent_executor=None,
+        percent=0,
+    ) -> np.ndarray:
+        assert nodes is not None, "Nodes must be provided"
+        assert external_cache is not None, "External cache must be provided"
+
+        h, w, _ = get_h_w_c(sprite_sheet)
+        assert (
+            h % rows == 0
+        ), "Height of sprite sheet must be a multiple of the number of rows"
+        assert (
+            w % columns == 0
+        ), "Width of sprite sheet must be a multiple of the number of columns"
+
+        img_loader_node_id = None
+        output_node_id = None
+        child_nodes = []
+        for k, v in nodes.items():
+            if v["schemaId"] == SPRITESHEET_ITERATOR_INPUT_NODE_ID:
+                img_loader_node_id = v["id"]
+            elif v["schemaId"] == SPRITESHEET_ITERATOR_OUTPUT_NODE_ID:
+                output_node_id = v["id"]
+            if nodes[k]["child"]:
+                child_nodes.append(v["id"])
+            # Set this to false to actually allow processing to happen
+            nodes[k]["child"] = False
+
+        individual_h = h // rows
+        individual_w = w // columns
+
+        # Split sprite sheet into a single list of images
+        img_list = []
+        for row in range(rows):
+            for col in range(columns):
+                img_list.append(
+                    sprite_sheet[
+                        row * individual_h : (row + 1) * individual_h,
+                        col * individual_w : (col + 1) * individual_w,
+                    ]
+                )
+
+        # img_arr = np.array_split(sprite_sheet, rows, axis=0)
+        # img_arr = np.array_split(img_arr, columns, axis=1)
+
+        length = len(img_list)
+
+        results = []
+        nodes[output_node_id]["inputs"].append(results)
+        for idx, img in enumerate(img_list):
+            if parent_executor is not None and parent_executor.should_stop_running():
+                break
+            await queue.put(
+                {
+                    "event": "iterator-progress-update",
+                    "data": {
+                        "percent": idx / length,
+                        "iteratorId": iterator_id,
+                        "running": child_nodes,
+                    },
+                }
+            )
+            # Replace the input filepath with the filepath from the loop
+            nodes[img_loader_node_id]["inputs"] = [img]
+            # logger.info(nodes[output_node_id]["inputs"])
+            executor = Executor(
+                nodes,
+                loop,
+                queue,
+                external_cache.copy(),
+                parent_executor=parent_executor,
+            )
+            await executor.run()
+            await queue.put(
+                {
+                    "event": "iterator-progress-update",
+                    "data": {
+                        "percent": (idx + 1) / length,
+                        "iteratorId": iterator_id,
+                        "running": None,
+                    },
+                }
+            )
+        logger.info(results)
+        # Turn the results dict into an array
+        # results = list(results.values())
+        # Merge results back into sprite sheet
+        # sheet_arr = np.reshape(np.array(results), (-1, columns))
+        # # result_arr = []
+        # # for i in range(sheet_arr.shape[0]):
+        # #     row = np.concatenate(sheet_arr[i], axis=1)
+        # concat_1 = np.concatenate(sheet_arr, axis=0)
+        # concat_2 = np.concatenate(concat_1, axis=1)
+        # logger.info(concat_2.shape)
+        result_rows = []
+        for i in range(rows):
+            row = np.concatenate(results[i * columns : (i + 1) * columns], axis=1)
+            result_rows.append(row)
+        return np.concatenate(result_rows, axis=0)

--- a/backend/src/nodes/image_iterator_nodes.py
+++ b/backend/src/nodes/image_iterator_nodes.py
@@ -81,7 +81,7 @@ class ImageFileIteratorNode(IteratorNodeBase):
         directory: str,
         nodes: Union[dict, None] = None,
         external_cache: Union[dict, None] = None,
-        loop=None,
+        loop: asyncio.AbstractEventLoop = asyncio.AbstractEventLoop(),
         queue: asyncio.Queue = asyncio.Queue(),
         iterator_id="",
         parent_executor=None,
@@ -267,7 +267,7 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
         path: str,
         nodes: Union[dict, None] = None,
         external_cache: Union[dict, None] = None,
-        loop=None,
+        loop: asyncio.AbstractEventLoop = asyncio.AbstractEventLoop(),
         queue: asyncio.Queue = asyncio.Queue(),
         iterator_id="",
         parent_executor=None,
@@ -350,7 +350,7 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
 
 
 @NodeFactory.register(SPRITESHEET_ITERATOR_INPUT_NODE_ID)
-class ImageFileIteratorLoadImageNode(NodeBase):
+class ImageSpriteSheetIteratorLoadImageNode(NodeBase):
     def __init__(self):
         super().__init__()
         self.description = ""
@@ -369,7 +369,7 @@ class ImageFileIteratorLoadImageNode(NodeBase):
 
 
 @NodeFactory.register(SPRITESHEET_ITERATOR_OUTPUT_NODE_ID)
-class ImageFileIteratorAppendImageNode(NodeBase):
+class ImageSpriteSheetIteratorAppendImageNode(NodeBase):
     def __init__(self):
         super().__init__()
         self.description = ""
@@ -420,11 +420,11 @@ class ImageSpriteSheetIteratorNode(IteratorNodeBase):
         columns: int,
         nodes: Union[dict, None] = None,
         external_cache: Union[dict, None] = None,
-        loop=None,
+        loop: asyncio.AbstractEventLoop = asyncio.AbstractEventLoop(),
         queue: asyncio.Queue = asyncio.Queue(),
         iterator_id="",
         parent_executor=None,
-        percent=0,
+        _percent=0,
     ) -> np.ndarray:
         assert nodes is not None, "Nodes must be provided"
         assert external_cache is not None, "External cache must be provided"
@@ -464,9 +464,6 @@ class ImageSpriteSheetIteratorNode(IteratorNodeBase):
                     ]
                 )
 
-        # img_arr = np.array_split(sprite_sheet, rows, axis=0)
-        # img_arr = np.array_split(img_arr, columns, axis=1)
-
         length = len(img_list)
 
         results = []
@@ -505,17 +502,6 @@ class ImageSpriteSheetIteratorNode(IteratorNodeBase):
                     },
                 }
             )
-        logger.info(results)
-        # Turn the results dict into an array
-        # results = list(results.values())
-        # Merge results back into sprite sheet
-        # sheet_arr = np.reshape(np.array(results), (-1, columns))
-        # # result_arr = []
-        # # for i in range(sheet_arr.shape[0]):
-        # #     row = np.concatenate(sheet_arr[i], axis=1)
-        # concat_1 = np.concatenate(sheet_arr, axis=0)
-        # concat_2 = np.concatenate(concat_1, axis=1)
-        # logger.info(concat_2.shape)
         result_rows = []
         for i in range(rows):
             row = np.concatenate(results[i * columns : (i + 1) * columns], axis=1)

--- a/backend/src/nodes/image_iterator_nodes.py
+++ b/backend/src/nodes/image_iterator_nodes.py
@@ -396,8 +396,20 @@ class ImageSpriteSheetIteratorNode(IteratorNodeBase):
         self.description = "Iterate over sub-images in a single image spritesheet."
         self.inputs = [
             ImageInput("Spritesheet"),
-            NumberInput("Number of rows (vertical)", 1, 1, 1, 1),
-            NumberInput("Number of columns (horizontal)", 1, 1, 1, 1),
+            NumberInput(
+                "Number of rows (vertical)",
+                step=1,
+                controls_step=1,
+                minimum=1,
+                default=1,
+            ),
+            NumberInput(
+                "Number of columns (horizontal)",
+                step=1,
+                controls_step=1,
+                minimum=1,
+                default=1,
+            ),
         ]
         self.outputs = [ImageOutput()]
         self.category = IMAGE
@@ -424,7 +436,8 @@ class ImageSpriteSheetIteratorNode(IteratorNodeBase):
         queue: asyncio.Queue = asyncio.Queue(),
         iterator_id="",
         parent_executor=None,
-        _percent=0,
+        # pylint: disable=unused-argument
+        percent=0,
     ) -> np.ndarray:
         assert nodes is not None, "Nodes must be provided"
         assert external_cache is not None, "External cache must be provided"
@@ -455,6 +468,7 @@ class ImageSpriteSheetIteratorNode(IteratorNodeBase):
 
         # Split sprite sheet into a single list of images
         img_list = []
+
         for row in range(rows):
             for col in range(columns):
                 img_list.append(


### PR DESCRIPTION
Sorta does what #564 wants, though this will need to be revisited when we change how iterators are. What this does, is it takes in a spritesheet and the number of rows and columns to split it into, and then iterates over them all, then takes the results and combines them back into a spritesheet.

This doesn't entirely solve the use case mentioned in discord, but it should help when you want to upscale individual sprites in a sheet rather than doing them all at once.