### PR TITLE
Detect stale previews based on input hashes

### DIFF
--- a/src/renderer/components/node/NodeOutputs.tsx
+++ b/src/renderer/components/node/NodeOutputs.tsx
@@ -5,8 +5,7 @@ import { useContext, useContextSelector } from 'use-context-selector';
 import { Output, OutputId, OutputKind, SchemaId } from '../../../common/common-types';
 import { Type } from '../../../common/types/types';
 import { assertNever } from '../../../common/util';
-import { ExecutionContext } from '../../contexts/ExecutionContext';
-import { GlobalContext } from '../../contexts/GlobalNodeState';
+import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { DefaultImageOutput } from '../outputs/DefaultImageOutput';
 import { GenericOutput } from '../outputs/GenericOutput';
 import { LargeImageOutput } from '../outputs/LargeImageOutput';
@@ -66,13 +65,20 @@ interface NodeOutputProps {
 }
 
 export const NodeOutputs = memo(({ outputs, id, schemaId, animated = false }: NodeOutputProps) => {
-    const { functionDefinitions } = useContext(GlobalContext);
-    const useOutputDataContext = useContextSelector(ExecutionContext, (c) => c.useOutputData);
+    const { functionDefinitions, getInputHash } = useContext(GlobalContext);
+    const outputDataEntry = useContextSelector(GlobalVolatileContext, (c) =>
+        c.outputDataMap.get(id)
+    );
 
     const useOutputData = useCallback(
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        (outputId: OutputId) => useOutputDataContext(id, outputId),
-        [useOutputDataContext, id]
+        // eslint-disable-next-line prefer-arrow-functions/prefer-arrow-functions, func-names
+        function <T>(outputId: OutputId): readonly [value: T | undefined, inputHash: string] {
+            if (outputDataEntry) {
+                return [outputDataEntry.data[outputId] as T | undefined, outputDataEntry.inputHash];
+            }
+            return [undefined, getInputHash(id)];
+        },
+        [outputDataEntry]
     );
 
     const functions = functionDefinitions.get(schemaId)!.outputDefaults;

--- a/src/renderer/components/outputs/GenericOutput.tsx
+++ b/src/renderer/components/outputs/GenericOutput.tsx
@@ -18,7 +18,7 @@ export const GenericOutput = memo(
 
         const schema = schemata.get(schemaId);
 
-        const value = useOutputData(outputId);
+        const [value] = useOutputData(outputId);
 
         useEffect(() => {
             if (isStartingNode(schema)) {

--- a/src/renderer/components/outputs/LargeImageOutput.tsx
+++ b/src/renderer/components/outputs/LargeImageOutput.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-nested-ternary */
 import { ViewOffIcon, WarningIcon } from '@chakra-ui/icons';
 import { Box, Center, HStack, Image, Spinner, Text, useColorModeValue } from '@chakra-ui/react';
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { NamedExpression, NamedExpressionField } from '../../../common/types/expression';
 import { NumericLiteralType } from '../../../common/types/types';
@@ -18,36 +18,14 @@ interface LargeImageBroadcastData {
 
 export const LargeImageOutput = memo(
     ({ id, outputId, useOutputData, animated = false, schemaId }: OutputProps) => {
-        const inputDataChanges = useContextSelector(
-            GlobalVolatileContext,
-            (c) => c.inputDataChanges
-        );
-        const lastInputDataUpdatedId = useContextSelector(
-            GlobalVolatileContext,
-            (c) => c.lastInputDataUpdatedId
-        );
-
-        const [stale, setStale] = useState(false);
-
-        const zoom = useContextSelector(GlobalVolatileContext, (c) => c.zoom);
-
-        const value = useOutputData(outputId) as LargeImageBroadcastData | undefined;
-
         const { setManualOutputType, schemata } = useContext(GlobalContext);
-
         const schema = schemata.get(schemaId);
 
-        useEffect(() => {
-            if (value) {
-                setStale(false);
-            }
-        }, [value]);
+        const inputHash = useContextSelector(GlobalVolatileContext, (c) => c.inputHashes.get(id));
+        const zoom = useContextSelector(GlobalVolatileContext, (c) => c.zoom);
 
-        useEffect(() => {
-            if (value && lastInputDataUpdatedId !== id) {
-                setStale(true);
-            }
-        }, [inputDataChanges]);
+        const [value, valueInputHash] = useOutputData<LargeImageBroadcastData>(outputId);
+        const stale = value !== undefined && valueInputHash !== inputHash;
 
         useEffect(() => {
             if (isStartingNode(schema)) {
@@ -90,7 +68,7 @@ export const LargeImageOutput = memo(
                     w="200px"
                 >
                     <Box
-                        display={stale ? 'block' : 'none'}
+                        display={stale && !animated ? 'block' : 'none'}
                         h="200px"
                         marginRight="-200px"
                         w="200px"

--- a/src/renderer/components/outputs/PyTorchOutput.tsx
+++ b/src/renderer/components/outputs/PyTorchOutput.tsx
@@ -41,7 +41,7 @@ const getColorMode = (channels: number) => {
 
 export const PyTorchOutput = memo(
     ({ id, outputId, useOutputData, animated = false, schemaId }: OutputProps) => {
-        const value = useOutputData(outputId) as PyTorchModelData | undefined;
+        const [value] = useOutputData<PyTorchModelData>(outputId);
 
         const { setManualOutputType, schemata } = useContext(GlobalContext);
 

--- a/src/renderer/components/outputs/props.ts
+++ b/src/renderer/components/outputs/props.ts
@@ -8,7 +8,9 @@ export interface OutputProps {
     readonly schemaId: SchemaId;
     readonly definitionType: Type;
     readonly hasHandle: boolean;
-    readonly useOutputData: (outputId: OutputId) => unknown;
+    readonly useOutputData: <T>(
+        outputId: OutputId
+    ) => readonly [value: T | undefined, inputHash: string];
     readonly animated: boolean;
     readonly kind: OutputKind;
 }

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -1,8 +1,7 @@
-import isDeepEqual from 'fast-deep-equal/react';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { Edge, Node, useReactFlow } from 'react-flow-renderer';
 import { useHotkeys } from 'react-hotkeys-hook';
-import { createContext, useContext, useContextSelector } from 'use-context-selector';
+import { createContext, useContext } from 'use-context-selector';
 import { useThrottledCallback } from 'use-debounce';
 import { getBackend } from '../../common/Backend';
 import {
@@ -34,7 +33,7 @@ import {
 import { useBatchedCallback } from '../hooks/useBatchedCallback';
 import { useMemoObject } from '../hooks/useMemo';
 import { AlertBoxContext, AlertType } from './AlertBoxContext';
-import { GlobalContext, GlobalVolatileContext } from './GlobalNodeState';
+import { GlobalContext } from './GlobalNodeState';
 import { SettingsContext } from './SettingsContext';
 
 export enum ExecutionStatus {
@@ -50,7 +49,6 @@ interface ExecutionContextValue {
     status: ExecutionStatus;
     isBackendKilled: boolean;
     setIsBackendKilled: React.Dispatch<React.SetStateAction<boolean>>;
-    useOutputData: (id: string, outputId: OutputId) => unknown;
 }
 
 const convertToUsableFormat = (
@@ -141,8 +139,14 @@ export const ExecutionContext = createContext<Readonly<ExecutionContextValue>>(
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>) => {
-    const { schemata, useAnimate, setIteratorPercent, typeStateRef } = useContext(GlobalContext);
-    const useOutputDataMap = useContextSelector(GlobalVolatileContext, (c) => c.useOutputDataMap);
+    const {
+        schemata,
+        useAnimate,
+        setIteratorPercent,
+        typeStateRef,
+        outputDataActions,
+        getInputHash,
+    } = useContext(GlobalContext);
     const { useIsCpu, useIsFp16, port } = useContext(SettingsContext);
     const { sendAlert } = useContext(AlertBoxContext);
 
@@ -157,12 +161,6 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
     const backend = getBackend(port);
 
     const [isBackendKilled, setIsBackendKilled] = useState(false);
-
-    const [outputDataMap, setOutputDataMap] = useOutputDataMap;
-    const useOutputData = useCallback(
-        (id: string, outputId: OutputId): unknown => outputDataMap.get(id)?.[outputId],
-        [outputDataMap]
-    );
 
     useEffect(() => {
         // TODO: Actually fix this so it un-animates correctly
@@ -229,18 +227,18 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
                 }
 
                 if (data) {
-                    setOutputDataMap((prev) => {
-                        const existingData = prev.get(nodeId);
-                        if (!existingData || !isDeepEqual(existingData, data)) {
-                            return new Map([...prev, [nodeId, data]]);
-                        }
-                        return prev;
-                    });
+                    // TODO: This is incorrect. The inputs of the node might have changed since
+                    // the chain started running. However, sending the then current input hashes
+                    // of the chain to the backend along with the rest of its data and then making
+                    // the backend send us those hashes is incorrect too because of iterators, I
+                    // think.
+                    const inputHash = getInputHash(nodeId);
+                    outputDataActions.set(nodeId, inputHash, data);
                 }
             }
         },
         500,
-        [unAnimate, setOutputDataMap]
+        [unAnimate, outputDataActions, getInputHash]
     );
     useBackendEventSourceListener(eventSource, 'node-finish', updateNodeFinish, [
         // TODO: This is a hack due to useEventSource having a bug related to useEffect jank
@@ -450,7 +448,6 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
         status,
         isBackendKilled,
         setIsBackendKilled,
-        useOutputData,
     });
 
     return <ExecutionContext.Provider value={value}>{children}</ExecutionContext.Provider>;

--- a/src/renderer/hooks/useInputHashes.ts
+++ b/src/renderer/hooks/useInputHashes.ts
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from 'react';
+import { Edge, Node, useReactFlow } from 'react-flow-renderer';
+import { EdgeData, NodeData } from '../../common/common-types';
+import { SchemaMap } from '../../common/SchemaMap';
+import { EMPTY_MAP, deriveUniqueId, stringifyTargetHandle } from '../../common/util';
+
+const EMPTY = '6227edf5-cc54-4d34-b863-f647d3a73509';
+
+/**
+ * Given a graph, this will returns a map from node id to the input hash of the node with that id.
+ *
+ * An input hash is a representation of the inputs for a node. If the input hash changes, at least
+ * of its inputs changed. At least, that's the idea. Due to the imperfect nature of hashes, input
+ * hashes only guarantee that if the input hash doesn't change, that the inputs for a node did not
+ * change.
+ */
+const computeInputHashes = (
+    nodes: readonly Node<NodeData>[],
+    edges: readonly Edge<EdgeData>[],
+    schemata: SchemaMap
+): Map<string, string> => {
+    const byId = new Map(nodes.map((n) => [n.id, n]));
+    const byTargetHandle = new Map(
+        edges.filter((e) => e.targetHandle).map((e) => [e.targetHandle!, e])
+    );
+
+    const hashes = new Map<string, string>();
+    const getInputHash = (node: Node<NodeData>): string => {
+        let hash = hashes.get(node.id);
+        if (hash) return hash;
+
+        const schema = schemata.get(node.data.schemaId);
+        const inputs: string[] = [];
+        for (const { id: inputId } of schema.inputs) {
+            const connectedEdge = byTargetHandle.get(stringifyTargetHandle(node.id, inputId));
+            if (connectedEdge) {
+                const source = byId.get(connectedEdge.source);
+                if (source) {
+                    // input gets passed by the connected node
+                    inputs.push(getInputHash(source));
+                    // eslint-disable-next-line no-continue
+                    continue;
+                }
+            }
+
+            const value = node.data.inputData[inputId];
+            // eslint-disable-next-line eqeqeq
+            if (value == undefined) {
+                inputs.push(EMPTY);
+            } else {
+                inputs.push(deriveUniqueId(String(value)));
+            }
+        }
+
+        if (inputs.length === 0) {
+            hash = EMPTY;
+        } else if (inputs.length === 1) {
+            // eslint-disable-next-line prefer-destructuring
+            hash = inputs[0];
+        } else {
+            hash = deriveUniqueId(inputs.join(';'));
+        }
+
+        hashes.set(node.id, hash);
+        return hash;
+    };
+
+    for (const node of nodes) {
+        getInputHash(node);
+    }
+
+    return hashes;
+};
+
+export const useInputHashes = (schemata: SchemaMap, deps: readonly unknown[]) => {
+    const ref = useRef<ReadonlyMap<string, string>>(EMPTY_MAP);
+
+    const { getNodes, getEdges } = useReactFlow();
+    useEffect(() => {
+        ref.current = computeInputHashes(getNodes(), getEdges(), schemata);
+    }, deps);
+
+    return ref;
+};

--- a/src/renderer/hooks/useOutputDataStore.ts
+++ b/src/renderer/hooks/useOutputDataStore.ts
@@ -1,0 +1,49 @@
+import isDeepEqual from 'fast-deep-equal/react';
+import { useCallback, useState } from 'react';
+import { OutputData } from '../../common/common-types';
+import { EMPTY_MAP } from '../../common/util';
+import { useMemoObject } from './useMemo';
+
+export interface OutputDataEntry {
+    inputHash: string;
+    data: OutputData;
+}
+
+export interface OutputDataActions {
+    set(nodeId: string, nodeInputHash: string, data: OutputData): void;
+    delete(nodeId: string): void;
+}
+
+export const useOutputDataStore = () => {
+    const [map, setMap] = useState<ReadonlyMap<string, OutputDataEntry>>(EMPTY_MAP);
+
+    const actions: OutputDataActions = {
+        set: useCallback(
+            (nodeId, inputHash, data) => {
+                setMap((prev) => {
+                    const existingData = prev.get(nodeId);
+                    if (!existingData || !isDeepEqual(existingData, data)) {
+                        const newMap = new Map(prev);
+                        newMap.set(nodeId, { data, inputHash });
+                        return newMap;
+                    }
+                    return prev;
+                });
+            },
+            [setMap]
+        ),
+        delete: useCallback(
+            (nodeId) => {
+                setMap((prev) => {
+                    if (!prev.has(nodeId)) return prev;
+                    const newMap = new Map(prev);
+                    newMap.delete(nodeId);
+                    return newMap;
+                });
+            },
+            [setMap]
+        ),
+    };
+
+    return [map, useMemoObject(actions)] as const;
+};


### PR DESCRIPTION
This implements the input hashes I was talking about on discord.

The coolest thing about this is that you can do changes, undo them, and Chainner will know that a preview is still up-to-date.