### PR TITLE
Fixed opening files causing unsaved changes

### DIFF
--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -58,7 +58,12 @@ import {
 } from '../helpers/reactFlowUtil';
 import { TypeState } from '../helpers/TypeState';
 import { useAsyncEffect } from '../hooks/useAsyncEffect';
-import { ChangeCounter, useChangeCounter, wrapChanges } from '../hooks/useChangeCounter';
+import {
+    ChangeCounter,
+    nextChangeCount,
+    useChangeCounter,
+    wrapChanges,
+} from '../hooks/useChangeCounter';
 import { useInputHashes } from '../hooks/useInputHashes';
 import { useIpcRendererListener } from '../hooks/useIpcRendererListener';
 import { useMemoArray, useMemoObject } from '../hooks/useMemo';
@@ -411,7 +416,10 @@ export const GlobalProvider = memo(
                 }
 
                 outputDataActions.clear();
-                setLastSavedChanges([nodeChangesRef.current + 1, edgeChangesRef.current + 1]);
+                setLastSavedChanges([
+                    nextChangeCount(nodeChangesRef.current),
+                    nextChangeCount(edgeChangesRef.current),
+                ]);
                 changeNodes(validNodes);
                 changeEdges(validEdges);
                 if (loadPosition) {

--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -152,8 +152,8 @@ export const GlobalProvider = memo(
         const { schemata, functionDefinitions } = useContext(BackendContext);
         const { useStartupTemplate } = useContext(SettingsContext);
 
-        const [nodeChanges, addNodeChanges] = useChangeCounter();
-        const [edgeChanges, addEdgeChanges] = useChangeCounter();
+        const [nodeChanges, addNodeChanges, nodeChangesRef] = useChangeCounter();
+        const [edgeChanges, addEdgeChanges, edgeChangesRef] = useChangeCounter();
         const {
             setViewport,
             getViewport,
@@ -282,7 +282,9 @@ export const GlobalProvider = memo(
 
         const [hoveredNode, setHoveredNode] = useState<string | null | undefined>(null);
 
-        const [hasUnsavedChanges, setHasUnsavedChanges] = useState(true);
+        const [lastSavedChanges, setLastSavedChanges] = useState<
+            readonly [nodeChanges: number, edgeChanges: number]
+        >([0, 0]);
         /**
          * Whether the current chain as *relevant* unsaved changes.
          *
@@ -290,14 +292,13 @@ export const GlobalProvider = memo(
          */
         const [hasRelevantUnsavedChanges, setHasRelevantUnsavedChanges] = useState(false);
         useEffect(() => {
+            const hasUnsavedChanges =
+                lastSavedChanges[0] !== nodeChanges || lastSavedChanges[1] !== edgeChanges;
             const value = hasUnsavedChanges && (getNodes().length > 0 || !!savePath);
             setHasRelevantUnsavedChanges(value);
             ipcRenderer.send('update-has-unsaved-changes', value);
-        }, [hasUnsavedChanges, savePath, nodeChanges]);
+        }, [lastSavedChanges, savePath, nodeChanges, edgeChanges]);
 
-        useEffect(() => {
-            setHasUnsavedChanges(true);
-        }, [nodeChanges, edgeChanges]);
         useEffect(() => {
             const id = setTimeout(() => {
                 const dot = hasRelevantUnsavedChanges ? ' •' : '';
@@ -410,6 +411,7 @@ export const GlobalProvider = memo(
                 }
 
                 outputDataActions.clear();
+                setLastSavedChanges([nodeChangesRef.current + 1, edgeChangesRef.current + 1]);
                 changeNodes(validNodes);
                 changeEdges(validEdges);
                 if (loadPosition) {
@@ -417,7 +419,6 @@ export const GlobalProvider = memo(
                 }
                 setSavePath(path);
                 pushOpenPath(path);
-                setHasUnsavedChanges(false);
             },
             [hasRelevantUnsavedChanges, schemata, changeNodes, changeEdges, outputDataActions]
         );
@@ -485,7 +486,7 @@ export const GlobalProvider = memo(
                             }
                         }
                         if (!isTemplate) {
-                            setHasUnsavedChanges(false);
+                            setLastSavedChanges([nodeChangesRef.current, edgeChangesRef.current]);
                         }
                     } catch (error) {
                         log.error(error);

--- a/src/renderer/hooks/useChangeCounter.ts
+++ b/src/renderer/hooks/useChangeCounter.ts
@@ -1,16 +1,21 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 export type ChangeCounter = number & { __changeCounter: true };
 
 export const useChangeCounter = () => {
     const [counter, setCounter] = useState(0);
+    const counterRef = useRef(0);
 
     const change = useCallback(() => {
         // we have to wrap at some point, so I just arbitrarily chose 1 million
-        setCounter((prev) => (prev + 1) % 1_000_000);
+        setCounter((prev) => {
+            const newValue = (prev + 1) % 1_000_000;
+            counterRef.current = newValue;
+            return newValue;
+        });
     }, [setCounter]);
 
-    return [counter as ChangeCounter, change] as const;
+    return [counter as ChangeCounter, change, counterRef] as const;
 };
 
 export const wrapChanges = <T>(

--- a/src/renderer/hooks/useChangeCounter.ts
+++ b/src/renderer/hooks/useChangeCounter.ts
@@ -2,6 +2,8 @@ import { useCallback, useRef, useState } from 'react';
 
 export type ChangeCounter = number & { __changeCounter: true };
 
+export const nextChangeCount = (count: number): number => (count + 1) % 1_000_000;
+
 export const useChangeCounter = () => {
     const [counter, setCounter] = useState(0);
     const counterRef = useRef(0);
@@ -9,7 +11,7 @@ export const useChangeCounter = () => {
     const change = useCallback(() => {
         // we have to wrap at some point, so I just arbitrarily chose 1 million
         setCounter((prev) => {
-            const newValue = (prev + 1) % 1_000_000;
+            const newValue = nextChangeCount(prev);
             counterRef.current = newValue;
             return newValue;
         });


### PR DESCRIPTION
As it turned out, opening any chain would make chainner think that this chain had unsaved changes. This is because `hasUnsavedChanges` was set to `false` by the nodes and edges being set using `change{Nodes,Edges}` (which is necessary for history to work) which caused an effect that set `hasUnsavedChanges` to `true`.

So my fix is to replace `hasUnsavedChanges` with `lastSavedChanges`. This stores the counter states `{node,edge}Changes` for last time they were saved. This system seems to be more robust.