### PR TITLE
Show node inputs in error messages

### DIFF
--- a/backend/src/events.py
+++ b/backend/src/events.py
@@ -14,9 +14,19 @@ class FinishData(TypedDict):
     message: str
 
 
+class ImageInputInfo(TypedDict):
+    width: int
+    height: int
+    channels: int
+
+
+InputsDict = Dict[int, Union[str, int, float, ImageInputInfo, None]]
+
+
 class ExecutionErrorSource(TypedDict):
     nodeId: str
     schemaId: str
+    inputs: InputsDict
 
 
 class ExecutionErrorData(TypedDict):

--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -221,6 +221,7 @@ async def run(request: Request):
             error["source"] = {
                 "nodeId": exception.node["id"],
                 "schemaId": exception.node["schemaId"],
+                "inputs": exception.inputs,
             }
 
         await ctx.queue.put({"event": "execution-error", "data": error})

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -1,5 +1,5 @@
 import fetch from 'cross-fetch';
-import { Category, InputValue, NodeSchema, SchemaId, UsableData } from './common-types';
+import { Category, InputId, InputValue, NodeSchema, SchemaId, UsableData } from './common-types';
 
 export interface BackendSuccessResponse {
     message: string;
@@ -8,6 +8,12 @@ export interface BackendSuccessResponse {
 export interface BackendExceptionSource {
     nodeId: string;
     schemaId: SchemaId;
+    inputs: Partial<
+        Record<
+            InputId,
+            { width: number; height: number; channels: number } | string | number | null
+        >
+    >;
 }
 export interface BackendExceptionResponse {
     message: string;


### PR DESCRIPTION
When possible, the executor will now collect the inputs of a node to transmit the information to the frontend. This will hopefully make it easier to understand and fix errors, even the error message is bad.

![image](https://user-images.githubusercontent.com/20878432/184636650-566e0b18-ddfa-45dd-9957-9eee2cca7ed7.png)
![image](https://user-images.githubusercontent.com/20878432/184636657-ae3797c1-bdb9-4ede-827d-8f49ffcc951c.png)
