### PR TITLE
Let node-finish handler handle un-animating rather than final finish

### DIFF
--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -185,7 +185,6 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
         eventSource,
         'finish',
         () => {
-            unAnimate();
             setStatus(ExecutionStatus.READY);
         },
         [setStatus, unAnimate]


### PR DESCRIPTION
Since broadcasts are done in another thread, this would cause the chain to be finished before the data was sent to the frontend. This would cause view nodes to become unanimated before being ready to show their new previews.

I can't think of any downsides of removing this, as it just lets each node handle the un-animating rather than every node un-animating, but that doesn't mean there couldn't be some hidden issue that would need to be fixed by this.