### PR TITLE
Removed `os.environ["killed"]`

### DIFF
--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -315,7 +315,6 @@ class Executor:
         logger.info(f"Resuming executor {self.execution_id}")
         self.paused = False
         self.resumed = True
-        os.environ["killed"] = "False"
         await self.process_nodes()
 
     async def pause(self):
@@ -327,7 +326,6 @@ class Executor:
         """Kill the executor"""
         logger.info(f"Killing executor {self.execution_id}")
         self.killed = True
-        os.environ["killed"] = "True"
 
     def is_killed(self):
         """Return if the executor is killed"""

--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -175,7 +175,6 @@ async def run(request: Request):
         # wait until all previews are done
         await runIndividualCounter.wait_zero()
 
-        os.environ["killed"] = "False"
         if ctx.executor:
             logger.info("Resuming existing executor...")
             executor = ctx.executor


### PR DESCRIPTION
Global mutable and stringly typed state bad.

This value was only read by commented out code in the auto split functions of NCNN and PyTorch.
