### PR TITLE
Added backend context

### DIFF
--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -158,7 +158,7 @@ async def nodes(_):
         if node_object.get_type() == "iterator":
             node_dict["defaultNodes"] = node_object.get_default_nodes()  # type: ignore
         node_list.append(node_dict)
-    return json(node_list)
+    return json({"nodes": node_list, "categories": category_order})
 
 
 class RunRequest(TypedDict):

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -14,7 +14,10 @@ export interface BackendExceptionResponse {
     source?: BackendExceptionSource | null;
     exception: string;
 }
-export type BackendNodesResponse = NodeSchema[];
+export interface BackendNodesResponse {
+    nodes: NodeSchema[];
+    categories: string[];
+}
 export interface BackendRunRequest {
     data: Record<string, UsableData>;
     isCpu: boolean;

--- a/src/renderer/components/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge.tsx
@@ -6,6 +6,7 @@ import { useContext, useContextSelector } from 'use-context-selector';
 import { useDebouncedCallback } from 'use-debounce';
 import { EdgeData, NodeData } from '../../common/common-types';
 import { parseSourceHandle } from '../../common/util';
+import { BackendContext } from '../contexts/BackendContext';
 import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { SettingsContext } from '../contexts/SettingsContext';
 import { shadeColor } from '../helpers/colorTools';
@@ -51,7 +52,8 @@ export const CustomEdge = memo(
         const parentNode = useMemo(() => getNode(source)!, [source]);
         const isSourceEnabled = !effectivelyDisabledNodes.has(source);
 
-        const { removeEdgeById, setHoveredNode, functionDefinitions } = useContext(GlobalContext);
+        const { removeEdgeById, setHoveredNode } = useContext(GlobalContext);
+        const { functionDefinitions } = useContext(BackendContext);
 
         const [isHovered, setIsHovered] = useState(false);
 

--- a/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
+++ b/src/renderer/components/NodeSelectorPanel/NodeSelectorPanel.tsx
@@ -23,7 +23,7 @@ import { motion } from 'framer-motion';
 import { memo, useMemo, useState } from 'react';
 import { BsCaretDownFill, BsCaretLeftFill, BsCaretRightFill, BsCaretUpFill } from 'react-icons/bs';
 import { useContext, useContextSelector } from 'use-context-selector';
-import { SchemaMap } from '../../../common/SchemaMap';
+import { BackendContext } from '../../contexts/BackendContext';
 import { DependencyContext } from '../../contexts/DependencyContext';
 import { SettingsContext } from '../../contexts/SettingsContext';
 import {
@@ -37,11 +37,8 @@ import { FavoritesAccordionItem } from './FavoritesAccordionItem';
 import { RegularAccordionItem } from './RegularAccordionItem';
 import { TextBox } from './TextBox';
 
-interface NodeSelectorProps {
-    schemata: SchemaMap;
-}
-
-export const NodeSelector = memo(({ schemata }: NodeSelectorProps) => {
+export const NodeSelector = memo(() => {
+    const { schemata } = useContext(BackendContext);
     const { openDependencyManager } = useContext(DependencyContext);
 
     const [searchQuery, setSearchQuery] = useState('');

--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -21,6 +21,7 @@ import ReactFlow, {
 import { useContext, useContextSelector } from 'use-context-selector';
 import { EdgeData, NodeData } from '../../common/common-types';
 import { AlertBoxContext, AlertType } from '../contexts/AlertBoxContext';
+import { BackendContext } from '../contexts/BackendContext';
 import { ContextMenuContext } from '../contexts/ContextMenuContext';
 import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { SettingsContext } from '../contexts/SettingsContext';
@@ -156,7 +157,6 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
     const { closeContextMenu } = useContext(ContextMenuContext);
     const { createNode, createConnection } = useContext(GlobalVolatileContext);
     const {
-        schemata,
         setZoom,
         setHoveredNode,
         addNodeChanges,
@@ -167,6 +167,7 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
         setSetEdges,
         updateIteratorBounds,
     } = useContext(GlobalContext);
+    const { schemata } = useContext(BackendContext);
 
     const useSnapToGrid = useContextSelector(SettingsContext, (c) => c.useSnapToGrid);
     const animateChain = useContextSelector(SettingsContext, (c) => c.useAnimateChain[0]);

--- a/src/renderer/components/inputs/InputContainer.tsx
+++ b/src/renderer/components/inputs/InputContainer.tsx
@@ -5,7 +5,8 @@ import { useContext } from 'use-context-selector';
 import { InputId, NodeData } from '../../../common/common-types';
 import { Type } from '../../../common/types/types';
 import { parseSourceHandle, parseTargetHandle, stringifyTargetHandle } from '../../../common/util';
-import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
+import { BackendContext } from '../../contexts/BackendContext';
+import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { SettingsContext } from '../../contexts/SettingsContext';
 import { defaultColor, getTypeAccentColors } from '../../helpers/getTypeAccentColors';
 import { noContextMenu } from '../../hooks/useContextMenu';
@@ -86,7 +87,7 @@ export const InputContainer = memo(
             });
         }, [connectingFrom, definitionType, id, inputId]);
 
-        const { functionDefinitions } = useContext(GlobalContext);
+        const { functionDefinitions } = useContext(BackendContext);
         const { useIsDarkMode } = useContext(SettingsContext);
         const [isDarkMode] = useIsDarkMode;
 

--- a/src/renderer/components/node/IteratorHelperNode.tsx
+++ b/src/renderer/components/node/IteratorHelperNode.tsx
@@ -2,6 +2,7 @@ import { Center, VStack, useColorModeValue } from '@chakra-ui/react';
 import { memo, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeData } from '../../../common/common-types';
+import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { shadeColor } from '../../helpers/colorTools';
 import { DisabledStatus, getDisabledStatus } from '../../helpers/disabled';
@@ -22,7 +23,8 @@ export const IteratorHelperNode = memo(({ data, selected }: IteratorHelperNodePr
         GlobalVolatileContext,
         (c) => c.effectivelyDisabledNodes
     );
-    const { schemata, updateIteratorBounds, setHoveredNode } = useContext(GlobalContext);
+    const { updateIteratorBounds, setHoveredNode } = useContext(GlobalContext);
+    const { schemata } = useContext(BackendContext);
 
     const { id, inputData, isLocked, parentNode, schemaId } = data;
     const animated = useContextSelector(GlobalVolatileContext, (c) => c.isAnimated(id));

--- a/src/renderer/components/node/IteratorNode.tsx
+++ b/src/renderer/components/node/IteratorNode.tsx
@@ -2,7 +2,8 @@ import { Center, Text, VStack, useColorModeValue } from '@chakra-ui/react';
 import { memo, useMemo, useRef } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeData } from '../../../common/common-types';
-import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
+import { BackendContext } from '../../contexts/BackendContext';
+import { GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { shadeColor } from '../../helpers/colorTools';
 import { DisabledStatus } from '../../helpers/disabled';
 import { getNodeAccentColor } from '../../helpers/getNodeAccentColor';
@@ -29,7 +30,7 @@ export const IteratorNode = memo(({ data, selected }: IteratorNodeProps) => (
 ));
 
 const IteratorNodeInner = memo(({ data, selected }: IteratorNodeProps) => {
-    const { schemata } = useContext(GlobalContext);
+    const { schemata } = useContext(BackendContext);
 
     const {
         id,

--- a/src/renderer/components/node/Node.tsx
+++ b/src/renderer/components/node/Node.tsx
@@ -5,6 +5,7 @@ import { useContext, useContextSelector } from 'use-context-selector';
 import { Input, NodeData } from '../../../common/common-types';
 import { isStartingNode } from '../../../common/util';
 import { AlertBoxContext } from '../../contexts/AlertBoxContext';
+import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { shadeColor } from '../../helpers/colorTools';
 import { getSingleFileWithExtension } from '../../helpers/dataTransfer';
@@ -49,8 +50,8 @@ export interface NodeProps {
 
 const NodeInner = memo(({ data, selected }: NodeProps) => {
     const { sendToast } = useContext(AlertBoxContext);
-    const { schemata, updateIteratorBounds, setHoveredNode, useInputData } =
-        useContext(GlobalContext);
+    const { updateIteratorBounds, setHoveredNode, useInputData } = useContext(GlobalContext);
+    const { schemata } = useContext(BackendContext);
 
     const { id, inputData, inputSize, isLocked, parentNode, schemaId } = data;
     const animated = useContextSelector(GlobalVolatileContext, (c) => c.isAnimated(id));

--- a/src/renderer/components/node/NodeInputs.tsx
+++ b/src/renderer/components/node/NodeInputs.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../common/common-types';
 import { Type } from '../../../common/types/types';
 import { assertNever } from '../../../common/util';
+import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalContext } from '../../contexts/GlobalNodeState';
 import { DirectoryInput } from '../inputs/DirectoryInput';
 import { DropDownInput } from '../inputs/DropDownInput';
@@ -101,11 +102,9 @@ interface NodeInputsProps {
 
 export const NodeInputs = memo(
     ({ inputs, id, inputData, inputSize, isLocked, schemaId, accentColor }: NodeInputsProps) => {
-        const {
-            useInputData: useInputDataContext,
-            useInputSize: useInputSizeContext,
-            functionDefinitions,
-        } = useContext(GlobalContext);
+        const { useInputData: useInputDataContext, useInputSize: useInputSizeContext } =
+            useContext(GlobalContext);
+        const { functionDefinitions } = useContext(BackendContext);
 
         const useInputData = useCallback(
             <T extends InputSchemaValue>(inputId: InputId) =>

--- a/src/renderer/components/node/NodeOutputs.tsx
+++ b/src/renderer/components/node/NodeOutputs.tsx
@@ -5,6 +5,7 @@ import { useContext, useContextSelector } from 'use-context-selector';
 import { Output, OutputId, OutputKind, SchemaId } from '../../../common/common-types';
 import { Type } from '../../../common/types/types';
 import { assertNever } from '../../../common/util';
+import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { DefaultImageOutput } from '../outputs/DefaultImageOutput';
 import { GenericOutput } from '../outputs/GenericOutput';
@@ -65,7 +66,8 @@ interface NodeOutputProps {
 }
 
 export const NodeOutputs = memo(({ outputs, id, schemaId, animated = false }: NodeOutputProps) => {
-    const { functionDefinitions, getInputHash } = useContext(GlobalContext);
+    const { getInputHash } = useContext(GlobalContext);
+    const { functionDefinitions } = useContext(BackendContext);
     const outputDataEntry = useContextSelector(GlobalVolatileContext, (c) =>
         c.outputDataMap.get(id)
     );

--- a/src/renderer/components/outputs/GenericOutput.tsx
+++ b/src/renderer/components/outputs/GenericOutput.tsx
@@ -4,6 +4,7 @@ import { useContext, useContextSelector } from 'use-context-selector';
 import { NamedExpression, NamedExpressionField } from '../../../common/types/expression';
 import { StringLiteralType } from '../../../common/types/types';
 import { isStartingNode } from '../../../common/util';
+import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { TypeTags } from '../TypeTag';
 import { OutputProps } from './props';
@@ -14,7 +15,8 @@ export const GenericOutput = memo(
             c.typeState.functions.get(id)?.outputs.get(outputId)
         );
 
-        const { setManualOutputType, schemata } = useContext(GlobalContext);
+        const { setManualOutputType } = useContext(GlobalContext);
+        const { schemata } = useContext(BackendContext);
 
         const schema = schemata.get(schemaId);
 

--- a/src/renderer/components/outputs/LargeImageOutput.tsx
+++ b/src/renderer/components/outputs/LargeImageOutput.tsx
@@ -6,6 +6,7 @@ import { useContext, useContextSelector } from 'use-context-selector';
 import { NamedExpression, NamedExpressionField } from '../../../common/types/expression';
 import { NumericLiteralType } from '../../../common/types/types';
 import { isStartingNode } from '../../../common/util';
+import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalContext, GlobalVolatileContext } from '../../contexts/GlobalNodeState';
 import { OutputProps } from './props';
 
@@ -18,7 +19,8 @@ interface LargeImageBroadcastData {
 
 export const LargeImageOutput = memo(
     ({ id, outputId, useOutputData, animated = false, schemaId }: OutputProps) => {
-        const { setManualOutputType, schemata } = useContext(GlobalContext);
+        const { setManualOutputType } = useContext(GlobalContext);
+        const { schemata } = useContext(BackendContext);
         const schema = schemata.get(schemaId);
 
         const inputHash = useContextSelector(GlobalVolatileContext, (c) => c.inputHashes.get(id));

--- a/src/renderer/components/outputs/PyTorchOutput.tsx
+++ b/src/renderer/components/outputs/PyTorchOutput.tsx
@@ -15,6 +15,7 @@ import { useContext } from 'use-context-selector';
 import { NamedExpression, NamedExpressionField } from '../../../common/types/expression';
 import { NumericLiteralType, StringLiteralType } from '../../../common/types/types';
 import { isStartingNode } from '../../../common/util';
+import { BackendContext } from '../../contexts/BackendContext';
 import { GlobalContext } from '../../contexts/GlobalNodeState';
 import { OutputProps } from './props';
 
@@ -43,7 +44,8 @@ export const PyTorchOutput = memo(
     ({ id, outputId, useOutputData, animated = false, schemaId }: OutputProps) => {
         const [value] = useOutputData<PyTorchModelData>(outputId);
 
-        const { setManualOutputType, schemata } = useContext(GlobalContext);
+        const { setManualOutputType } = useContext(GlobalContext);
+        const { schemata } = useContext(BackendContext);
 
         const schema = schemata.get(schemaId);
 

--- a/src/renderer/contexts/BackendContext.tsx
+++ b/src/renderer/contexts/BackendContext.tsx
@@ -1,0 +1,53 @@
+import React, { memo } from 'react';
+import { createContext } from 'use-context-selector';
+import { Backend, getBackend } from '../../common/Backend';
+import { SchemaId } from '../../common/common-types';
+import { SchemaMap } from '../../common/SchemaMap';
+import { FunctionDefinition } from '../../common/types/function';
+import { useMemoObject } from '../hooks/useMemo';
+
+interface BackendContextState {
+    port: number;
+    backend: Backend;
+    schemata: SchemaMap;
+    /**
+     * An ordered list of all categories supported by the backend.
+     *
+     * Some categories might be empty.
+     */
+    categories: string[];
+    functionDefinitions: Map<SchemaId, FunctionDefinition>;
+}
+
+export const BackendContext = createContext<Readonly<BackendContextState>>(
+    {} as BackendContextState
+);
+
+interface BackendProviderProps {
+    port: number;
+    schemata: SchemaMap;
+    categories: string[];
+    functionDefinitions: Map<SchemaId, FunctionDefinition>;
+}
+
+export const BackendProvider = memo(
+    ({
+        port,
+        schemata,
+        categories,
+        functionDefinitions,
+        children,
+    }: React.PropsWithChildren<BackendProviderProps>) => {
+        const backend = getBackend(port);
+
+        const value = useMemoObject<BackendContextState>({
+            port,
+            backend,
+            schemata,
+            categories,
+            functionDefinitions,
+        });
+
+        return <BackendContext.Provider value={value}>{children}</BackendContext.Provider>;
+    }
+);

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -3,7 +3,6 @@ import { Edge, Node, useReactFlow } from 'react-flow-renderer';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { createContext, useContext } from 'use-context-selector';
 import { useThrottledCallback } from 'use-debounce';
-import { getBackend } from '../../common/Backend';
 import {
     EdgeData,
     EdgeHandle,
@@ -33,6 +32,7 @@ import {
 import { useBatchedCallback } from '../hooks/useBatchedCallback';
 import { useMemoObject } from '../hooks/useMemo';
 import { AlertBoxContext, AlertType } from './AlertBoxContext';
+import { BackendContext } from './BackendContext';
 import { GlobalContext } from './GlobalNodeState';
 import { SettingsContext } from './SettingsContext';
 
@@ -140,7 +140,6 @@ export const ExecutionContext = createContext<Readonly<ExecutionContextValue>>(
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>) => {
     const {
-        schemata,
         animate,
         unAnimate,
         setIteratorPercent,
@@ -148,7 +147,8 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
         outputDataActions,
         getInputHash,
     } = useContext(GlobalContext);
-    const { useIsCpu, useIsFp16, port } = useContext(SettingsContext);
+    const { schemata, port, backend } = useContext(BackendContext);
+    const { useIsCpu, useIsFp16 } = useContext(SettingsContext);
     const { sendAlert } = useContext(AlertBoxContext);
 
     const [isCpu] = useIsCpu;
@@ -157,7 +157,6 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
     const { getNodes, getEdges } = useReactFlow<NodeData, EdgeData>();
 
     const [status, setStatus] = useState(ExecutionStatus.READY);
-    const backend = getBackend(port);
 
     const [isBackendKilled, setIsBackendKilled] = useState(false);
 

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -24,16 +24,13 @@ import {
     Mutable,
     NodeData,
     OutputId,
-    SchemaId,
     Size,
 } from '../../common/common-types';
 import { ipcRenderer } from '../../common/safeIpc';
 import { ParsedSaveData, SaveData, openSaveFile } from '../../common/SaveFile';
-import { SchemaMap } from '../../common/SchemaMap';
 import { getChainnerScope } from '../../common/types/chainner-scope';
 import { evaluate } from '../../common/types/evaluate';
 import { Expression } from '../../common/types/expression';
-import { FunctionDefinition } from '../../common/types/function';
 import { Type } from '../../common/types/types';
 import {
     EMPTY_SET,
@@ -73,6 +70,7 @@ import {
 } from '../hooks/useOutputDataStore';
 import { getSessionStorageOrDefault, useSessionStorage } from '../hooks/useSessionStorage';
 import { AlertBoxContext, AlertType } from './AlertBoxContext';
+import { BackendContext } from './BackendContext';
 import { SettingsContext } from './SettingsContext';
 
 type SetState<T> = React.Dispatch<React.SetStateAction<T>>;
@@ -97,7 +95,6 @@ interface GlobalVolatile {
     ];
 }
 interface Global {
-    schemata: SchemaMap;
     reactFlowWrapper: React.RefObject<Element>;
     defaultIteratorSize: Readonly<Size>;
     setSetNodes: SetState<SetState<Node<NodeData>[]>>;
@@ -135,7 +132,6 @@ interface Global {
     setHoveredNode: SetState<string | null | undefined>;
     setZoom: SetState<number>;
     setManualOutputType: (nodeId: string, outputId: OutputId, type: Expression | undefined) => void;
-    functionDefinitions: ReadonlyMap<SchemaId, FunctionDefinition>;
     typeStateRef: Readonly<React.MutableRefObject<TypeState>>;
     releaseNodeFromParent: (id: string) => void;
     outputDataActions: OutputDataActions;
@@ -147,19 +143,13 @@ export const GlobalVolatileContext = createContext<Readonly<GlobalVolatile>>({} 
 export const GlobalContext = createContext<Readonly<Global>>({} as Global);
 
 interface GlobalProviderProps {
-    schemata: SchemaMap;
     reactFlowWrapper: React.RefObject<Element>;
-    functionDefinitions: Map<SchemaId, FunctionDefinition>;
 }
 
 export const GlobalProvider = memo(
-    ({
-        children,
-        schemata,
-        reactFlowWrapper,
-        functionDefinitions,
-    }: React.PropsWithChildren<GlobalProviderProps>) => {
+    ({ children, reactFlowWrapper }: React.PropsWithChildren<GlobalProviderProps>) => {
         const { sendAlert, sendToast, showAlert } = useContext(AlertBoxContext);
+        const { schemata, functionDefinitions } = useContext(BackendContext);
         const { useStartupTemplate } = useContext(SettingsContext);
 
         const [nodeChanges, addNodeChanges] = useChangeCounter();
@@ -1063,7 +1053,6 @@ export const GlobalProvider = memo(
         });
 
         const globalValue = useMemoObject<Global>({
-            schemata,
             reactFlowWrapper,
             defaultIteratorSize,
             setSetNodes,
@@ -1089,7 +1078,6 @@ export const GlobalProvider = memo(
             setNodeDisabled,
             setZoom,
             setManualOutputType,
-            functionDefinitions,
             typeStateRef,
             releaseNodeFromParent,
             outputDataActions,

--- a/src/renderer/contexts/SettingsContext.tsx
+++ b/src/renderer/contexts/SettingsContext.tsx
@@ -27,70 +27,62 @@ interface Settings {
         React.Dispatch<React.SetStateAction<readonly SchemaId[]>>
     ];
     useNodeSelectorCollapsed: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
-
-    // Port
-    port: number;
 }
 
 // TODO: create context requires default values
 export const SettingsContext = createContext<Readonly<Settings>>({} as Settings);
 
-export const SettingsProvider = memo(
-    ({ children, port }: React.PropsWithChildren<{ port: number }>) => {
-        // Global Settings
-        const useIsCpu = useMemoArray(useLocalStorage('is-cpu', false));
-        const useIsFp16 = useMemoArray(useLocalStorage('is-fp16', false));
-        const useIsSystemPython = useMemoArray(useLocalStorage('use-system-python', false));
-        const useDisHwAccel = useMemoArray(useLocalStorage('disable-hw-accel', false));
-        const useStartupTemplate = useMemoArray(useLocalStorage('startup-template', ''));
+export const SettingsProvider = memo(({ children }: React.PropsWithChildren<unknown>) => {
+    // Global Settings
+    const useIsCpu = useMemoArray(useLocalStorage('is-cpu', false));
+    const useIsFp16 = useMemoArray(useLocalStorage('is-fp16', false));
+    const useIsSystemPython = useMemoArray(useLocalStorage('use-system-python', false));
+    const useDisHwAccel = useMemoArray(useLocalStorage('disable-hw-accel', false));
+    const useStartupTemplate = useMemoArray(useLocalStorage('startup-template', ''));
 
-        const useIsDarkMode = useMemoArray(useLocalStorage('use-dark-mode', true));
+    const useIsDarkMode = useMemoArray(useLocalStorage('use-dark-mode', true));
 
-        const { setColorMode } = useColorMode();
-        const [isDarkMode] = useIsDarkMode;
-        useEffect(() => {
-            setColorMode(isDarkMode ? 'dark' : 'light');
-        }, [setColorMode, isDarkMode]);
+    const { setColorMode } = useColorMode();
+    const [isDarkMode] = useIsDarkMode;
+    useEffect(() => {
+        setColorMode(isDarkMode ? 'dark' : 'light');
+    }, [setColorMode, isDarkMode]);
 
-        const useAnimateChain = useMemoArray(useLocalStorage('animate-chain', true));
+    const useAnimateChain = useMemoArray(useLocalStorage('animate-chain', true));
 
-        // Snap to grid
-        const [isSnapToGrid, setIsSnapToGrid] = useLocalStorage('snap-to-grid', false);
-        const [snapToGridAmount, setSnapToGridAmount] = useLocalStorage('snap-to-grid-amount', 15);
-        const useSnapToGrid = useMemoArray([
-            isSnapToGrid,
-            setIsSnapToGrid,
-            snapToGridAmount || 1,
-            setSnapToGridAmount,
-        ] as const);
+    // Snap to grid
+    const [isSnapToGrid, setIsSnapToGrid] = useLocalStorage('snap-to-grid', false);
+    const [snapToGridAmount, setSnapToGridAmount] = useLocalStorage('snap-to-grid-amount', 15);
+    const useSnapToGrid = useMemoArray([
+        isSnapToGrid,
+        setIsSnapToGrid,
+        snapToGridAmount || 1,
+        setSnapToGridAmount,
+    ] as const);
 
-        // Node Settings
-        const useNodeFavorites = useMemoArray(
-            useLocalStorage<readonly SchemaId[]>('node-favorites', [])
-        );
-        const useNodeSelectorCollapsed = useMemoArray(
-            useLocalStorage('node-selector-collapsed', false)
-        );
+    // Node Settings
+    const useNodeFavorites = useMemoArray(
+        useLocalStorage<readonly SchemaId[]>('node-favorites', [])
+    );
+    const useNodeSelectorCollapsed = useMemoArray(
+        useLocalStorage('node-selector-collapsed', false)
+    );
 
-        const contextValue = useMemoObject<Settings>({
-            // Globals
-            useIsCpu,
-            useIsFp16,
-            useIsSystemPython,
-            useSnapToGrid,
-            useDisHwAccel,
-            useStartupTemplate,
-            useIsDarkMode,
-            useAnimateChain,
+    const contextValue = useMemoObject<Settings>({
+        // Globals
+        useIsCpu,
+        useIsFp16,
+        useIsSystemPython,
+        useSnapToGrid,
+        useDisHwAccel,
+        useStartupTemplate,
+        useIsDarkMode,
+        useAnimateChain,
 
-            // Node
-            useNodeFavorites,
-            useNodeSelectorCollapsed,
+        // Node
+        useNodeFavorites,
+        useNodeSelectorCollapsed,
+    });
 
-            // Port
-            port,
-        });
-
-        return <SettingsContext.Provider value={contextValue}>{children}</SettingsContext.Provider>;
-    }
-);
+    return <SettingsContext.Provider value={contextValue}>{children}</SettingsContext.Provider>;
+});

--- a/src/renderer/hooks/useDisabled.ts
+++ b/src/renderer/hooks/useDisabled.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useContext, useContextSelector } from 'use-context-selector';
 import { NodeData } from '../../common/common-types';
+import { BackendContext } from '../contexts/BackendContext';
 import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { DisabledStatus, getDisabledStatus } from '../helpers/disabled';
 import { useMemoObject } from './useMemo';
@@ -19,7 +20,8 @@ export const useDisabled = (data: NodeData): UseDisabled => {
         GlobalVolatileContext,
         (c) => c.effectivelyDisabledNodes
     );
-    const { schemata, setNodeDisabled } = useContext(GlobalContext);
+    const { setNodeDisabled } = useContext(GlobalContext);
+    const { schemata } = useContext(BackendContext);
 
     const schema = schemata.get(schemaId);
 

--- a/src/renderer/hooks/usePaneNodeSearchMenu.tsx
+++ b/src/renderer/hooks/usePaneNodeSearchMenu.tsx
@@ -28,8 +28,9 @@ import {
     stringifyTargetHandle,
 } from '../../common/util';
 import { IconFactory } from '../components/CustomIcons';
+import { BackendContext } from '../contexts/BackendContext';
 import { ContextMenuContext } from '../contexts/ContextMenuContext';
-import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeState';
+import { GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { interpolateColor } from '../helpers/colorTools';
 import { getNodeAccentColor } from '../helpers/getNodeAccentColor';
 import { getMatchingNodes, getNodesByCategory, sortSchemata } from '../helpers/nodeSearchFuncs';
@@ -265,7 +266,7 @@ export const usePaneNodeSearchMenu = (
     const { createNode, createConnection, typeState, useConnectingFrom } =
         useContext(GlobalVolatileContext);
     const { closeContextMenu } = useContext(ContextMenuContext);
-    const { schemata, functionDefinitions } = useContext(GlobalContext);
+    const { schemata, functionDefinitions } = useContext(BackendContext);
 
     const { favorites } = useNodeFavorites();
 

--- a/src/renderer/hooks/useRunNode.ts
+++ b/src/renderer/hooks/useRunNode.ts
@@ -1,18 +1,18 @@
 import { useMemo, useRef } from 'react';
 import { useContext } from 'use-context-selector';
-import { getBackend } from '../../common/Backend';
 import { NodeData } from '../../common/common-types';
 import { delay, getInputValues } from '../../common/util';
 import { AlertBoxContext } from '../contexts/AlertBoxContext';
+import { BackendContext } from '../contexts/BackendContext';
 import { GlobalContext } from '../contexts/GlobalNodeState';
 import { SettingsContext } from '../contexts/SettingsContext';
 import { useAsyncEffect } from './useAsyncEffect';
 
 export const useRunNode = ({ inputData, id, schemaId }: NodeData, shouldRun: boolean): void => {
     const { sendToast } = useContext(AlertBoxContext);
-    const { animate, unAnimate, schemata } = useContext(GlobalContext);
-    const { useIsCpu, useIsFp16, port } = useContext(SettingsContext);
-    const backend = getBackend(port);
+    const { animate, unAnimate } = useContext(GlobalContext);
+    const { schemata, backend } = useContext(BackendContext);
+    const { useIsCpu, useIsFp16 } = useContext(SettingsContext);
 
     const [isCpu] = useIsCpu;
     const [isFp16] = useIsFp16;

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -21,6 +21,7 @@ import { Node } from './components/node/Node';
 import { NodeSelector } from './components/NodeSelectorPanel/NodeSelectorPanel';
 import { ReactFlowBox } from './components/ReactFlowBox';
 import { AlertBoxContext, AlertType } from './contexts/AlertBoxContext';
+import { BackendProvider } from './contexts/BackendContext';
 import { DependencyProvider } from './contexts/DependencyContext';
 import { ExecutionProvider } from './contexts/ExecutionContext';
 import { GlobalProvider } from './contexts/GlobalNodeState';
@@ -30,17 +31,18 @@ import { useLastWindowSize } from './hooks/useLastWindowSize';
 
 interface NodesInfo {
     schemata: SchemaMap;
+    categories: string[];
     functionDefinitions: Map<SchemaId, FunctionDefinition>;
 }
 
-const processBackendResponse = (response: BackendNodesResponse): NodesInfo => {
-    const schemata = new SchemaMap(response);
+const processBackendResponse = ({ nodes, categories }: BackendNodesResponse): NodesInfo => {
+    const schemata = new SchemaMap(nodes);
 
     const functionDefinitions = new Map<SchemaId, FunctionDefinition>();
 
     const errors: string[] = [];
 
-    for (const schema of response) {
+    for (const schema of nodes) {
         try {
             functionDefinitions.set(
                 schema.schemaId,
@@ -55,7 +57,7 @@ const processBackendResponse = (response: BackendNodesResponse): NodesInfo => {
         throw new Error(errors.join('\n\n'));
     }
 
-    return { schemata, functionDefinitions };
+    return { schemata, categories, functionDefinitions };
 };
 
 const nodeTypes: NodeTypes = {
@@ -167,41 +169,44 @@ export const Main = memo(({ port }: MainProps) => {
 
     return (
         <ReactFlowProvider>
-            <SettingsProvider port={port}>
-                <GlobalProvider
+            <SettingsProvider>
+                <BackendProvider
+                    categories={nodesInfo.categories}
                     functionDefinitions={nodesInfo.functionDefinitions}
-                    reactFlowWrapper={reactFlowWrapper}
+                    port={port}
                     schemata={nodesInfo.schemata}
                 >
-                    <ExecutionProvider>
-                        <DependencyProvider>
-                            <HistoryProvider>
-                                <VStack
-                                    bg={bgColor}
-                                    h="100vh"
-                                    overflow="hidden"
-                                    p={2}
-                                    w="100vw"
-                                >
-                                    <Header />
-                                    <HStack
-                                        h="calc(100vh - 80px)"
-                                        minH="360px"
-                                        minW="720px"
-                                        w="full"
+                    <GlobalProvider reactFlowWrapper={reactFlowWrapper}>
+                        <ExecutionProvider>
+                            <DependencyProvider>
+                                <HistoryProvider>
+                                    <VStack
+                                        bg={bgColor}
+                                        h="100vh"
+                                        overflow="hidden"
+                                        p={2}
+                                        w="100vw"
                                     >
-                                        <NodeSelector schemata={nodesInfo.schemata} />
-                                        <ReactFlowBox
-                                            edgeTypes={edgeTypes}
-                                            nodeTypes={nodeTypes}
-                                            wrapperRef={reactFlowWrapper}
-                                        />
-                                    </HStack>
-                                </VStack>
-                            </HistoryProvider>
-                        </DependencyProvider>
-                    </ExecutionProvider>
-                </GlobalProvider>
+                                        <Header />
+                                        <HStack
+                                            h="calc(100vh - 80px)"
+                                            minH="360px"
+                                            minW="720px"
+                                            w="full"
+                                        >
+                                            <NodeSelector />
+                                            <ReactFlowBox
+                                                edgeTypes={edgeTypes}
+                                                nodeTypes={nodeTypes}
+                                                wrapperRef={reactFlowWrapper}
+                                            />
+                                        </HStack>
+                                    </VStack>
+                                </HistoryProvider>
+                            </DependencyProvider>
+                        </ExecutionProvider>
+                    </GlobalProvider>
+                </BackendProvider>
             </SettingsProvider>
         </ReactFlowProvider>
     );


### PR DESCRIPTION
I never liked how the immutable data of the backend is split between contexts. For some reason, Settings has the port and GlobalNodeState has the schemata.

In preparation of [this](https://discord.com/channels/930865462852591648/957801090248736818/1006124120985042954), I also made it so that the backend now returns a list of all categories. This is what prompted the context refactoring. I didn't want to just throw the category list into Settings or GlobalNodeState.