### PR TITLE
Compute broadcasts in parallel to regular node execution

### DIFF
--- a/backend/src/events.py
+++ b/backend/src/events.py
@@ -27,17 +27,14 @@ class ExecutionErrorData(TypedDict):
 
 class NodeFinishData(TypedDict):
     finished: List[str]
+    nodeId: str
+    data: Optional[Dict[int, Any]]
 
 
 class IteratorProgressUpdateData(TypedDict):
     percent: float
     iteratorId: str
     running: Optional[List[str]]
-
-
-class NodeOutputDataData(TypedDict):
-    nodeId: str
-    data: Dict[int, Any]
 
 
 class FinishEvent(TypedDict):
@@ -60,17 +57,11 @@ class IteratorProgressUpdateEvent(TypedDict):
     data: IteratorProgressUpdateData
 
 
-class NodeOutputDataEvent(TypedDict):
-    event: Literal["node-output-data"]
-    data: NodeOutputDataData
-
-
 Event = Union[
     FinishEvent,
     ExecutionErrorEvent,
     NodeFinishEvent,
     IteratorProgressUpdateEvent,
-    NodeOutputDataEvent,
 ]
 
 

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -267,7 +267,8 @@ class Executor:
         # await all broadcasts
         tasks = self.__broadcast_tasks
         self.__broadcast_tasks = []
-        await asyncio.gather(*tasks, loop=self.loop)
+        for task in tasks:
+            await task
 
     async def run(self):
         """Run the executor"""

--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -257,8 +257,12 @@ async def run_individual(request: Request):
                     logger.error(f"Error broadcasting output: {error}")
             await ctx.queue.put(
                 {
-                    "event": "node-output-data",
-                    "data": {"nodeId": full_data["id"], "data": broadcast_data},
+                    "event": "node-finish",
+                    "data": {
+                        "finished": [],
+                        "nodeId": full_data["id"],
+                        "data": broadcast_data,
+                    },
                 }
             )
         # Cache the output of the node

--- a/src/renderer/hooks/useBackendEventSource.ts
+++ b/src/renderer/hooks/useBackendEventSource.ts
@@ -23,9 +23,8 @@ export interface BackendEventMap {
         source?: BackendExceptionSource | null;
         exception: string;
     };
-    'node-finish': { finished: string[] };
+    'node-finish': { finished: string[]; nodeId: string; data?: OutputData | null };
     'iterator-progress-update': { percent: number; iteratorId: string; running?: string[] | null };
-    'node-output-data': { nodeId: string; data: OutputData };
 }
 
 export type BackendEventSourceListener<T extends keyof BackendEventMap> = (


### PR DESCRIPTION
What the title says. I did this by using a ThreadPoolExecutor to compute the broadcast in a separate thread. Since `run_in_executor` does not guarantee any number of threads (it could be just a single thread for all that we know), I explicitly created my own pool with 4 threads. It would be more, but 4 should be more than enough for now.

However, there is one bug(?) I noticed. The `node-output-data` event may now arrive later than `node-finish` event, which causes the frontend to display a "Preview not available" instead of a loading spinner. I don't know whether this is a problem in the frontend (because it assumes that the broadcast arrives before `node-finish`) or in the backend (because it doesn't guarantee the event order).