### PR TITLE
Fixed input hashes not accounting for node type

### DIFF
--- a/src/renderer/hooks/useInputHashes.ts
+++ b/src/renderer/hooks/useInputHashes.ts
@@ -30,7 +30,7 @@ const computeInputHashes = (
         if (hash) return hash;
 
         const schema = schemata.get(node.data.schemaId);
-        const inputs: string[] = [];
+        const inputs: string[] = [node.data.schemaId];
         for (const { id: inputId } of schema.inputs) {
             const connectedEdge = byTargetHandle.get(stringifyTargetHandle(node.id, inputId));
             if (connectedEdge) {
@@ -52,15 +52,7 @@ const computeInputHashes = (
             }
         }
 
-        if (inputs.length === 0) {
-            hash = EMPTY;
-        } else if (inputs.length === 1) {
-            // eslint-disable-next-line prefer-destructuring
-            hash = inputs[0];
-        } else {
-            hash = deriveUniqueId(inputs.join(';'));
-        }
-
+        hash = deriveUniqueId(inputs.join(';'));
         hashes.set(node.id, hash);
         return hash;
     };


### PR DESCRIPTION
This fixes a little bug with input hashes. Basically, input hashes only considered the inputs of a node, but not the node itself. So as long as 2 nodes have the same inputs, they have the same input hash, even if they are different types of nodes.

The fix is simply to add the schema ID of the node as an input.