### PR TITLE
Improved dependency manager UI

### DIFF
--- a/src/common/pip.ts
+++ b/src/common/pip.ts
@@ -56,7 +56,7 @@ export const runPip = async (args: readonly string[], onStdio: OnStdio = {}): Pr
     });
 };
 
-export type PipList = { [packageName: string]: string };
+export type PipList = { [packageName: string]: string | undefined };
 
 export const runPipList = async (onStdio?: OnStdio): Promise<PipList> => {
     const output = await runPip(['list', '--format=json'], onStdio);


### PR DESCRIPTION

Changes:
- Pip listed version are not explicitly optional, so I had to rewrite some code. Fixed #708
- The Update button is now only visible when there are packages to update. I also fixed the faulty update condition. Previously, the update button was only enabled when all packages were outdated. Now it's displayed when some packages are outdated.

![image](https://user-images.githubusercontent.com/20878432/183444016-b5dee3c8-a376-44fc-ad0e-51c5094fd119.png)


