### PR TITLE
Fixed open from CLI not working

### DIFF
--- a/src/renderer/components/ReactFlowBox.tsx
+++ b/src/renderer/components/ReactFlowBox.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import { Box, useColorModeValue } from '@chakra-ui/react';
 import log from 'electron-log';
-import { DragEvent, memo, useCallback, useEffect, useMemo } from 'react';
+import { DragEvent, memo, useCallback, useMemo } from 'react';
 import ReactFlow, {
     Background,
     BackgroundVariant,
@@ -163,8 +163,8 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
         addEdgeChanges,
         changeNodes,
         changeEdges,
-        setSetNodes,
-        setSetEdges,
+        setNodesRef,
+        setEdgesRef,
         updateIteratorBounds,
     } = useContext(GlobalContext);
     const { schemata } = useContext(BackendContext);
@@ -177,6 +177,8 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
 
     const [nodes, setNodes, internalOnNodesChange] = useNodesState<NodeData>([]);
     const [edges, setEdges, internalOnEdgesChange] = useEdgesState<EdgeData>([]);
+    setNodesRef.current = setNodes;
+    setEdgesRef.current = setEdges;
 
     const onNodesChange: OnNodesChange = useCallback(
         (changes) => {
@@ -192,11 +194,6 @@ export const ReactFlowBox = memo(({ wrapperRef, nodeTypes, edgeTypes }: ReactFlo
         },
         [internalOnEdgesChange]
     );
-
-    useEffect(() => {
-        setSetNodes(() => setNodes);
-        setSetEdges(() => setEdges);
-    }, [setNodes, setEdges]);
 
     const [displayNodes, displayEdges] = useMemo(() => {
         const displayNodes = nodes.map<Node<NodeData>>((n) => ({ ...n })).sort(compareById);

--- a/src/renderer/hooks/useChangeCounter.ts
+++ b/src/renderer/hooks/useChangeCounter.ts
@@ -29,3 +29,12 @@ export const wrapChanges = <T>(
         addChange();
     };
 };
+export const wrapRefChanges = <T>(
+    setter: Readonly<React.MutableRefObject<React.Dispatch<React.SetStateAction<T>>>>,
+    addChange: () => void
+): React.Dispatch<React.SetStateAction<T>> => {
+    return (value) => {
+        setter.current(value);
+        addChange();
+    };
+};


### PR DESCRIPTION
This fixes [this bug reported to us on discord](https://discord.com/channels/930865462852591648/930865725135011851/1010851705484746782).

The problem was that the effect depended on `setStateFromJSON` which changed quite a lot. So every time it changed, it would (1) cause changes and (2) try to load the `get-cli-open` chain again. I fixed this by simply using a ref for `setStateFromJSON`. 

However, there was another problem. `setNodes` and `setEdges` get set by an effect in ReactFlowBox. So if the CLI chain loaded quickly enough, it would be set before the `set{Nodes,Edges}` functions arrived. Race condition. I fixed this by using a ref to set the `set{Nodes,Edges}` functions. This not only fixed this bug, but it should also save a re-render.