### PR TITLE
Open node selector panel when interacting with the search bar

### DIFF
--- a/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
+++ b/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
@@ -112,6 +112,7 @@ export const NodeSelector = memo(({ schemata }: NodeSelectorProps) => {
                         <TabPanels>
                             <TabPanel
                                 m={0}
+                                overflowX="hidden"
                                 p={0}
                             >
                                 <InputGroup borderRadius={0}>
@@ -123,13 +124,16 @@ export const NodeSelector = memo(({ schemata }: NodeSelectorProps) => {
                                     </InputLeftElement>
                                     <Input
                                         borderRadius={0}
-                                        disabled={collapsed}
                                         placeholder="Search..."
                                         spellCheck={false}
                                         type="text"
                                         value={searchQuery}
                                         variant="filled"
-                                        onChange={(e) => setSearchQuery(e.target.value)}
+                                        onChange={(e) => {
+                                            setSearchQuery(e.target.value);
+                                            setCollapsed(false);
+                                        }}
+                                        onClick={() => setCollapsed(false)}
                                     />
                                     <InputRightElement
                                         _hover={{ color: useColorModeValue('black', 'white') }}


### PR DESCRIPTION
Closes #440.

When the search bar is clicked or text is changed, the node selector will automatically open, so the user can see what they're doing.