### PR TITLE
Refactored type compatibility checks

### DIFF
--- a/src/common/types/function.ts
+++ b/src/common/types/function.ts
@@ -270,6 +270,22 @@ export class FunctionDefinition {
     static fromSchema(schema: NodeSchema, scope: ReadonlyScope): FunctionDefinition {
         return new FunctionDefinition(schema, scope);
     }
+
+    canAssignInput(inputId: InputId, type: Type): boolean {
+        const inputType = this.inputDefaults.get(inputId);
+        if (!inputType) {
+            throw new Error('Invalid input id');
+        }
+        return !isDisjointWith(inputType, type);
+    }
+
+    canAssignOutput(outputId: OutputId, type: Type): boolean {
+        const outputType = this.outputDefaults.get(outputId);
+        if (!outputType) {
+            throw new Error('Invalid output id');
+        }
+        return !isDisjointWith(outputType, type);
+    }
 }
 
 export interface FunctionInputAssignmentError {

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -81,7 +81,6 @@ interface GlobalVolatile {
     effectivelyDisabledNodes: ReadonlySet<string>;
     zoom: number;
     hoveredNode: string | null | undefined;
-    useConnectingFromType: readonly [Type | null, SetState<Type | null>];
     useConnectingFrom: readonly [
         OnConnectStartParams | null,
         SetState<OnConnectStartParams | null>
@@ -940,7 +939,6 @@ export const GlobalProvider = memo(
 
         const [zoom, setZoom] = useState(1);
 
-        const [connectingFromType, setConnectingFromType] = useState<Type | null>(null);
         const [connectingFrom, setConnectingFrom] = useState<OnConnectStartParams | null>(null);
 
         const globalChainValue = useMemoObject<GlobalVolatile>({
@@ -954,10 +952,6 @@ export const GlobalProvider = memo(
             isValidConnection,
             zoom,
             hoveredNode,
-            useConnectingFromType: useMemoArray([
-                connectingFromType,
-                setConnectingFromType,
-            ] as const),
             useConnectingFrom: useMemoArray([connectingFrom, setConnectingFrom] as const),
         });
 

--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -16,9 +16,8 @@ import {
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { Node, OnConnectStartParams, useReactFlow } from 'react-flow-renderer';
 import { useContext } from 'use-context-selector';
-import { NodeData, NodeSchema, SchemaId } from '../../common/common-types';
+import { InputId, NodeData, NodeSchema, OutputId, SchemaId } from '../../common/common-types';
 import { FunctionDefinition } from '../../common/types/function';
-import { isDisjointWith } from '../../common/types/intersection';
 import { Type } from '../../common/types/types';
 import {
     assertNever,
@@ -188,6 +187,11 @@ const Menu = memo(({ onSelect, schemata, favorites }: MenuProps) => {
     );
 });
 
+const getFirstPossibleInput = (fn: FunctionDefinition, type: Type): InputId | undefined =>
+    fn.schema.inputs.find((i) => i.hasHandle && fn.canAssignInput(i.id, type))?.id;
+const getFirstPossibleOutput = (fn: FunctionDefinition, type: Type): OutputId | undefined =>
+    fn.schema.outputs.find((o) => fn.canAssignOutput(o.id, type))?.id;
+
 const canConnectWith = (
     connectingFrom: OnConnectStartParams,
     schema: NodeSchema,
@@ -200,28 +204,18 @@ const canConnectWith = (
     }
     switch (connectingFrom.handleType) {
         case 'source': {
-            const sourceFn = typeState.functions.get(connectingFrom.nodeId);
-            if (!sourceFn) {
-                return false;
-            }
-
             const { inOutId } = parseSourceHandle(connectingFrom.handleId);
-            const sourceType = sourceFn.outputs.get(inOutId);
+            const sourceType = typeState.functions.get(connectingFrom.nodeId)?.outputs.get(inOutId);
             if (!sourceType) {
                 return false;
             }
 
-            const targetTypes = functionDefinitions.get(schema.schemaId);
-            if (!targetTypes) {
+            const targetFn = functionDefinitions.get(schema.schemaId);
+            if (!targetFn) {
                 return false;
             }
 
-            return [...targetTypes.inputDefaults].some(([inputId, type]) => {
-                return (
-                    !isDisjointWith(type, sourceType) &&
-                    schema.inputs.find((i) => i.id === inputId)?.hasHandle
-                );
-            });
+            return getFirstPossibleInput(targetFn, sourceType) !== undefined;
         }
         case 'target': {
             const sourceNode = getNode(connectingFrom.nodeId);
@@ -239,14 +233,12 @@ const canConnectWith = (
                 return false;
             }
 
-            const targetTypes = functionDefinitions.get(schema.schemaId);
-            if (!targetTypes) {
+            const targetFn = functionDefinitions.get(schema.schemaId);
+            if (!targetFn) {
                 return false;
             }
 
-            return [...targetTypes.outputDefaults].some(([, type]) => {
-                return !isDisjointWith(type, sourceType);
-            });
+            return getFirstPossibleOutput(targetFn, sourceType) !== undefined;
         }
         default:
             assertNever(connectingFrom.handleType);
@@ -268,7 +260,7 @@ interface Position {
 export const usePaneNodeSearchMenu = (
     wrapperRef: React.RefObject<HTMLDivElement>
 ): UsePaneNodeSearchMenuValue => {
-    const { createNode, createConnection, typeState, useConnectingFromType, useConnectingFrom } =
+    const { createNode, createConnection, typeState, useConnectingFrom } =
         useContext(GlobalVolatileContext);
     const { closeContextMenu } = useContext(ContextMenuContext);
     const { schemata, functionDefinitions } = useContext(GlobalContext);
@@ -276,7 +268,6 @@ export const usePaneNodeSearchMenu = (
     const { favorites } = useNodeFavorites();
 
     const [connectingFrom, setConnectingFrom] = useState<OnConnectStartParams | null>(null);
-    const [, setGlobalConnectingFromType] = useConnectingFromType;
     const [, setGlobalConnectingFrom] = useConnectingFrom;
     const [connectingFromType, setConnectingFromType] = useState<Type | null>(null);
 
@@ -314,44 +305,33 @@ export const usePaneNodeSearchMenu = (
                 },
                 nodeType: schema.nodeType,
             });
-            const targetTypes = functionDefinitions.get(schema.schemaId);
+            const targetFn = functionDefinitions.get(schema.schemaId);
             if (
                 isStoppedOnPane &&
                 connectingFrom &&
-                targetTypes &&
+                targetFn &&
                 connectingFromType &&
                 connectingFrom.handleType
             ) {
                 switch (connectingFrom.handleType) {
                     case 'source': {
-                        const firstPossibleTarget = [...targetTypes.inputDefaults].find(
-                            ([inputId, type]) => {
-                                return (
-                                    !isDisjointWith(type, connectingFromType) &&
-                                    schema.inputs.find((i) => i.id === inputId)?.hasHandle
-                                );
-                            }
-                        );
-                        if (firstPossibleTarget) {
+                        const first = getFirstPossibleInput(targetFn, connectingFromType);
+                        if (first !== undefined) {
                             createConnection({
                                 source: connectingFrom.nodeId,
                                 sourceHandle: connectingFrom.handleId,
                                 target: nodeId,
-                                targetHandle: `${nodeId}-${firstPossibleTarget[0]}`,
+                                targetHandle: `${nodeId}-${first}`,
                             });
                         }
                         break;
                     }
                     case 'target': {
-                        const firstPossibleTarget = [...targetTypes.outputDefaults].find(
-                            ([, type]) => {
-                                return !isDisjointWith(type, connectingFromType);
-                            }
-                        );
-                        if (firstPossibleTarget) {
+                        const first = getFirstPossibleOutput(targetFn, connectingFromType);
+                        if (first !== undefined) {
                             createConnection({
                                 source: nodeId,
-                                sourceHandle: `${nodeId}-${firstPossibleTarget[0]}`,
+                                sourceHandle: `${nodeId}-${first}`,
                                 target: connectingFrom.nodeId,
                                 targetHandle: connectingFrom.handleId,
                             });
@@ -399,7 +379,6 @@ export const usePaneNodeSearchMenu = (
                             .get(node.data.schemaId)
                             ?.outputDefaults.get(inOutId);
                         setConnectingFromType(sourceType ?? null);
-                        setGlobalConnectingFromType(sourceType ?? null);
                         break;
                     }
                     case 'target': {
@@ -408,7 +387,6 @@ export const usePaneNodeSearchMenu = (
                             .get(node.data.schemaId)
                             ?.inputDefaults.get(inOutId);
                         setConnectingFromType(targetType ?? null);
-                        setGlobalConnectingFromType(targetType ?? null);
                         break;
                     }
                     default:
@@ -448,7 +426,6 @@ export const usePaneNodeSearchMenu = (
                 x: event.pageX,
                 y: event.pageY,
             });
-            setGlobalConnectingFromType(null);
             setGlobalConnectingFrom(null);
         },
         [setCoordinates, setIsStoppedOnPane]


### PR DESCRIPTION
Changes:
- FunctionDefinition now has a method to check input/output type compatibility. This is important because I need to change this check for the number rounding thing.
- I removed some unnecessary code from InputContainer/OutputContainer. `isValidConnextion` already does type checking. No need to repeat it. This also made `useConnectingFromType` from GlobalNodeState unnecessary.
- I added getFirstPossibleInput/Output functions for the context pane.