### PR TITLE
Safe window load

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -581,7 +581,11 @@ const doSplashScreenChecks = async () =>
             splash.webContents.send('finish-loading');
             splash.on('close', () => {});
             await sleep(500);
-            splash.destroy();
+            try {
+                splash.destroy();
+            } catch (error) {
+                log.error(error);
+            }
             mainWindow.show();
             if (lastWindowSize?.maximized) {
                 mainWindow.maximize();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -536,7 +536,11 @@ const doSplashScreenChecks = async () =>
         });
 
         splash.on('close', () => {
-            mainWindow.destroy();
+            try {
+                mainWindow.destroy();
+            } catch (error) {
+                log.error(error);
+            }
         });
 
         // Look, I just wanna see the cool animation

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -630,7 +630,7 @@ const createWindow = lazy(async () => {
     }
 
     // Open the DevTools.
-    if (!app.isPackaged) {
+    if (!app.isPackaged && !mainWindow.isDestroyed()) {
         mainWindow.webContents.openDevTools();
     }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -543,6 +543,7 @@ const doSplashScreenChecks = async () =>
 
         splash.on('close', () => {
             mainWindow.destroy();
+            resolve();
         });
 
         // Look, I just wanna see the cool animation

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -528,7 +528,13 @@ const doSplashScreenChecks = async () =>
             // icon: `${__dirname}/public/icons/cross_platform/icon`,
             show: false,
         }) as BrowserWindowWithSafeIpc;
-        splash.loadURL(SPLASH_SCREEN_WEBPACK_ENTRY);
+        if (!splash.isDestroyed()) {
+            try {
+                splash.loadURL(SPLASH_SCREEN_WEBPACK_ENTRY);
+            } catch (error) {
+                log.error('Error loading splash window.', error);
+            }
+        }
 
         splash.once('ready-to-show', () => {
             splash.show();
@@ -536,13 +542,7 @@ const doSplashScreenChecks = async () =>
         });
 
         splash.on('close', () => {
-            try {
-                if (!mainWindow.isDestroyed()) {
-                    mainWindow.destroy();
-                }
-            } catch (error) {
-                log.error(error);
-            }
+            mainWindow.destroy();
         });
 
         // Look, I just wanna see the cool animation
@@ -583,13 +583,7 @@ const doSplashScreenChecks = async () =>
             splash.webContents.send('finish-loading');
             splash.on('close', () => {});
             await sleep(500);
-            try {
-                if (!splash.isDestroyed()) {
-                    splash.destroy();
-                }
-            } catch (error) {
-                log.error(error);
-            }
+            splash.destroy();
             mainWindow.show();
             if (lastWindowSize?.maximized) {
                 mainWindow.maximize();
@@ -626,7 +620,13 @@ const createWindow = lazy(async () => {
     await doSplashScreenChecks();
 
     // and load the index.html of the app.
-    await mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
+    if (!mainWindow.isDestroyed()) {
+        try {
+            await mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
+        } catch (error) {
+            log.error('Error loading main window.', error);
+        }
+    }
 
     // Open the DevTools.
     if (!app.isPackaged) {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -537,7 +537,9 @@ const doSplashScreenChecks = async () =>
 
         splash.on('close', () => {
             try {
-                mainWindow.destroy();
+                if (!mainWindow.isDestroyed()) {
+                    mainWindow.destroy();
+                }
             } catch (error) {
                 log.error(error);
             }
@@ -582,7 +584,9 @@ const doSplashScreenChecks = async () =>
             splash.on('close', () => {});
             await sleep(500);
             try {
-                splash.destroy();
+                if (!splash.isDestroyed()) {
+                    splash.destroy();
+                }
             } catch (error) {
                 log.error(error);
             }


### PR DESCRIPTION
This is an attempt to fix #800 and #813. Replacing the splash screen will take some time, so for now let's wrap the destroy calls with a try/catch as well as an if statement to check if the windows have been destroyed already. Theoretically, it will fix the issues if the problem really is that it is running the splash 'onclose' handler after the window has been destroyed