### PR TITLE
Measure node execution time

### DIFF
--- a/backend/src/events.py
+++ b/backend/src/events.py
@@ -28,6 +28,7 @@ class ExecutionErrorData(TypedDict):
 class NodeFinishData(TypedDict):
     finished: List[str]
     nodeId: str
+    executionTime: Optional[float]
     data: Optional[Dict[int, Any]]
 
 

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -5,7 +5,8 @@ from concurrent.futures import ThreadPoolExecutor
 import functools
 import os
 import uuid
-from typing import Any, Dict, List, Optional, TypedDict
+import time
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict
 
 from sanic.log import logger
 from events import EventQueue, Event
@@ -63,6 +64,16 @@ class ExecutionContext:
             self.cache.copy(),
             self.executor,
         )
+
+
+def timed_supplier(supplier: Callable[[], Any]) -> Callable[[], Tuple[Any, float]]:
+    def wrapper():
+        start = time.time()
+        result = supplier()
+        duration = time.time() - start
+        return result, duration
+
+    return wrapper
 
 
 class Executor:
@@ -195,8 +206,10 @@ class Executor:
         else:
             # Run the node and pass in inputs as args
             run_func = functools.partial(node_instance.run, *enforced_inputs)
-            output = await self.loop.run_in_executor(self.pool, run_func)
-            await self.__broadcast_data(node_instance, node_id, output)
+            output, execution_time = await self.loop.run_in_executor(
+                self.pool, timed_supplier(run_func)
+            )
+            await self.__broadcast_data(node_instance, node_id, execution_time, output)
             # Cache the output of the node
             self.output_cache[node_id] = output
             del node_instance, run_func
@@ -206,6 +219,7 @@ class Executor:
         self,
         node_instance: NodeBase,
         node_id: str,
+        execution_time: float,
         output: Any,
     ):
         node_outputs = node_instance.get_outputs()
@@ -231,7 +245,12 @@ class Executor:
             await self.queue.put(
                 {
                     "event": "node-finish",
-                    "data": {"finished": finished, "nodeId": node_id, "data": data},
+                    "data": {
+                        "finished": finished,
+                        "nodeId": node_id,
+                        "executionTime": execution_time,
+                        "data": data,
+                    },
                 }
             )
 
@@ -243,7 +262,12 @@ class Executor:
             await self.queue.put(
                 {
                     "event": "node-finish",
-                    "data": {"finished": finished, "nodeId": node_id, "data": None},
+                    "data": {
+                        "finished": finished,
+                        "nodeId": node_id,
+                        "executionTime": execution_time,
+                        "data": None,
+                    },
                 }
             )
 
@@ -254,7 +278,12 @@ class Executor:
 
         return {
             "event": "node-finish",
-            "data": {"finished": finished, "nodeId": node_id, "data": None},
+            "data": {
+                "finished": finished,
+                "nodeId": node_id,
+                "executionTime": None,
+                "data": None,
+            },
         }
 
     def get_output_nodes(self) -> List[UsableData]:

