### PR TITLE
Disable fp16 for SwinIR

### DIFF
--- a/backend/src/nodes/utils/architecture/SwinIR.py
+++ b/backend/src/nodes/utils/architecture/SwinIR.py
@@ -974,7 +974,7 @@ class SwinIR(nn.Module):
         self.img_size = img_size
         self.img_range = img_range
 
-        self.supports_fp16 = supports_fp16
+        self.supports_fp16 = False  # Too much weirdness to support this at the moment
         self.supports_bfp16 = True
 
         self.img_range = img_range


### PR DESCRIPTION
Found more models that don't support it, so disabling until I figure out why that is.