### PR TITLE
Readonly scope

### DIFF
--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -1,7 +1,7 @@
 import { lazy } from '../util';
 import { globalScope } from './global-scope';
 import { parseDefinitions } from './parse';
-import { ReadonlyScope, Scope } from './scope';
+import { Scope, ScopeBuilder } from './scope';
 import { SourceDocument } from './source';
 
 const code = `
@@ -78,13 +78,13 @@ def getUpscaleChannels(
 }
 `;
 
-export const getChainnerScope = lazy((): ReadonlyScope => {
-    const scope = new Scope('Chainner scope', globalScope);
+export const getChainnerScope = lazy((): Scope => {
+    const builder = new ScopeBuilder('Chainner scope', globalScope);
 
     const definitions = parseDefinitions(new SourceDocument(code, 'chainner-internal'));
     for (const d of definitions) {
-        scope.add(d);
+        builder.add(d);
     }
 
-    return scope;
+    return builder.createScope();
 });

--- a/src/common/types/evaluate.ts
+++ b/src/common/types/evaluate.ts
@@ -465,7 +465,7 @@ const evaluateScope = (expression: ScopeExpression, parentScope: ReadonlyScope):
  *
  * @throws {@link EvaluationError}
  */
-export const evaluate = (expression: Expression, scope: ReadonlyScope): Type => {
+export const evaluate = (expression: Expression, scope: Scope): Type => {
     if (expression.underlying !== 'expression') {
         // type
         return expression;

--- a/src/common/types/evaluate.ts
+++ b/src/common/types/evaluate.ts
@@ -19,11 +19,12 @@ import { isSubsetOf } from './relation';
 import {
     BuiltinFunctionDefinition,
     NameResolutionError,
-    ReadonlyScope,
     ResolvedName,
     Scope,
+    ScopeBuilder,
     ScopeBuiltinFunctionDefinition,
     ScopeFunctionDefinition,
+    ScopeParameterDefinition,
     ScopeStructDefinition,
     ScopeVariableDefinition,
 } from './scope';
@@ -122,10 +123,7 @@ export class EvaluationError extends Error {
     }
 }
 
-const evaluateStructDefinition = (
-    def: StructDefinition,
-    scope: ReadonlyScope
-): StructType | NeverType => {
+const evaluateStructDefinition = (def: StructDefinition, scope: Scope): StructType | NeverType => {
     const fields: StructTypeField[] = [];
     for (const f of def.fields) {
         let type;
@@ -149,9 +147,9 @@ const evaluateStructDefinition = (
 };
 const evaluateStruct = (
     expression: NamedExpression,
-    scope: ReadonlyScope,
+    scope: Scope,
     definition: ScopeStructDefinition,
-    definitionScope: ReadonlyScope
+    definitionScope: Scope
 ): Type => {
     // eslint-disable-next-line no-param-reassign
     definition.default ??= evaluateStructDefinition(definition.definition, definitionScope);
@@ -208,8 +206,8 @@ const evaluateStruct = (
 
 const resolveNamed = (
     expression: NamedExpression,
-    currentScope: ReadonlyScope
-): ResolvedName<ScopeStructDefinition | ScopeVariableDefinition> => {
+    currentScope: Scope
+): ResolvedName<ScopeStructDefinition | ScopeVariableDefinition | ScopeParameterDefinition> => {
     let resolved;
     try {
         resolved = currentScope.get(expression.name);
@@ -236,8 +234,13 @@ const resolveNamed = (
 
     return { definition, scope };
 };
-const evaluateNamed = (expression: NamedExpression, scope: ReadonlyScope): Type => {
+const evaluateNamed = (expression: NamedExpression, scope: Scope): Type => {
     const { definition, scope: definitionScope } = resolveNamed(expression, scope);
+
+    // parameter
+    if (definition.type === 'parameter') {
+        return definition.value;
+    }
 
     // variable
     if (definition.type === 'variable') {
@@ -260,7 +263,7 @@ const evaluateNamed = (expression: NamedExpression, scope: ReadonlyScope): Type 
     return evaluateStruct(expression, scope, definition, definitionScope);
 };
 
-const evaluateFieldAccess = (expression: FieldAccessExpression, scope: ReadonlyScope): Type => {
+const evaluateFieldAccess = (expression: FieldAccessExpression, scope: Scope): Type => {
     const type = evaluate(expression.of, scope);
     if (type.type === 'never') return NeverType.instance;
     if (type.type === 'any') {
@@ -304,7 +307,7 @@ const evaluateFieldAccess = (expression: FieldAccessExpression, scope: ReadonlyS
 
 const resolveFunction = (
     expression: FunctionCallExpression,
-    currentScope: ReadonlyScope
+    currentScope: Scope
 ): ResolvedName<ScopeFunctionDefinition | ScopeBuiltinFunctionDefinition> => {
     let resolved;
     try {
@@ -332,7 +335,7 @@ const resolveFunction = (
         message: `The name ${expression.functionName} resolves to a ${resolved.definition.type} and not a function.`,
     });
 };
-const evaluateFunctionCall = (expression: FunctionCallExpression, scope: ReadonlyScope): Type => {
+const evaluateFunctionCall = (expression: FunctionCallExpression, scope: Scope): Type => {
     const { definition, scope: definitionScope } = resolveFunction(expression, scope);
 
     // check argument number
@@ -411,25 +414,25 @@ const evaluateFunctionCall = (expression: FunctionCallExpression, scope: Readonl
 
     // run function
     if (definition.type === 'function') {
-        const functionScope = new Scope('function scope', definitionScope);
+        const functionScope = new ScopeBuilder('function scope', definitionScope);
         definition.definition.parameters.forEach(({ name }, i) => {
             functionScope.add(new VariableDefinition(name, args[i]));
         });
-        return evaluate(definition.definition.value, functionScope);
+        return evaluate(definition.definition.value, functionScope.createScope());
     }
     return definition.definition.fn(...args);
 };
 
-const evaluateMatch = (expression: MatchExpression, scope: ReadonlyScope): Type => {
+const evaluateMatch = (expression: MatchExpression, scope: Scope): Type => {
     let type = evaluate(expression.of, scope);
     if (type.type === 'never') return NeverType.instance;
 
-    const withBinding = (arm: MatchArm, armType: Type): ReadonlyScope => {
+    const withBinding = (arm: MatchArm, armType: Type): Scope => {
         if (arm.binding === undefined) return scope;
 
-        const armScope = new Scope(`match arm`, scope);
+        const armScope = new ScopeBuilder(`match arm`, scope);
         armScope.add(new VariableDefinition(arm.binding, armType));
-        return armScope;
+        return armScope.createScope();
     };
 
     const matchTypes: Type[] = [];
@@ -445,19 +448,19 @@ const evaluateMatch = (expression: MatchExpression, scope: ReadonlyScope): Type 
     return union(...matchTypes);
 };
 
-const evaluateScope = (expression: ScopeExpression, parentScope: ReadonlyScope): Type => {
+const evaluateScope = (expression: ScopeExpression, parentScope: Scope): Type => {
     let name = 'scope expression';
     if (expression.source) {
         const { document, span } = expression.source;
         name += ` at ${document.name}:${span[0]}`;
     }
-    const scope = new Scope(name, parentScope);
 
+    const scope = new ScopeBuilder(name, parentScope);
     for (const def of expression.definitions) {
         scope.add(def);
     }
 
-    return evaluate(expression.expression, scope);
+    return evaluate(expression.expression, scope.createScope());
 };
 
 /**

--- a/src/common/types/global-scope.ts
+++ b/src/common/types/global-scope.ts
@@ -17,47 +17,47 @@ import {
     toString,
 } from './builtin';
 import { VariableDefinition } from './expression';
-import { BuiltinFunctionDefinition, ReadonlyScope, Scope } from './scope';
+import { BuiltinFunctionDefinition, ScopeBuilder } from './scope';
 import { AnyType, IntIntervalType, NeverType, NumberType, StringType } from './types';
 import { union } from './union';
 
-const scope = new Scope('Global scope');
+const builder = new ScopeBuilder('Global scope');
 
 // fail-safes for primitives
-scope.add(new VariableDefinition('any', AnyType.instance));
-scope.add(new VariableDefinition('never', NeverType.instance));
-scope.add(new VariableDefinition('number', NumberType.instance));
-scope.add(new VariableDefinition('string', StringType.instance));
+builder.add(new VariableDefinition('any', AnyType.instance));
+builder.add(new VariableDefinition('never', NeverType.instance));
+builder.add(new VariableDefinition('number', NumberType.instance));
+builder.add(new VariableDefinition('string', StringType.instance));
 
 // builtin types
-scope.add(new VariableDefinition('int', new IntIntervalType(-Infinity, Infinity)));
-scope.add(new VariableDefinition('uint', new IntIntervalType(0, Infinity)));
+builder.add(new VariableDefinition('int', new IntIntervalType(-Infinity, Infinity)));
+builder.add(new VariableDefinition('uint', new IntIntervalType(0, Infinity)));
 
 // builtin functions
 // eslint-disable-next-line @typescript-eslint/unbound-method
 const { unary, binary, varArgs } = BuiltinFunctionDefinition;
-scope.add(varArgs('add', add, NumberType.instance));
-scope.add(binary('subtract', subtract, NumberType.instance, NumberType.instance));
-scope.add(varArgs('multiply', multiply, NumberType.instance));
-scope.add(binary('divide', divide, NumberType.instance, NumberType.instance));
-scope.add(varArgs('min', minimum, NumberType.instance));
-scope.add(varArgs('max', maximum, NumberType.instance));
-scope.add(varArgs('abs', abs, NumberType.instance));
-scope.add(unary('negate', negate, NumberType.instance));
-scope.add(unary('round', round, NumberType.instance));
-scope.add(unary('floor', floor, NumberType.instance));
-scope.add(unary('ceil', ceil, NumberType.instance));
+builder.add(varArgs('add', add, NumberType.instance));
+builder.add(binary('subtract', subtract, NumberType.instance, NumberType.instance));
+builder.add(varArgs('multiply', multiply, NumberType.instance));
+builder.add(binary('divide', divide, NumberType.instance, NumberType.instance));
+builder.add(varArgs('min', minimum, NumberType.instance));
+builder.add(varArgs('max', maximum, NumberType.instance));
+builder.add(varArgs('abs', abs, NumberType.instance));
+builder.add(unary('negate', negate, NumberType.instance));
+builder.add(unary('round', round, NumberType.instance));
+builder.add(unary('floor', floor, NumberType.instance));
+builder.add(unary('ceil', ceil, NumberType.instance));
 
-scope.add(unary('degToRad', degToRad, NumberType.instance));
-scope.add(unary('sin', sin, NumberType.instance));
-scope.add(unary('cos', cos, NumberType.instance));
+builder.add(unary('degToRad', degToRad, NumberType.instance));
+builder.add(unary('sin', sin, NumberType.instance));
+builder.add(unary('cos', cos, NumberType.instance));
 
-scope.add(varArgs('concat', concat, StringType.instance));
-scope.add(unary('toString', toString, union(StringType.instance, NumberType.instance)));
+builder.add(varArgs('concat', concat, StringType.instance));
+builder.add(unary('toString', toString, union(StringType.instance, NumberType.instance)));
 
 /**
  * The global scope.
  *
  * This is Navi's top-level scope. It contains all of Navi's builtin types and functions.
  */
-export const globalScope: ReadonlyScope = scope;
+export const globalScope = builder.createScope();

--- a/src/common/types/scope.ts
+++ b/src/common/types/scope.ts
@@ -275,7 +275,7 @@ export class Scope {
                 `${name} refers to a ${p.type} and not a parameter in scope ${this.name}`
             );
         }
-        if (isSubsetOf(value, p.definition.value)) {
+        if (!isSubsetOf(value, p.definition.value)) {
             throw new ParameterAssignmentError(
                 `Type cannot be assigned to parameter ${name} in scope ${
                     this.name

--- a/src/common/types/scope.ts
+++ b/src/common/types/scope.ts
@@ -8,7 +8,7 @@ import {
 } from './expression';
 import { assertValidFunctionName, assertValidStructName } from './names';
 import { isSubsetOf } from './relation';
-import { NeverType, StructType, Type } from './types';
+import { AnyType, NeverType, StructType, Type } from './types';
 
 export class BuiltinFunctionDefinition {
     readonly type = 'builtin-function';
@@ -66,7 +66,7 @@ export class ParameterDefinition {
 
     readonly value: Type;
 
-    constructor(name: string, value: Type) {
+    constructor(name: string, value: Type = AnyType.instance) {
         assertValidStructName(name);
         this.name = name;
         this.value = value;

--- a/tests/common/chainner-scope.test.ts
+++ b/tests/common/chainner-scope.test.ts
@@ -6,8 +6,11 @@ import { assertNever } from '../../src/common/util';
 // eslint-disable-next-line consistent-return
 test(`Chainner scope is correct`, () => {
     const scope = getChainnerScope();
-    for (const [name, def] of scope.definitions) {
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    for (const [name, def] of scope['definitions']) {
         switch (def.type) {
+            case 'parameter':
+                break;
             case 'variable':
             case 'struct':
                 evaluate(new NamedExpression(name), scope);

--- a/tests/common/types/evaluate.test.ts
+++ b/tests/common/types/evaluate.test.ts
@@ -10,7 +10,7 @@ import {
     NamedExpression,
     UnionExpression,
 } from '../../../src/common/types/expression';
-import { BuiltinFunctionDefinition, Scope } from '../../../src/common/types/scope';
+import { BuiltinFunctionDefinition, ScopeBuilder } from '../../../src/common/types/scope';
 import {
     AnyType,
     NeverType,
@@ -34,8 +34,9 @@ import {
     unorderedPairs,
 } from './data';
 
-const scope = new Scope('test scope', getChainnerScope());
-scope.add(BuiltinFunctionDefinition.unary('reciprocal', reciprocal, NumberType.instance));
+const scopeBuilder = new ScopeBuilder('test scope', getChainnerScope());
+scopeBuilder.add(BuiltinFunctionDefinition.unary('reciprocal', reciprocal, NumberType.instance));
+const scope = scopeBuilder.createScope();
 
 const assertSame = (a: Expression, b: Expression): void => {
     const expected = evaluate(a, scope).getTypeId();


### PR DESCRIPTION
This is a refactoring(?) PR. These changes will be necessary for future features, but they don't do anything right now. The main change is that `Scope` is now immutable in respect to the registered definitions. To build a scope, the `ScopeBuilder` class has to be used now. I also added an explicit parameter definition type. This will be important for later static analysis (#601).