### PR TITLE
Let the node-finish handler un-animate individual node runs

### DIFF
--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -235,11 +235,7 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
                     data ?? undefined
                 );
 
-                if (finished.length > 0) {
-                    unAnimate(finished);
-                } else if (nodeId) {
-                    unAnimate([nodeId]);
-                }
+                unAnimate([nodeId, ...finished]);
             }
         },
         500,

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -221,9 +221,6 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
         (eventData) => {
             if (eventData) {
                 const { finished, nodeId, executionTime, data } = eventData;
-                if (finished.length > 0) {
-                    unAnimate(finished);
-                }
 
                 // TODO: This is incorrect. The inputs of the node might have changed since
                 // the chain started running. However, sending the then current input hashes
@@ -237,6 +234,12 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
                     inputHash,
                     data ?? undefined
                 );
+
+                if (finished.length > 0) {
+                    unAnimate(finished);
+                } else if (nodeId) {
+                    unAnimate([nodeId]);
+                }
             }
         },
         500,

--- a/src/renderer/hooks/useRunNode.ts
+++ b/src/renderer/hooks/useRunNode.ts
@@ -37,9 +37,8 @@ export const useRunNode = ({ inputData, id, schemaId }: NodeData, shouldRun: boo
 
                 const result = await backend.runIndividual({ schemaId, id, inputs, isCpu, isFp16 });
 
-                unAnimate([id]);
-
                 if (!result.success) {
+                    unAnimate([id]);
                     sendToast({
                         status: 'error',
                         title: 'Error',


### PR DESCRIPTION
This fixes the issue I mentioned about the node un-animating before the output data was set. Now, the SSE handler handles un-animating the node, and it does so after the output data has been set. The node only un-animates when there is an error.