### PR TITLE
Fix PYTHONHOME variable deletion causing crash

### DIFF
--- a/src/common/env.ts
+++ b/src/common/env.ts
@@ -6,5 +6,7 @@ export const isM1 = isMac && (os.cpus()[0]?.model.includes('Apple M1') ?? false)
 export const isRenderer = typeof process !== 'undefined' && process.type === 'renderer';
 
 const env = { ...process.env };
-delete env.PYTHONHOME;
+if (env.PYTHONHOME) {
+    delete env.PYTHONHOME;
+}
 export const sanitizedEnv = env;


### PR DESCRIPTION
For sure fixes #752 and fixes #749. Might fix the others as well, but I'm not entirely sure.