### PR TITLE
Disable context menu option for file and dir inputs

### DIFF
--- a/src/renderer/components/inputs/DirectoryInput.tsx
+++ b/src/renderer/components/inputs/DirectoryInput.tsx
@@ -45,6 +45,7 @@ export const DirectoryInput = memo(
         const menu = useContextMenu(() => (
             <MenuList className="nodrag">
                 <MenuItem
+                    disabled={isLocked || isInputLocked}
                     icon={<BsFolderPlus />}
                     // eslint-disable-next-line @typescript-eslint/no-misused-promises
                     onClick={onButtonClick}

--- a/src/renderer/components/inputs/FileInput.tsx
+++ b/src/renderer/components/inputs/FileInput.tsx
@@ -151,6 +151,7 @@ export const FileInput = memo(
         const menu = useContextMenu(() => (
             <MenuList className="nodrag">
                 <MenuItem
+                    disabled={isLocked || isInputLocked}
                     icon={<BsFileEarmarkPlus />}
                     // eslint-disable-next-line @typescript-eslint/no-misused-promises
                     onClick={onButtonClick}


### PR DESCRIPTION
This fixes a small bug I noticed. It was possible to select a file/dir using the context menu even when the input was disabled.