### PR TITLE
Added "None" option for flip axis

### DIFF
--- a/backend/src/nodes/image_util_nodes.py
+++ b/backend/src/nodes/image_util_nodes.py
@@ -11,7 +11,7 @@ from .node_base import NodeBase
 from .node_factory import NodeFactory
 from .properties.inputs import *
 from .properties.outputs import *
-from .utils.image_utils import blend_images, calculate_ssim, shift
+from .utils.image_utils import blend_images, calculate_ssim, shift, FlipAxis
 from .utils.pil_utils import *
 from .utils.utils import get_h_w_c
 
@@ -505,6 +505,8 @@ class FlipNode(NodeBase):
         self.sub = "Modification"
 
     def run(self, img: np.ndarray, axis: int) -> np.ndarray:
+        if axis == FlipAxis.NONE:
+            return img
         return cv2.flip(img, axis)
 
 

--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -4,7 +4,7 @@ from .. import expression
 
 from .base_input import BaseInput
 from ...utils.blend_modes import BlendModes as bm
-from ...utils.image_utils import FillColor
+from ...utils.image_utils import FillColor, FlipAxis
 
 
 class DropDownInput(BaseInput):
@@ -196,9 +196,10 @@ def FlipAxisInput() -> DropDownInput:
         input_type="FlipAxis",
         label="Flip Axis",
         options=[
-            {"option": "Horizontal", "value": 1},
-            {"option": "Vertical", "value": 0},
-            {"option": "Both", "value": -1},
+            {"option": "Horizontal", "value": FlipAxis.HORIZONTAL},
+            {"option": "Vertical", "value": FlipAxis.VERTICAL},
+            {"option": "Both", "value": FlipAxis.BOTH},
+            {"option": "None", "value": FlipAxis.NONE},
         ],
     )
 

--- a/backend/src/nodes/utils/image_utils.py
+++ b/backend/src/nodes/utils/image_utils.py
@@ -15,6 +15,13 @@ class FillColor:
     TRANSPARENT = 1
 
 
+class FlipAxis:
+    HORIZONTAL = 1
+    VERTICAL = 0
+    BOTH = -1
+    NONE = 2
+
+
 def get_opencv_formats():
     available_formats = [
         # Bitmaps


### PR DESCRIPTION
As suggested [here](https://discord.com/channels/930865462852591648/930865780663398451/1008421491592933406).

This PR adds a noop option to the Flip node.

While this option can mitigate the current lack of passthrough, I think it's still useful on its own. If we want to move towards a librarification direction (user-defined nodes via chains), then these noop options will come in handy.

![image](https://user-images.githubusercontent.com/20878432/184548039-f82f98be-edc7-4a87-90ee-54fc751240f6.png)
