### PR TITLE
Removed unnecessary `overflowX: hidden`

### DIFF
--- a/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
+++ b/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
@@ -90,7 +90,6 @@ export const NodeSelector = memo(({ schemata }: NodeSelectorProps) => {
                 borderRadius="lg"
                 borderWidth="0px"
                 h="100%"
-                overflowX="hidden"
             >
                 <motion.div
                     animate={{ width: collapsed ? '76px' : '300px' }}


### PR DESCRIPTION
Fixes #667.

@joeyballentine added this line in #401 to prevent scrollbars from appearing during animations. However, it doesn't seem to be necessary. Even without it, animations do not cause a scrollbar to appear.