### PR TITLE
Minor improvements to numeric inputs

### DIFF
--- a/backend/src/nodes/properties/inputs/numeric_inputs.py
+++ b/backend/src/nodes/properties/inputs/numeric_inputs.py
@@ -95,7 +95,7 @@ class NumberInput(BaseInput):
         }
 
     def make_optional(self):
-        raise ValueError("DropDownInput cannot be made optional")
+        raise ValueError("NumberInput and SliderInput cannot be made optional")
 
     def enforce(self, value):
         return clampNumber(value, self.offset, self.step, self.minimum, self.maximum)
@@ -143,6 +143,3 @@ class SliderInput(NumberInput):
             "ends": self.ends,
             "sliderStep": self.slider_step,
         }
-
-    def enforce(self, value):
-        return clampNumber(value, self.offset, self.step, self.minimum, self.maximum)


### PR DESCRIPTION
Changes:
- Improved the `make_optional` error message.
- Removed SliderInput's `enforce` method. I should inherit that from NumberInput (I think).