### PR TITLE
Put quotes around exec paths

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -213,7 +213,7 @@ const getValidPort = async (splashWindow: BrowserWindowWithSafeIpc) => {
 };
 
 const getPythonVersion = async (pythonBin: string) => {
-    const { stdout } = await exec(`${pythonBin} --version`);
+    const { stdout } = await exec(`"${pythonBin}" --version`);
     log.info(`Python version (raw): ${stdout}`);
 
     const { version } = semver.coerce(stdout)!;

--- a/src/main/nvidiaSmi.ts
+++ b/src/main/nvidiaSmi.ts
@@ -88,7 +88,7 @@ export const getNvidiaSmi = lazy(async (): Promise<string | undefined> => {
 export const getNvidiaGpuName = async (nvidiaSmi: string): Promise<string> => {
     const [nvidiaGpu] = (
         await exec(
-            `${nvidiaSmi} --query-gpu=name --format=csv,noheader,nounits ${
+            `"${nvidiaSmi}" --query-gpu=name --format=csv,noheader,nounits ${
                 process.platform === 'linux' ? '  2>/dev/null' : ''
             }`
         )


### PR DESCRIPTION
Fixes the issue on macOS where the python version was not getting populated