### PR TITLE
Added a test to verify that all of Chainner's type definitions are valid

### DIFF
--- a/tests/common/chainner-scope.test.ts
+++ b/tests/common/chainner-scope.test.ts
@@ -1,0 +1,31 @@
+import { getChainnerScope } from '../../src/common/types/chainner-scope';
+import { evaluate } from '../../src/common/types/evaluate';
+import { FunctionCallExpression, NamedExpression } from '../../src/common/types/expression';
+import { assertNever } from '../../src/common/util';
+
+// eslint-disable-next-line consistent-return
+test(`Chainner scope is correct`, () => {
+    const scope = getChainnerScope();
+    for (const [name, def] of scope.definitions) {
+        switch (def.type) {
+            case 'variable':
+            case 'struct':
+                evaluate(new NamedExpression(name), scope);
+                break;
+            case 'builtin-function':
+                evaluate(new FunctionCallExpression(name, def.definition.parameters), scope);
+                break;
+            case 'function':
+                evaluate(
+                    new FunctionCallExpression(
+                        name,
+                        def.definition.parameters.map((p) => p.type)
+                    ),
+                    scope
+                );
+                break;
+            default:
+                return assertNever(def);
+        }
+    }
+});


### PR DESCRIPTION
What the title says. The test goes through all definitions and evaluates them. If a definition is invalid, an evaluation error will be thrown and the test will fail.