### PR TITLE
Less mutable global state

### DIFF
--- a/backend/src/nodes/onnx_nodes.py
+++ b/backend/src/nodes/onnx_nodes.py
@@ -15,6 +15,7 @@ from .properties.inputs import *
 from .properties.outputs import *
 from .utils.onnx_auto_split import onnx_auto_split_process
 from .utils.utils import get_h_w_c, np2nptensor, nptensor2np, convenient_upscale
+from .utils.exec_options import get_execution_options
 
 
 class TensorOrders:
@@ -140,7 +141,7 @@ class OnnxImageUpscaleNode(NodeBase):
             onnx_model,
             providers=[
                 "CPUExecutionProvider"
-                if os.environ["device"] == "cpu"
+                if get_execution_options().device == "cpu"
                 else "CUDAExecutionProvider"
             ],
         )

--- a/backend/src/nodes/utils/exec_options.py
+++ b/backend/src/nodes/utils/exec_options.py
@@ -1,0 +1,17 @@
+from typing import Literal
+
+
+DeviceType = Literal["cpu", "cuda"]
+
+
+class ExecutionOptions:
+    def __init__(self, device: DeviceType, fp16: bool) -> None:
+        self.device: DeviceType = device
+        self.fp16 = fp16
+
+
+__global_exec_options = ExecutionOptions("cpu", False)
+
+
+def get_execution_options() -> ExecutionOptions:
+    return __global_exec_options

--- a/backend/src/nodes/utils/exec_options.py
+++ b/backend/src/nodes/utils/exec_options.py
@@ -6,8 +6,16 @@ DeviceType = Literal["cpu", "cuda"]
 
 class ExecutionOptions:
     def __init__(self, device: DeviceType, fp16: bool) -> None:
-        self.device: DeviceType = device
-        self.fp16 = fp16
+        self.__device: DeviceType = device
+        self.__fp16 = fp16
+
+    @property
+    def device(self) -> DeviceType:
+        return self.__device
+
+    @property
+    def fp16(self):
+        return self.__fp16
 
 
 __global_exec_options = ExecutionOptions("cpu", False)

--- a/backend/src/nodes/utils/exec_options.py
+++ b/backend/src/nodes/utils/exec_options.py
@@ -23,3 +23,10 @@ __global_exec_options = ExecutionOptions("cpu", False)
 
 def get_execution_options() -> ExecutionOptions:
     return __global_exec_options
+
+
+def set_execution_options(value: ExecutionOptions):
+    # TODO: Make the mutable global state unnecessary
+    # pylint: disable=global-statement
+    global __global_exec_options
+    __global_exec_options = value

--- a/backend/src/nodes/utils/pytorch_auto_split.py
+++ b/backend/src/nodes/utils/pytorch_auto_split.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import gc
-import os
-from functools import reduce
-from operator import mul
 from typing import Tuple, Union
 
 import torch
 from sanic.log import logger
 from torch import Tensor
+
+from .exec_options import ExecutionOptions
 
 
 def torch_center_crop(tensor, crop_x, crop_y):
