### PR TITLE
Mitigate stale validity causing problems

### DIFF
--- a/src/renderer/components/node/IteratorHelperNode.tsx
+++ b/src/renderer/components/node/IteratorHelperNode.tsx
@@ -1,14 +1,13 @@
 import { Center, VStack, useColorModeValue } from '@chakra-ui/react';
-import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { useReactFlow } from 'react-flow-renderer';
+import { memo, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { EdgeData, NodeData } from '../../../common/common-types';
+import { NodeData } from '../../../common/common-types';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
-import { VALID, checkNodeValidity } from '../../helpers/checkNodeValidity';
 import { shadeColor } from '../../helpers/colorTools';
 import { DisabledStatus, getDisabledStatus } from '../../helpers/disabled';
 import { getNodeAccentColor } from '../../helpers/getNodeAccentColor';
 import { useDisabled } from '../../hooks/useDisabled';
+import { useValidity } from '../../hooks/useValidity';
 import { NodeBody } from './NodeBody';
 import { NodeFooter } from './NodeFooter/NodeFooter';
 import { NodeHeader } from './NodeHeader';
@@ -19,13 +18,11 @@ interface IteratorHelperNodeProps {
 }
 
 export const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodeProps) => {
-    const edgeChanges = useContextSelector(GlobalVolatileContext, (c) => c.edgeChanges);
     const effectivelyDisabledNodes = useContextSelector(
         GlobalVolatileContext,
         (c) => c.effectivelyDisabledNodes
     );
     const { schemata, updateIteratorBounds, setHoveredNode } = useContext(GlobalContext);
-    const { getEdges } = useReactFlow<NodeData, EdgeData>();
 
     const { id, inputData, isLocked, parentNode, schemaId } = data;
     const animated = useContextSelector(GlobalVolatileContext, (c) => c.isAnimated(id));
@@ -35,10 +32,6 @@ export const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodePr
     const schema = schemata.get(schemaId);
     const { inputs, outputs, icon, category, name } = schema;
 
-    const functionInstance = useContextSelector(GlobalVolatileContext, (c) =>
-        c.typeState.functions.get(id)
-    );
-
     const regularBorderColor = useColorModeValue('gray.100', 'gray.800');
     const accentColor = getNodeAccentColor(category);
     const borderColor = useMemo(
@@ -46,20 +39,7 @@ export const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodePr
         [selected, accentColor, regularBorderColor]
     );
 
-    const [validity, setValidity] = useState(VALID);
-    useEffect(() => {
-        if (inputs.length) {
-            setValidity(
-                checkNodeValidity({
-                    id,
-                    schema,
-                    inputData,
-                    edges: getEdges(),
-                    functionInstance,
-                })
-            );
-        }
-    }, [inputData, edgeChanges, getEdges, functionInstance]);
+    const { validity } = useValidity(id, schema, inputData);
 
     const disabledStatus = useMemo(
         () => getDisabledStatus(data, effectivelyDisabledNodes),

--- a/src/renderer/components/node/IteratorNode.tsx
+++ b/src/renderer/components/node/IteratorNode.tsx
@@ -1,15 +1,14 @@
 import { Center, Text, VStack, useColorModeValue } from '@chakra-ui/react';
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
-import { useReactFlow } from 'react-flow-renderer';
+import { memo, useMemo, useRef } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { EdgeData, NodeData } from '../../../common/common-types';
+import { NodeData } from '../../../common/common-types';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
-import { VALID, checkNodeValidity } from '../../helpers/checkNodeValidity';
 import { shadeColor } from '../../helpers/colorTools';
 import { DisabledStatus } from '../../helpers/disabled';
 import { getNodeAccentColor } from '../../helpers/getNodeAccentColor';
 import { useDisabled } from '../../hooks/useDisabled';
 import { useNodeMenu } from '../../hooks/useNodeMenu';
+import { useValidity } from '../../hooks/useValidity';
 import { IteratorNodeBody } from './IteratorNodeBody';
 import { IteratorNodeHeader } from './IteratorNodeHeader';
 import { NodeFooter } from './NodeFooter/NodeFooter';
@@ -30,9 +29,7 @@ export const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => (
 ));
 
 const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
-    const edgeChanges = useContextSelector(GlobalVolatileContext, (c) => c.edgeChanges);
     const { schemata } = useContext(GlobalContext);
-    const { getEdges } = useReactFlow<NodeData, EdgeData>();
 
     const {
         id,
@@ -51,10 +48,6 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
     const schema = schemata.get(schemaId);
     const { inputs, outputs, icon, category, name } = schema;
 
-    const functionInstance = useContextSelector(GlobalVolatileContext, (c) =>
-        c.typeState.functions.get(id)
-    );
-
     const regularBorderColor = useColorModeValue('gray.100', 'gray.800');
     const accentColor = getNodeAccentColor(category);
     const borderColor = useMemo(
@@ -62,20 +55,7 @@ const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
         [selected, accentColor, regularBorderColor]
     );
 
-    const [validity, setValidity] = useState(VALID);
-    useEffect(() => {
-        if (inputs.length) {
-            setValidity(
-                checkNodeValidity({
-                    id,
-                    schema,
-                    inputData,
-                    edges: getEdges(),
-                    functionInstance,
-                })
-            );
-        }
-    }, [inputData, edgeChanges, functionInstance]);
+    const { validity } = useValidity(id, schema, inputData);
 
     const iteratorBoxRef = useRef<HTMLDivElement | null>(null);
 

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -1,13 +1,11 @@
 import { Center, VStack, useColorModeValue } from '@chakra-ui/react';
 import path from 'path';
-import { DragEvent, memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { useReactFlow } from 'react-flow-renderer';
+import { DragEvent, memo, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { EdgeData, Input, NodeData } from '../../../common/common-types';
+import { Input, NodeData } from '../../../common/common-types';
 import { isStartingNode } from '../../../common/util';
 import { AlertBoxContext } from '../../contexts/AlertBoxContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
-import { Validity, checkNodeValidity } from '../../helpers/checkNodeValidity';
 import { shadeColor } from '../../helpers/colorTools';
 import { getSingleFileWithExtension } from '../../helpers/dataTransfer';
 import { DisabledStatus } from '../../helpers/disabled';
@@ -15,6 +13,7 @@ import { getNodeAccentColor } from '../../helpers/getNodeAccentColor';
 import { useDisabled } from '../../hooks/useDisabled';
 import { useNodeMenu } from '../../hooks/useNodeMenu';
 import { useRunNode } from '../../hooks/useRunNode';
+import { useValidity } from '../../hooks/useValidity';
 import { NodeBody } from './NodeBody';
 import { NodeFooter } from './NodeFooter/NodeFooter';
 import { NodeHeader } from './NodeHeader';
@@ -50,10 +49,8 @@ export interface NodeProps {
 
 const NodeInner = memo(({ data, selected }: NodeProps) => {
     const { sendToast } = useContext(AlertBoxContext);
-    const edgeChanges = useContextSelector(GlobalVolatileContext, (c) => c.edgeChanges);
     const { schemata, updateIteratorBounds, setHoveredNode, useInputData } =
         useContext(GlobalContext);
-    const { getEdges } = useReactFlow<NodeData, EdgeData>();
 
     const { id, inputData, inputSize, isLocked, parentNode, schemaId } = data;
     const animated = useContextSelector(GlobalVolatileContext, (c) => c.isAnimated(id));
@@ -63,9 +60,7 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
     const schema = schemata.get(schemaId);
     const { inputs, outputs, icon, category, name } = schema;
 
-    const functionInstance = useContextSelector(GlobalVolatileContext, (c) =>
-        c.typeState.functions.get(id)
-    );
+    const { validity } = useValidity(id, schema, inputData);
 
     const regularBorderColor = useColorModeValue('gray.200', 'gray.800');
     const accentColor = getNodeAccentColor(category);
@@ -73,24 +68,6 @@ const NodeInner = memo(({ data, selected }: NodeProps) => {
         () => (selected ? shadeColor(accentColor, 0) : regularBorderColor),
         [selected, accentColor, regularBorderColor]
     );
-
-    const [validity, setValidity] = useState<Validity>({
-        isValid: false,
-        reason: 'Validating nodes...',
-    });
-    useEffect(() => {
-        if (inputs.length) {
-            setValidity(
-                checkNodeValidity({
-                    id,
-                    schema,
-                    inputData,
-                    edges: getEdges(),
-                    functionInstance,
-                })
-            );
-        }
-    }, [inputData, edgeChanges, functionInstance]);
 
     const targetRef = useRef<HTMLDivElement>(null);
     const [checkedSize, setCheckedSize] = useState(false);

--- a/src/renderer/hooks/useValidity.ts
+++ b/src/renderer/hooks/useValidity.ts
@@ -1,0 +1,64 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useReactFlow } from 'react-flow-renderer';
+import { useContextSelector } from 'use-context-selector';
+import { EdgeData, InputData, NodeData, NodeSchema } from '../../common/common-types';
+import { GlobalVolatileContext } from '../contexts/GlobalNodeState';
+import {
+    VALID,
+    Validity,
+    checkNodeValidity,
+    checkRequiredInputs,
+} from '../helpers/checkNodeValidity';
+
+const STARTING_VALIDITY: Validity = {
+    isValid: false,
+    reason: 'Validating nodes...',
+};
+
+export interface UseValidity {
+    validity: Validity;
+}
+
+export const useValidity = (id: string, schema: NodeSchema, inputData: InputData): UseValidity => {
+    const edgeChanges = useContextSelector(GlobalVolatileContext, (c) => c.edgeChanges);
+    const functionInstance = useContextSelector(GlobalVolatileContext, (c) =>
+        c.typeState.functions.get(id)
+    );
+    const { getEdges } = useReactFlow<NodeData, EdgeData>();
+
+    const alwaysValid = schema.inputs.length === 0;
+
+    const guaranteedMissingInputs = useMemo(
+        (): Validity => checkRequiredInputs(schema, inputData),
+        [schema, inputData]
+    );
+
+    const [fullValidity, setValidity] = useState<Validity>(alwaysValid ? VALID : STARTING_VALIDITY);
+    useEffect(() => {
+        if (!alwaysValid) {
+            setValidity(
+                checkNodeValidity({
+                    id,
+                    schema,
+                    inputData,
+                    edges: getEdges(),
+                    functionInstance,
+                })
+            );
+        }
+    }, [id, schema, inputData, edgeChanges, functionInstance]);
+
+    // The problem with `checkNodeValidity` is that is must be computed with a delay due to
+    // `getEdges`. This means that the full validity we return here might be outdated. This is a
+    // problem when other aspects of the problem rely on the fact that that valid nodes can be
+    // executed. To mitigate (but unfortunately not fully fix) this problem, we also synchronously
+    // compute an approximate conservative validity. This second validity will only be invalid, if
+    // the node is guaranteed to be invalid, but it might be valid even though the node is
+    // actually invalid.
+    const validity =
+        fullValidity.isValid && !guaranteedMissingInputs.isValid
+            ? guaranteedMissingInputs
+            : fullValidity;
+
+    return { validity };
+};


### PR DESCRIPTION
Fixes #682.

The problem was that the node validity is stale immediately have input data changes. The run hook actually has [a hacky workaround](https://github.com/joeyballentine/chaiNNer/blob/c253fa41570ef9181734fb757b89ba59f360a112/src/renderer/hooks/useRunNode.ts#L32) for this, but it works via a timer which isn't guaranteed to work. This was the problem. With a lot of stuff going on in complex chains, we run out of time and update the validity after starting to run the node.

My solution is to improve validity to not be as stale. The idea is that we can do some validity checks synchronously without `useEffect`. While those checks are only an approximation, they are never stale. So if the approximate validity says that the node is invalid, it is guaranteed to be invalid. By combining the approximate and full (but potentially stale) validity, we get a more up-to-date validity.

This fixes the bug but barely. The approximation just isn't that good because there is only so much we can validate without edges. The real fix is something RF has to do. The only reason we have to do the full validity check in an `useEffect` in the first place is that `getEdges` sometimes returns stale results when invoked inside the render function (e.g. inside `useMemo`).