### PR TITLE
Extracted the code for running a single node out into a hook

### DIFF
--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -179,3 +179,9 @@ export const topologicalSort = <T>(
 export const isStartingNode = (schema: NodeSchema) => {
     return !schema.inputs.some((i) => i.hasHandle);
 };
+
+export const delay = (ms: number): Promise<void> => {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+};

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -1,23 +1,20 @@
 import { Center, VStack, useColorModeValue } from '@chakra-ui/react';
-import isDeepEqual from 'fast-deep-equal/react';
 import path from 'path';
 import { DragEvent, memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useReactFlow } from 'react-flow-renderer';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { getBackend } from '../../../common/Backend';
 import { EdgeData, Input, NodeData } from '../../../common/common-types';
 import { isStartingNode } from '../../../common/util';
 import { AlertBoxContext } from '../../contexts/AlertBoxContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
-import { SettingsContext } from '../../contexts/SettingsContext';
 import { Validity, checkNodeValidity } from '../../helpers/checkNodeValidity';
 import { shadeColor } from '../../helpers/colorTools';
 import { getSingleFileWithExtension } from '../../helpers/dataTransfer';
 import { DisabledStatus } from '../../helpers/disabled';
 import { getNodeAccentColor } from '../../helpers/getNodeAccentColor';
-import { useAsyncEffect } from '../../hooks/useAsyncEffect';
 import { useDisabled } from '../../hooks/useDisabled';
 import { useNodeMenu } from '../../hooks/useNodeMenu';
+import { useRunNode } from '../../hooks/useRunNode';
 import { NodeBody } from './NodeBody';
 import { NodeFooter } from './NodeFooter/NodeFooter';
 import { NodeHeader } from './NodeHeader';
@@ -54,14 +51,9 @@ export interface NodeProps {
 const NodeInner = memo(({ data, selected }: NodeProps) => {
     const { sendToast } = useContext(AlertBoxContext);
     const edgeChanges = useContextSelector(GlobalVolatileContext, (c) => c.edgeChanges);
-    const { schemata, updateIteratorBounds, setHoveredNode, useInputData, changeNodes } =
+    const { schemata, updateIteratorBounds, setHoveredNode, useInputData } =
         useContext(GlobalContext);
     const { getEdges } = useReactFlow<NodeData, EdgeData>();
-    const { useIsCpu, useIsFp16, port } = useContext(SettingsContext);
-    const backend = getBackend(port);
-
-    const [isCpu] = useIsCpu;
-    const [isFp16] = useIsFp16;
 
     const { id, inputData, inputSize, isLocked, parentNode, schemaId, animated = false } = data;
 
@@ -160,72 +152,7 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
     const bgColor = useColorModeValue('gray.400', 'gray.750');
     const shadowColor = useColorModeValue('gray.600', 'gray.900');
 
-    const inputDataRef = useRef(inputData);
-    if (!isDeepEqual(inputDataRef.current, inputData)) {
-        inputDataRef.current = inputData;
-    }
-    const [shouldRun, setShouldRun] = useState(false);
-    useEffect(() => {
-        setShouldRun(
-            !isLocked &&
-                !disabled.isDirectlyDisabled &&
-                validity.isValid &&
-                isStartingNode(schema) &&
-                // Without the below line, the node will run the first render after clearing, which we don't want.
-                Object.values(inputData).length >= inputs.filter((i) => !i.optional).length
-        );
-    }, [inputDataRef.current, validity.isValid]);
-
-    useAsyncEffect(async () => {
-        if (shouldRun) {
-            changeNodes((nodes) =>
-                nodes.map((n) => {
-                    if (n.id === id) {
-                        return {
-                            ...n,
-                            data: {
-                                ...n.data,
-                                animated: true,
-                            },
-                        };
-                    }
-                    return n;
-                })
-            );
-
-            const result = await backend.runIndividual({
-                schemaId,
-                id,
-                inputs: Object.values(inputData),
-                isCpu,
-                isFp16,
-            });
-
-            changeNodes((nodes) =>
-                nodes.map((n) => {
-                    if (n.id === id) {
-                        return {
-                            ...n,
-                            data: {
-                                ...n.data,
-                                animated: false,
-                            },
-                        };
-                    }
-                    return n;
-                })
-            );
-
-            if (!result.success) {
-                sendToast({
-                    status: 'error',
-                    title: 'Error',
-                    description: 'Image failed to load, probably unsupported file type.',
-                });
-            }
-            setShouldRun(false);
-        }
-    }, [shouldRun]);
+    useRunNode(data, validity.isValid && isStartingNode(schema));
 
     return (
         <Center

--- a/src/renderer/hooks/useRunNode.ts
+++ b/src/renderer/hooks/useRunNode.ts
@@ -1,0 +1,70 @@
+import { useMemo, useRef } from 'react';
+import { useContext } from 'use-context-selector';
+import { getBackend } from '../../common/Backend';
+import { NodeData } from '../../common/common-types';
+import { delay } from '../../common/util';
+import { AlertBoxContext } from '../contexts/AlertBoxContext';
+import { GlobalContext } from '../contexts/GlobalNodeState';
+import { SettingsContext } from '../contexts/SettingsContext';
+import { useAsyncEffect } from './useAsyncEffect';
+
+export const useRunNode = ({ inputData, id, schemaId }: NodeData, shouldRun: boolean): void => {
+    const { sendToast } = useContext(AlertBoxContext);
+    const { changeNodes } = useContext(GlobalContext);
+    const { useIsCpu, useIsFp16, port } = useContext(SettingsContext);
+    const backend = getBackend(port);
+
+    const [isCpu] = useIsCpu;
+    const [isFp16] = useIsFp16;
+
+    const setAnimated = (nodeAnimated: boolean) => {
+        changeNodes((nodes) =>
+            nodes.map((n) => {
+                if (n.id === id) {
+                    return {
+                        ...n,
+                        data: {
+                            ...n.data,
+                            animated: nodeAnimated,
+                        },
+                    };
+                }
+                return n;
+            })
+        );
+    };
+
+    const inputHash = useMemo(() => JSON.stringify(Object.values(inputData)), [inputData]);
+    const lastRunInputHash = useRef<string>();
+    useAsyncEffect(
+        async (token) => {
+            if (shouldRun && inputHash !== lastRunInputHash.current) {
+                // give it some time for other effects to settle in
+                await delay(50);
+                token.checkCanceled();
+
+                lastRunInputHash.current = inputHash;
+                setAnimated(true);
+
+                const result = await backend.runIndividual({
+                    schemaId,
+                    id,
+                    inputs: Object.values(inputData),
+                    isCpu,
+                    isFp16,
+                });
+
+                setAnimated(false);
+
+                if (!result.success) {
+                    sendToast({
+                        status: 'error',
+                        title: 'Error',
+                        description: 'Image failed to load, probably unsupported file type.',
+                    });
+                }
+            }
+        },
+        [shouldRun, inputHash]
+    );
+};


### PR DESCRIPTION
What the title says. Also:

-  I changed how it is decided when to run a node. Instead of using `useEffect` and some setState functions, I remember the inputs with which the node was last run. This makes it easy to not run nodes again.
- `!isLocked && !disabled.isDirectlyDisabled` seems to be a left over from the disabled bug I reported. I removed this because I don't see why disabled or locked nodes shouldn't have previews.

`useRunNode` is a controlled hook, so the caller decides whether the nodes actually runs. Since the hook has a small delay before actually running, the caller may also change its mind with `useEffect`.