@@ -28,9 +27,10 @@ def torch_center_replace(tensor, crop_x, crop_y, replacement):
 
 @torch.inference_mode()
 def auto_split_process(
+    exec_options: ExecutionOptions,
     lr_img: Tensor,
     model: torch.nn.Module,
-    scale: int = 4,
+    scale: int,
     overlap: int = 16,
     max_depth: Union[int, None] = None,
     current_depth: int = 1,
@@ -59,10 +59,10 @@ def auto_split_process(
     if max_depth is None or max_depth == current_depth:
         d_img = None
         try:
-            device = torch.device(os.environ["device"])
+            device = torch.device(exec_options.device)
             d_img = lr_img.to(device)
             model = model.to(device)
-            if os.environ["isFp16"] == "True":
+            if exec_options.fp16:
                 model = model.half()
                 d_img = d_img.half()
             else:
@@ -96,6 +96,7 @@ def auto_split_process(
     # Recursively upscale the quadrants
     # After we go through the top left quadrant, we know the maximum depth and no longer need to test for out-of-memory
     top_left_rlt, depth = auto_split_process(
+        exec_options,
         top_left,
         model,
         scale=scale,
@@ -104,6 +105,7 @@ def auto_split_process(
         current_depth=current_depth + 1,
     )
     top_right_rlt, _ = auto_split_process(
+        exec_options,
         top_right,
         model,
         scale=scale,
@@ -112,6 +114,7 @@ def auto_split_process(
         current_depth=current_depth + 1,
     )
     bottom_left_rlt, _ = auto_split_process(
+        exec_options,
         bottom_left,
         model,
         scale=scale,
@@ -120,6 +123,7 @@ def auto_split_process(
         current_depth=current_depth + 1,
     )
     bottom_right_rlt, _ = auto_split_process(
+        exec_options,
         bottom_right,
         model,
         scale=scale,

--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -69,7 +69,7 @@ from nodes import utility_nodes  # type: ignore
 from nodes.node_factory import NodeFactory
 from events import EventQueue, ExecutionErrorData
 from process import Executor, NodeExecutionError, UsableData, timed_supplier
-from nodes.utils.exec_options import get_execution_options
+from nodes.utils.exec_options import set_execution_options, ExecutionOptions
 
 
 class AppContext:
@@ -185,9 +185,11 @@ async def run(request: Request):
             full_data: RunRequest = dict(request.json)  # type: ignore
             logger.info(full_data)
             nodes_list = full_data["data"]
-            exec_opts = get_execution_options()
-            exec_opts.device = "cpu" if full_data["isCpu"] else "cuda"
-            exec_opts.fp16 = full_data["isFp16"]
+            exec_opts = ExecutionOptions(
+                device="cpu" if full_data["isCpu"] else "cuda",
+                fp16=full_data["isFp16"],
+            )
+            set_execution_options(exec_opts)
             logger.info(f"Using device: {exec_opts.device}")
             executor = Executor(
                 nodes_list,
@@ -244,9 +246,11 @@ async def run_individual(request: Request):
         if ctx.cache.get(full_data["id"], None) is not None:
             del ctx.cache[full_data["id"]]
         logger.info(full_data)
-        exec_opts = get_execution_options()
-        exec_opts.device = "cpu" if full_data["isCpu"] else "cuda"
-        exec_opts.fp16 = full_data["isFp16"]
+        exec_opts = ExecutionOptions(
+            device="cpu" if full_data["isCpu"] else "cuda",
+            fp16=full_data["isFp16"],
+        )
+        set_execution_options(exec_opts)
         logger.info(f"Using device: {exec_opts.device}")
         # Create node based on given category/name information
         node_instance = NodeFactory.create_node(full_data["schemaId"])

--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -69,6 +69,7 @@ from nodes import utility_nodes  # type: ignore
 from nodes.node_factory import NodeFactory
 from events import EventQueue, ExecutionErrorData
 from process import Executor, NodeExecutionError, UsableData, timed_supplier
+from nodes.utils.exec_options import get_execution_options
 
 
 class AppContext:
@@ -184,9 +185,10 @@ async def run(request: Request):
             full_data: RunRequest = dict(request.json)  # type: ignore
             logger.info(full_data)
             nodes_list = full_data["data"]
-            os.environ["device"] = "cpu" if full_data["isCpu"] else "cuda"
-            os.environ["isFp16"] = str(full_data["isFp16"])
-            logger.info(f"Using device: {os.environ['device']}")
+            exec_opts = get_execution_options()
+            exec_opts.device = "cpu" if full_data["isCpu"] else "cuda"
+            exec_opts.fp16 = full_data["isFp16"]
+            logger.info(f"Using device: {exec_opts.device}")
             executor = Executor(
                 nodes_list,
                 app.loop,
@@ -242,9 +244,10 @@ async def run_individual(request: Request):
         if ctx.cache.get(full_data["id"], None) is not None:
             del ctx.cache[full_data["id"]]
         logger.info(full_data)
-        os.environ["device"] = "cpu" if full_data["isCpu"] else "cuda"
-        os.environ["isFp16"] = str(full_data["isFp16"])
-        logger.info(f"Using device: {os.environ['device']}")
+        exec_opts = get_execution_options()
+        exec_opts.device = "cpu" if full_data["isCpu"] else "cuda"
+        exec_opts.fp16 = full_data["isFp16"]
+        logger.info(f"Using device: {exec_opts.device}")
         # Create node based on given category/name information
         node_instance = NodeFactory.create_node(full_data["schemaId"])
 


### PR DESCRIPTION
This adds a new `ExecutionOptions` class that holds the information that was stored in `os.environ["device"]` and `os.environ["isFp16"]`. No more stringly-typed global mutable state.

Unfortunately, it's still stored as global state. While the global options variable is mutable, the options object itself is not. This will hopefully protect against race conditions in the future, because I expect the options to grow.