### PR TITLE
Added explicit type annotations for many class fields

### DIFF
--- a/backend/src/nodes/categories.py
+++ b/backend/src/nodes/categories.py
@@ -10,11 +10,11 @@ class Category:
         color: str,
         install_hint: Union[str, None] = None,
     ):
-        self.name = name
-        self.description = description
-        self.icon = icon
-        self.color = color
-        self.install_hint = install_hint
+        self.name: str = name
+        self.description: str = description
+        self.icon: str = icon
+        self.color: str = color
+        self.install_hint: Union[str, None] = install_hint
 
     def toDict(self):
         return {

--- a/backend/src/nodes/node_base.py
+++ b/backend/src/nodes/node_base.py
@@ -19,18 +19,18 @@ class NodeBase(metaclass=ABCMeta):
     def __init__(self):
         self.inputs: List[BaseInput] = []
         self.outputs: List[BaseOutput] = []
-        self.description = ""
+        self.description: str = ""
 
-        self.category = Category(
+        self.category: Category = Category(
             "Unknown", "Unknown category", "BsQuestionDiamond", "#718096"
         )
-        self.name = ""
-        self.icon = ""
-        self.sub = "Miscellaneous"
-        self.type = "regularNode"
+        self.name: str = ""
+        self.icon: str = ""
+        self.sub: str = "Miscellaneous"
+        self.type: str = "regularNode"
 
-        self.side_effects = False
-        self.deprecated = False
+        self.side_effects: bool = False
+        self.deprecated: bool = False
 
     @abstractmethod
     def run(self) -> Any:

--- a/backend/src/nodes/properties/inputs/base_input.py
+++ b/backend/src/nodes/properties/inputs/base_input.py
@@ -1,15 +1,15 @@
 from typing import Union, Literal
 from .. import expression
 
-InputKind = Union[
-    Literal["number"],
-    Literal["slider"],
-    Literal["dropdown"],
-    Literal["text"],
-    Literal["text-line"],
-    Literal["directory"],
-    Literal["file"],
-    Literal["generic"],
+InputKind = Literal[
+    "number",
+    "slider",
+    "dropdown",
+    "text",
+    "text-line",
+    "directory",
+    "file",
+    "generic",
 ]
 
 
@@ -21,12 +21,12 @@ class BaseInput:
         kind: InputKind = "generic",
         has_handle=True,
     ):
-        self.input_type = input_type
+        self.input_type: expression.ExpressionJson = input_type
         self.input_conversion: Union[expression.ExpressionJson, None] = None
-        self.kind = kind
-        self.label = label
+        self.kind: InputKind = kind
+        self.label: str = label
         self.optional: bool = False
-        self.has_handle = has_handle
+        self.has_handle: bool = has_handle
         self.id: Union[int, None] = None
 
     # This is the method that should be created by each input

--- a/backend/src/nodes/properties/outputs/base_output.py
+++ b/backend/src/nodes/properties/outputs/base_output.py
@@ -1,5 +1,7 @@
-from typing import Union
+from typing import Union, Literal
 from .. import expression
+
+OutputKind = Literal["image", "large-image", "text", "directory", "pytorch", "generic"]
 
 
 class BaseOutput:
@@ -7,15 +9,15 @@ class BaseOutput:
         self,
         output_type: expression.ExpressionJson,
         label: str,
-        kind: str = "generic",
+        kind: OutputKind = "generic",
         has_handle: bool = True,
     ):
-        self.output_type = output_type
-        self.label = label
+        self.output_type: expression.ExpressionJson = output_type
+        self.label: str = label
         self.id = None
         self.never_reason: Union[str, None] = None
-        self.kind = kind
-        self.has_handle = has_handle
+        self.kind: OutputKind = kind
+        self.has_handle: bool = has_handle
 
     def toDict(self):
         return {

--- a/backend/src/nodes/properties/outputs/file_outputs.py
+++ b/backend/src/nodes/properties/outputs/file_outputs.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from .base_output import BaseOutput
+from .base_output import BaseOutput, OutputKind
 from .. import expression
 
 
@@ -7,7 +7,10 @@ class FileOutput(BaseOutput):
     """Output for saving a local file"""
 
     def __init__(
-        self, file_type: expression.ExpressionJson, label: str, kind: str = "generic"
+        self,
+        file_type: expression.ExpressionJson,
+        label: str,
+        kind: OutputKind = "generic",
     ):
         super().__init__(file_type, label, kind=kind)
 

--- a/backend/src/nodes/properties/outputs/generic_outputs.py
+++ b/backend/src/nodes/properties/outputs/generic_outputs.py
@@ -1,4 +1,4 @@
-from .base_output import BaseOutput
+from .base_output import BaseOutput, OutputKind
 from .. import expression
 
 
@@ -9,7 +9,10 @@ def NumberOutput(label: str, output_type: expression.ExpressionJson = "number"):
 
 class TextOutput(BaseOutput):
     def __init__(
-        self, label: str, output_type: expression.ExpressionJson = "string", kind="text"
+        self,
+        label: str,
+        output_type: expression.ExpressionJson = "string",
+        kind: OutputKind = "text",
     ):
         super().__init__(expression.intersect("string", output_type), label, kind=kind)
 

--- a/backend/src/nodes/properties/outputs/numpy_outputs.py
+++ b/backend/src/nodes/properties/outputs/numpy_outputs.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from ...utils.image_utils import preview_encode
 from ...utils.utils import get_h_w_c
-from .base_output import BaseOutput
+from .base_output import BaseOutput, OutputKind
 from .. import expression
 
 
@@ -13,7 +13,7 @@ class NumPyOutput(BaseOutput):
         self,
         output_type: expression.ExpressionJson,
         label: str,
-        kind: str = "generic",
+        kind: OutputKind = "generic",
         has_handle: bool = True,
     ):
         super().__init__(output_type, label, kind=kind, has_handle=has_handle)
@@ -29,7 +29,7 @@ class ImageOutput(NumPyOutput):
         self,
         label: str = "Image",
         image_type: expression.ExpressionJson = "Image",
-        kind: str = "image",
+        kind: OutputKind = "image",
         has_handle: bool = True,
         broadcast_type: bool = False,
     ):
