### PR TITLE
Update ncnn

### DIFF
--- a/src/common/dependencies.ts
+++ b/src/common/dependencies.ts
@@ -25,7 +25,7 @@ export const getOptionalDependencies = (isNvidiaAvailable: boolean): Dependency[
     },
     {
         name: 'NCNN',
-        packages: [{ packageName: 'ncnn-vulkan', version: '2022.4.1' }],
+        packages: [{ packageName: 'ncnn-vulkan', version: '2022.7.29' }],
     },
     {
         name: 'ONNX',


### PR DESCRIPTION
This update allows ncnn to be updated to the latest version from the dependency manager.

In the future we're going to need to figure out how to force updates for certain things, because if we ever make an ncnn update to allow loading models from memory we'll need to force update to avoid breaking anything