### PR TITLE
Removed leftover code from #541 causing the chain to not display correctly

### DIFF
--- a/src/renderer/components/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge.tsx
@@ -130,7 +130,7 @@ export const CustomEdge = memo(
                             animated && animateChain
                                 ? 'dashdraw-chain 0.5s linear infinite'
                                 : 'none',
-                        opacity: animated && animateChain ? 1 : 0,
+                        opacity: animated ? 1 : 0,
                     }}
                 />
                 <path
@@ -153,7 +153,7 @@ export const CustomEdge = memo(
                             animated && animateChain
                                 ? 'dashdraw-chain 0.5s linear infinite'
                                 : 'none',
-                        opacity: animated && animateChain ? 1 : 0,
+                        opacity: animated ? 1 : 0,
                     }}
                 />
                 <path


### PR DESCRIPTION
When running a chain with chain animation turned off, edges would not change to the chain look at all. This is because of some leftover code from #541.