### PR TITLE
Added download size estimates for packages

### DIFF
--- a/src/common/dependencies.ts
+++ b/src/common/dependencies.ts
@@ -1,9 +1,17 @@
 import { isMac } from './env';
 
+const KB = 1024 ** 1;
+const MB = 1024 ** 2;
+const GB = 1024 ** 3;
+
 export interface PyPiPackage {
     packageName: string;
     version: string;
     findLink?: string;
+    /**
+     * A size estimate (in bytes) for the whl file to download.
+     */
+    sizeEstimate: number;
 }
 export interface Dependency {
     name: string;
@@ -20,12 +28,13 @@ export const getOptionalDependencies = (isNvidiaAvailable: boolean): Dependency[
                 findLink: `https://download.pytorch.org/whl/${
                     isNvidiaAvailable && !isMac ? 'cu113' : 'cpu'
                 }/torch_stable.html`,
+                sizeEstimate: isNvidiaAvailable && !isMac ? 2 * GB : 140 * MB,
             },
         ],
     },
     {
         name: 'NCNN',
-        packages: [{ packageName: 'ncnn-vulkan', version: '2022.8.12' }],
+        packages: [{ packageName: 'ncnn-vulkan', version: '2022.8.12', sizeEstimate: 4 * MB }],
     },
     {
         name: 'ONNX',
@@ -33,14 +42,17 @@ export const getOptionalDependencies = (isNvidiaAvailable: boolean): Dependency[
             {
                 packageName: 'onnx',
                 version: '1.11.0',
+                sizeEstimate: 12 * MB,
             },
             {
                 packageName: isNvidiaAvailable ? 'onnxruntime-gpu' : 'onnxruntime',
+                sizeEstimate: isNvidiaAvailable ? 110 * MB : 5 * MB,
                 version: '1.11.1',
             },
             {
                 packageName: 'protobuf',
                 version: '3.16.0',
+                sizeEstimate: 500 * KB,
             },
         ],
     },
@@ -49,22 +61,22 @@ export const getOptionalDependencies = (isNvidiaAvailable: boolean): Dependency[
 export const requiredDependencies: Dependency[] = [
     {
         name: 'Sanic',
-        packages: [{ packageName: 'sanic', version: '21.9.3' }],
+        packages: [{ packageName: 'sanic', version: '21.9.3', sizeEstimate: 270 * KB }],
     },
     {
         name: 'Sanic Cors',
-        packages: [{ packageName: 'Sanic-Cors', version: '1.0.1' }],
+        packages: [{ packageName: 'Sanic-Cors', version: '1.0.1', sizeEstimate: 17 * KB }],
     },
     {
         name: 'OpenCV',
-        packages: [{ packageName: 'opencv-python', version: '4.5.5.64' }],
+        packages: [{ packageName: 'opencv-python', version: '4.5.5.64', sizeEstimate: 30 * MB }],
     },
     {
         name: 'NumPy',
-        packages: [{ packageName: 'numpy', version: '1.22.3' }],
+        packages: [{ packageName: 'numpy', version: '1.22.3', sizeEstimate: 15 * MB }],
     },
     {
         name: 'Pillow (PIL)',
-        packages: [{ packageName: 'Pillow', version: '9.1.0' }],
+        packages: [{ packageName: 'Pillow', version: '9.1.0', sizeEstimate: 3 * MB }],
     },
 ];


### PR DESCRIPTION
Fixes #738.

![image](https://user-images.githubusercontent.com/20878432/184964793-90584cde-847e-49b5-9078-644f3984f1f9.png)

I added download sizes for all packages simple because I thought that we might use it in the future. I might be useful to tell the user how much data we are/are going to download for required deps on first install. But that's for another time.