### PR TITLE
Added dir output to Load Model nodes

### DIFF
--- a/backend/src/nodes/ncnn_nodes.py
+++ b/backend/src/nodes/ncnn_nodes.py
@@ -115,7 +115,11 @@ class NcnnSaveNode(NodeBase):
     def __init__(self):
         super().__init__()
         self.description = "Save an NCNN model to specified directory."
-        self.inputs = [NcnnNetInput(), DirectoryInput(), TextInput("Param/Bin Name")]
+        self.inputs = [
+            NcnnNetInput(),
+            DirectoryInput(has_handle=True),
+            TextInput("Param/Bin Name"),
+        ]
         self.outputs = []
 
         self.category = NCNNCategory

--- a/backend/src/nodes/onnx_nodes.py
+++ b/backend/src/nodes/onnx_nodes.py
@@ -31,7 +31,11 @@ class OnnxLoadModelNode(NodeBase):
             """Load ONNX model file (.onnx). Theoretically supports any ONNX model."""
         )
         self.inputs = [OnnxFileInput()]
-        self.outputs = [OnnxModelOutput(), TextOutput("Model Name")]
+        self.outputs = [
+            OnnxModelOutput(),
+            DirectoryOutput().with_id(2),
+            TextOutput("Model Name").with_id(1),
+        ]
 
         self.category = ONNXCategory
         self.name = "Load Model"
@@ -40,7 +44,7 @@ class OnnxLoadModelNode(NodeBase):
 
         self.model = None  # Defined in run
 
-    def run(self, path: str) -> Tuple[bytes, str]:
+    def run(self, path: str) -> Tuple[bytes, str, str]:
         """Read a pth file from the specified path and return it as a state dict
         and loaded model after finding arch config"""
 
@@ -53,9 +57,8 @@ class OnnxLoadModelNode(NodeBase):
 
         model_as_string = model.SerializeToString()  # type: ignore
 
-        basename = os.path.splitext(os.path.basename(path))[0]
-
-        return model_as_string, basename
+        dirname, basename = os.path.split(os.path.splitext(path)[0])
+        return model_as_string, dirname, basename
 
 
 @NodeFactory.register("chainner:onnx:save_model")
@@ -65,7 +68,11 @@ class OnnxSaveModelNode(NodeBase):
     def __init__(self):
         super().__init__()
         self.description = """Save ONNX model to file (.onnx)."""
-        self.inputs = [OnnxModelInput(), DirectoryInput(), TextInput("Model Name")]
+        self.inputs = [
+            OnnxModelInput(),
+            DirectoryInput(has_handle=True),
+            TextInput("Model Name"),
+        ]
         self.outputs = []
         self.category = ONNXCategory
         self.name = "Save Model"

--- a/backend/src/nodes/pytorch_nodes.py
+++ b/backend/src/nodes/pytorch_nodes.py
@@ -74,7 +74,8 @@ class LoadModelNode(NodeBase):
         self.inputs = [PthFileInput()]
         self.outputs = [
             ModelOutput(kind="pytorch", should_broadcast=True),
-            TextOutput("Model Name"),
+            DirectoryOutput().with_id(2),
+            TextOutput("Model Name").with_id(1),
         ]
 
         self.category = PyTorchCategory
@@ -82,7 +83,7 @@ class LoadModelNode(NodeBase):
         self.icon = "PyTorch"
         self.sub = "Input & Output"
 
-    def run(self, path: str) -> Tuple[PyTorchModel, str]:
+    def run(self, path: str) -> Tuple[PyTorchModel, str, str]:
         """Read a pth file from the specified path and return it as a state dict
         and loaded model after finding arch config"""
 
@@ -109,9 +110,8 @@ class LoadModelNode(NodeBase):
             # pylint: disable=raise-missing-from
             raise ValueError("Model unsupported by chaiNNer. Please try another.")
 
-        basename = os.path.splitext(os.path.basename(path))[0]
-
-        return model, basename
+        dirname, basename = os.path.split(os.path.splitext(path)[0])
+        return model, dirname, basename
 
 
 @NodeFactory.register("chainner:pytorch:upscale_image")
@@ -301,7 +301,11 @@ class PthSaveNode(NodeBase):
     def __init__(self):
         super().__init__()
         self.description = "Save a PyTorch model to specified directory."
-        self.inputs = [ModelInput(), DirectoryInput(), TextInput("Model Name")]
+        self.inputs = [
+            ModelInput(),
+            DirectoryInput(has_handle=True),
+            TextInput("Model Name"),
+        ]
         self.outputs = []
 
         self.category = PyTorchCategory


### PR DESCRIPTION
Fixes #740.

Changes:
- Added a directory output to Load Model for PyTorch and ONNX. 
- The directory input in the Save Model nodes for PyTorch, ONNX, and NCNN now have handles.

![image](https://user-images.githubusercontent.com/20878432/184930530-6a49ae48-3773-4ca6-9c11-dae412c5d379.png)

I didn't add a directory output for NCNN's Load Model because the output isn't clearly defined. NCNN has 2 file inputs, so which should it use to get the directory? There's no reason to choose one over the other.