### PR TITLE
use grab cursor for representative nodes

### DIFF
--- a/src/renderer/components/NodeSelectorPanel/RepresentativeNode.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RepresentativeNode.tsx
@@ -46,12 +46,13 @@ export const RepresentativeNode = memo(
             <Center
                 _active={{ outlineColor: accentColor }}
                 _focus={{ outlineColor: accentColor }}
-                _hover={{ outlineColor: accentColor }}
+                _hover={{ outlineColor: accentColor, cursor: 'grab' }}
                 bgGradient={bgGradient}
                 borderColor={bgColor}
                 borderRadius="lg"
                 borderWidth="0px"
                 boxShadow="lg"
+                className="representative-node"
                 outline="1px solid"
                 outlineColor={bgColor}
                 overflow="hidden"
@@ -67,8 +68,10 @@ export const RepresentativeNode = memo(
                 onMouseLeave={() => setHover(false)}
             >
                 <Box
+                    _hover={{ cursor: 'grab' }}
                     bg={bgColor}
                     borderRadius="8px 0 0 8px"
+                    className="representative-node"
                     h="auto"
                     ml="5px"
                     overflow="hidden"
@@ -77,14 +80,18 @@ export const RepresentativeNode = memo(
                     w="full"
                 >
                     <HStack
+                        _hover={{ cursor: 'grab' }}
+                        className="representative-node"
                         overflow="hidden"
                         pl={2}
                         textOverflow="ellipsis"
                         verticalAlign="middle"
                     >
                         <Center
+                            _hover={{ cursor: 'grab' }}
                             alignContent="center"
                             alignItems="center"
+                            className="representative-node"
                             h={4}
                             py={3}
                             verticalAlign="middle"
@@ -97,17 +104,23 @@ export const RepresentativeNode = memo(
                         </Center>
                         {!collapsed && (
                             <Flex
+                                _hover={{ cursor: 'grab' }}
+                                className="representative-node"
                                 overflow="hidden"
                                 w="300px"
                             >
                                 <Box
+                                    _hover={{ cursor: 'grab' }}
+                                    className="representative-node"
                                     overflow="hidden"
                                     textOverflow="ellipsis"
                                     verticalAlign="middle"
                                 >
                                     <Heading
+                                        _hover={{ cursor: 'grab' }}
                                         alignContent="center"
                                         as="h5"
+                                        className="representative-node"
                                         fontWeight={700}
                                         h="20px"
                                         lineHeight="20px"
@@ -124,7 +137,10 @@ export const RepresentativeNode = memo(
                                         {name.toUpperCase()}
                                     </Heading>
                                 </Box>
-                                <Spacer />
+                                <Spacer
+                                    _hover={{ cursor: 'grab' }}
+                                    className="representative-node"
+                                />
                                 <HStack
                                     overflow="hidden"
                                     px={2}

--- a/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
+++ b/src/renderer/components/NodeSelectorPanel/RepresentativeNodeWrapper.tsx
@@ -102,7 +102,7 @@ export const RepresentativeNodeWrapper = memo(
                     py={1}
                     onClose={onClose}
                 >
-                    <Box>
+                    <Box _hover={{ cursor: 'grab' }}>
                         <Tooltip
                             closeOnMouseDown
                             hasArrow
@@ -119,7 +119,9 @@ export const RepresentativeNodeWrapper = memo(
                         >
                             <Center
                                 draggable
+                                _hover={{ cursor: 'grab' }}
                                 boxSizing="content-box"
+                                className="representative-node"
                                 display="block"
                                 onClick={() => {
                                     setDidSingleClick(true);

--- a/src/renderer/global.css
+++ b/src/renderer/global.css
@@ -2,9 +2,9 @@
 :not(.chakra-slider__track):not(.chakra-menu__menu-button):not(.react-flow__handle)
 :not(.chakra-slider__track):not(.chakra-menu__menu-button):not(.react-flow__handle) */
 
-:not(input):not(textarea):not(button):not(svg):not(path):not(g):not(span),
-:not(input):not(textarea):not(button):not(svg):not(path):not(g):not(span)::after,
-:not(input):not(textarea):not(button):not(svg):not(path):not(g):not(span)::before {
+:not(input):not(textarea):not(button):not(svg):not(path):not(g):not(span):not(.representative-node),
+:not(input):not(textarea):not(button):not(svg):not(path):not(g):not(span):not(.representative-node)::after,
+:not(input):not(textarea):not(button):not(svg):not(path):not(g):not(span):not(.representative-node)::before {
     -webkit-user-select: none;
     user-select: none;
     cursor: default;


### PR DESCRIPTION
Yes, I know this is excessive. But, it was the only way to override the global cursor CSS for every part of the component