### PR TITLE
Interp noop

### DIFF
--- a/backend/src/nodes/ncnn_nodes.py
+++ b/backend/src/nodes/ncnn_nodes.py
@@ -199,10 +199,15 @@ class NcnnInterpolateModelsNode(NodeBase):
         return mean_color > 0.5
 
     def run(
-        self, a: NcnnModel, b: NcnnModel, amount: int
+        self, model_a: NcnnModel, model_b: NcnnModel, amount: int
     ) -> Tuple[NcnnModel, int, int]:
+        if amount == 0:
+            return model_a, 100, 0
+        elif amount == 100:
+            return model_b, 0, 100
+
         f_amount = 1 - amount / 100
-        interp_model = a.interpolate(b, f_amount)
+        interp_model = model_a.interpolate(model_b, f_amount)
 
         if not self.check_will_upscale(interp_model):
             raise ValueError(

--- a/backend/src/nodes/onnx_nodes.py
+++ b/backend/src/nodes/onnx_nodes.py
@@ -121,7 +121,7 @@ class OnnxImageUpscaleNode(NodeBase):
         self,
         img: np.ndarray,
         session: ort.InferenceSession,
-        tile_mode: int,
+        tile_mode: Union[int, None],
         change_shape: bool,
     ) -> np.ndarray:
         logger.info("Upscaling image")
@@ -140,7 +140,9 @@ class OnnxImageUpscaleNode(NodeBase):
         logger.info("Done upscaling")
         return out
 
-    def run(self, onnx_model: bytes, img: np.ndarray, tile_mode: int) -> np.ndarray:
+    def run(
+        self, onnx_model: bytes, img: np.ndarray, tile_mode: Union[int, None]
+    ) -> np.ndarray:
         """Upscales an image with a pretrained model"""
 
         logger.info(f"Upscaling image...")
@@ -233,7 +235,7 @@ class OnnxInterpolateModelsNode(NodeBase):
 
     def check_will_upscale(self, interp: bytes):
         fake_img = np.ones((3, 3, 3), dtype=np.float32, order="F")
-        result = OnnxImageUpscaleNode().run(interp, fake_img, 0)  # type: ignore
+        result = OnnxImageUpscaleNode().run(interp, fake_img, None)
 
         mean_color = np.mean(result)
         del result

--- a/backend/src/nodes/onnx_nodes.py
+++ b/backend/src/nodes/onnx_nodes.py
@@ -239,7 +239,14 @@ class OnnxInterpolateModelsNode(NodeBase):
         del result
         return mean_color > 0.5
 
-    def run(self, model_a: bytes, model_b: bytes, amount: int) -> bytes:
+    def run(
+        self, model_a: bytes, model_b: bytes, amount: int
+    ) -> Tuple[bytes, int, int]:
+        if amount == 0:
+            return model_a, 100, 0
+        elif amount == 100:
+            return model_b, 0, 100
+
         # Just to be sure there is no mismatch from opt/un-opt models
         passes = onnxoptimizer.get_fuse_and_elimination_passes()
 
@@ -272,7 +279,7 @@ class OnnxInterpolateModelsNode(NodeBase):
                 "These models are not compatible and not able to be interpolated together"
             )
 
-        return model_interp
+        return model_interp, 100 - amount, amount
 
 
 @NodeFactory.register("chainner:onnx:convert_to_ncnn")

--- a/backend/src/nodes/pytorch_nodes.py
+++ b/backend/src/nodes/pytorch_nodes.py
@@ -306,7 +306,13 @@ class InterpolateNode(NodeBase):
         gc.collect()
         return mean_color > 0.5
 
-    def run(self, model_a: PyTorchModel, model_b: PyTorchModel, amount: int) -> Any:
+    def run(
+        self, model_a: PyTorchModel, model_b: PyTorchModel, amount: int
+    ) -> Tuple[PyTorchModel, int, int]:
+        if amount == 0:
+            return model_a, 100, 0
+        elif amount == 100:
+            return model_b, 0, 100
 
         state_a = model_a.state
         state_b = model_b.state


### PR DESCRIPTION
If interp amount is 0 or 100, simply returns the appropriate model without trying to interpolate.

Also fixed the ONNX interpolate node not returning the amounts.