--- a/src/renderer/components/node/NodeOutputs.tsx
+++ b/src/renderer/components/node/NodeOutputs.tsx
@@ -74,7 +74,10 @@ export const NodeOutputs = memo(({ outputs, id, schemaId, animated = false }: No
         // eslint-disable-next-line prefer-arrow-functions/prefer-arrow-functions, func-names
         function <T>(outputId: OutputId): readonly [value: T | undefined, inputHash: string] {
             if (outputDataEntry) {
-                return [outputDataEntry.data[outputId] as T | undefined, outputDataEntry.inputHash];
+                return [
+                    outputDataEntry.data?.[outputId] as T | undefined,
+                    outputDataEntry.inputHash,
+                ];
             }
             return [undefined, getInputHash(id)];
         },

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -221,20 +221,23 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
     >(
         (eventData) => {
             if (eventData) {
-                const { finished, nodeId, data } = eventData;
+                const { finished, nodeId, executionTime, data } = eventData;
                 if (finished.length > 0) {
                     unAnimate(finished);
                 }
 
-                if (data) {
-                    // TODO: This is incorrect. The inputs of the node might have changed since
-                    // the chain started running. However, sending the then current input hashes
-                    // of the chain to the backend along with the rest of its data and then making
-                    // the backend send us those hashes is incorrect too because of iterators, I
-                    // think.
-                    const inputHash = getInputHash(nodeId);
-                    outputDataActions.set(nodeId, inputHash, data);
-                }
+                // TODO: This is incorrect. The inputs of the node might have changed since
+                // the chain started running. However, sending the then current input hashes
+                // of the chain to the backend along with the rest of its data and then making
+                // the backend send us those hashes is incorrect too because of iterators, I
+                // think.
+                const inputHash = getInputHash(nodeId);
+                outputDataActions.set(
+                    nodeId,
+                    executionTime ?? undefined,
+                    inputHash,
+                    data ?? undefined
+                );
             }
         },
         500,

--- a/src/renderer/hooks/useBackendEventSource.ts
+++ b/src/renderer/hooks/useBackendEventSource.ts
@@ -23,7 +23,12 @@ export interface BackendEventMap {
         source?: BackendExceptionSource | null;
         exception: string;
     };
-    'node-finish': { finished: string[]; nodeId: string; data?: OutputData | null };
+    'node-finish': {
+        finished: string[];
+        nodeId: string;
+        executionTime?: number | null;
+        data?: OutputData | null;
+    };
     'iterator-progress-update': { percent: number; iteratorId: string; running?: string[] | null };
 }
 

--- a/src/renderer/hooks/useOutputDataStore.ts
+++ b/src/renderer/hooks/useOutputDataStore.ts
@@ -6,11 +6,17 @@ import { useMemoObject } from './useMemo';
 
 export interface OutputDataEntry {
     inputHash: string;
-    data: OutputData;
+    executionTime: number | undefined;
+    data: OutputData | undefined;
 }
 
 export interface OutputDataActions {
-    set(nodeId: string, nodeInputHash: string, data: OutputData): void;
+    set(
+        nodeId: string,
+        executionTime: number | undefined,
+        nodeInputHash: string,
+        data: OutputData | undefined
+    ): void;
     delete(nodeId: string): void;
 }
 
@@ -19,12 +25,20 @@ export const useOutputDataStore = () => {
 
     const actions: OutputDataActions = {
         set: useCallback(
-            (nodeId, inputHash, data) => {
+            (nodeId, executionTime, inputHash, data) => {
                 setMap((prev) => {
-                    const existingData = prev.get(nodeId);
-                    if (!existingData || !isDeepEqual(existingData, data)) {
+                    const existingEntry = prev.get(nodeId);
+
+                    const useExistingData = existingEntry?.data && !data;
+                    const entry: OutputDataEntry = {
+                        data: useExistingData ? existingEntry.data : data,
+                        inputHash: useExistingData ? existingEntry.inputHash : inputHash,
+                        executionTime: executionTime ?? existingEntry?.executionTime,
+                    };
+
+                    if (!existingEntry || !isDeepEqual(existingEntry, entry)) {
                         const newMap = new Map(prev);
-                        newMap.set(nodeId, { data, inputHash });
+                        newMap.set(nodeId, entry);
                         return newMap;
                     }
                     return prev;

--- a/src/renderer/hooks/useOutputDataStore.ts
+++ b/src/renderer/hooks/useOutputDataStore.ts
@@ -6,7 +6,7 @@ import { useMemoObject } from './useMemo';
 
 export interface OutputDataEntry {
     inputHash: string;
-    executionTime: number | undefined;
+    lastExecutionTime: number | undefined;
     data: OutputData | undefined;
 }
 
@@ -33,7 +33,7 @@ export const useOutputDataStore = () => {
                     const entry: OutputDataEntry = {
                         data: useExistingData ? existingEntry.data : data,
                         inputHash: useExistingData ? existingEntry.inputHash : inputHash,
-                        executionTime: executionTime ?? existingEntry?.executionTime,
+                        lastExecutionTime: executionTime ?? existingEntry?.lastExecutionTime,
                     };
 
                     if (!existingEntry || !isDeepEqual(existingEntry, entry)) {


### PR DESCRIPTION
This makes progress towards displaying the last execution time of a node. The backend will now measure and send the execution of any non-iterator node. The frontend will store this time similar to how it stores broadcast data.

Since all the backend stuff is now implemented, we can focus on the visual presentation of the last execution time. Unfortunately, my UI design ideas are typically ugly, so I will leave this to you guys.