### PR TITLE
Don't highlight AMD GPUs red

### DIFF
--- a/src/renderer/contexts/DependencyContext.tsx
+++ b/src/renderer/contexts/DependencyContext.tsx
@@ -237,7 +237,6 @@ export const DependencyProvider = memo(({ children }: React.PropsWithChildren<un
                                     w="full"
                                 >
                                     <Text
-                                        color={gpu.isNvidia ? 'inherit' : 'red.500'}
                                         flex="1"
                                         textAlign="left"
                                     >


### PR DESCRIPTION
Fixes #556 

I think there maybe should also be some kind of description for each dependency that explains what it is and why it would be needed, and shows stuff like "Recommended for Nvidia users or for those who want to convert pytorch models (.pth) to other formats" for pytorch and "Recommended for AMD users" for ncnn, and maybe gives links to their main pages or something. But that can be a separate ticket