### PR TITLE
Don't run Note node

### DIFF
--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -181,7 +181,7 @@ export const topologicalSort = <T>(
 };
 
 export const isStartingNode = (schema: NodeSchema) => {
-    return !schema.inputs.some((i) => i.hasHandle);
+    return !schema.inputs.some((i) => i.hasHandle) && schema.outputs.length > 0;
 };
 
 export const delay = (ms: number): Promise<void> => {


### PR DESCRIPTION
Fixes #691.

Basically, starting nodes now have to be at the start of a path and must not be leaf node.