@@ -60,7 +60,7 @@ class LargeImageOutput(ImageOutput):
         self,
         label: str = "Image",
         image_type: expression.ExpressionJson = "Image",
-        kind: str = "large-image",
+        kind: OutputKind = "large-image",
         has_handle: bool = True,
     ):
         super().__init__(

--- a/backend/src/nodes/properties/outputs/pytorch_outputs.py
+++ b/backend/src/nodes/properties/outputs/pytorch_outputs.py
@@ -1,5 +1,5 @@
 from .. import expression
-from .base_output import BaseOutput
+from .base_output import BaseOutput, OutputKind
 
 from ...utils.torch_types import PyTorchModel
 
@@ -9,7 +9,7 @@ class ModelOutput(BaseOutput):
         self,
         model_type: expression.ExpressionJson = "PyTorchModel",
         label: str = "Model",
-        kind="generic",
+        kind: OutputKind = "generic",
         should_broadcast=False,
     ):
         super().__init__(model_type, label, kind=kind)

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -28,7 +28,7 @@ class UsableData(TypedDict):
 class NodeExecutionError(Exception):
     def __init__(self, node: UsableData, cause: str):
         super().__init__(cause)
-        self.node = node
+        self.node: UsableData = node
 
 
 class ExecutionContext:
@@ -43,16 +43,16 @@ class ExecutionContext:
         executor: Executor,
         percent: float,
     ):
-        self.nodes = nodes
+        self.nodes: Dict[str, UsableData] = nodes
 
-        self.loop = loop
-        self.queue = queue
-        self.pool = pool
+        self.loop: asyncio.AbstractEventLoop = loop
+        self.queue: EventQueue = queue
+        self.pool: ThreadPoolExecutor = pool
 
-        self.cache = cache
-        self.iterator_id = iterator_id
-        self.executor = executor
-        self.percent = percent
+        self.cache: Dict[str, Any] = cache
+        self.iterator_id: str = iterator_id
+        self.executor: Executor = executor
+        self.percent: float = percent
 
     def create_iterator_executor(self) -> Executor:
         return Executor(
@@ -89,19 +89,18 @@ class Executor:
         existing_cache: Dict[str, Any],
         parent_executor: Optional[Executor] = None,
     ):
-        self.execution_id = uuid.uuid4().hex
-        self.nodes = nodes
-        self.output_cache = existing_cache
+        self.execution_id: str = uuid.uuid4().hex
+        self.nodes: Dict[str, UsableData] = nodes
+        self.output_cache: Dict[str, Any] = existing_cache
         self.__broadcast_tasks: List[asyncio.Task[None]] = []
 
-        self.process_task = None
-        self.killed = False
-        self.paused = False
-        self.resumed = False
+        self.killed: bool = False
+        self.paused: bool = False
+        self.resumed: bool = False
 
-        self.loop = loop
-        self.queue = queue
-        self.pool = pool
+        self.loop: asyncio.AbstractEventLoop = loop
+        self.queue: EventQueue = queue
+        self.pool: ThreadPoolExecutor = pool
 
         self.parent_executor = parent_executor
 


### PR DESCRIPTION
This fixes the problem zamboni had, where a node allowed a str as a category. This is because class fields have the type of all the values written to them, unless they have an explicit type annotation. So any write is allowed. The new explicit type annotation will now ensure correctness.

I also added a `OutputKind` type to mirror `InputKind`. I also noticed that the `Executor.process_task` field was unused and removed it.