### PR TITLE
Fixed reading stale data of `getNode`

### DIFF
--- a/src/renderer/components/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge.tsx
@@ -9,7 +9,6 @@ import { parseSourceHandle } from '../../common/util';
 import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { SettingsContext } from '../contexts/SettingsContext';
 import { shadeColor } from '../helpers/colorTools';
-import { DisabledStatus, getDisabledStatus } from '../helpers/disabled';
 import { getTypeAccentColors } from '../helpers/getTypeAccentColors';
 
 export const CustomEdge = memo(
@@ -50,10 +49,7 @@ export const CustomEdge = memo(
 
         const { getNode } = useReactFlow<NodeData, EdgeData>();
         const parentNode = useMemo(() => getNode(source)!, [source]);
-        const disabledStatus = useMemo(
-            () => getDisabledStatus(parentNode.data, effectivelyDisabledNodes),
-            [parentNode.data, effectivelyDisabledNodes]
-        );
+        const isSourceEnabled = !effectivelyDisabledNodes.has(source);
 
         const { removeEdgeById, setHoveredNode, functionDefinitions } = useContext(GlobalContext);
 
@@ -86,7 +82,7 @@ export const CustomEdge = memo(
                 className="edge-chain-group"
                 style={{
                     cursor: 'pointer',
-                    opacity: disabledStatus === DisabledStatus.Enabled ? 1 : 0.5,
+                    opacity: isSourceEnabled ? 1 : 0.5,
                 }}
                 onDragEnter={() => setHoveredNode(parentNode.parentNode)}
                 onMouseEnter={() => setIsHovered(true)}


### PR DESCRIPTION
I *think* this fixes #659.

`get{Node,Edge}{,s}` from `useReactFlow` tend to return stale data when called in the render method directly. Specifically, it seems like they still read the previous value. I do not know what causes this, nor was I able to reproduce #659 with a simple chain (but I did have this bug before). It seems like we trigger some kind of race condition in `useReactFlow`, but I didn't investigate further.

This fix (hopefully) solves the problem by not using the data returned by `getNode`. `getDisabledStatus` internally reads `data.isDisabled` which might be stale. Since we only care about the effectively-disabled status of the source node, I just check for that directly.