### PR TITLE
Clear starting node's cache when Node component unmounts

### DIFF
--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -314,6 +314,19 @@ async def run_individual(request: Request):
         return json({"success": False, "error": str(exception)})
 
 
+@app.route("/clearcache/individual", methods=["POST"])
+async def clear_cache_individual(request: Request):
+    ctx = AppContext.get(request.app)
+    try:
+        full_data = dict(request.json)  # type: ignore
+        if ctx.cache.get(full_data["id"], None) is not None:
+            del ctx.cache[full_data["id"]]
+        return json({"success": True, "data": None})
+    except Exception as exception:
+        logger.error(exception, exc_info=True)
+        return json({"success": False, "error": str(exception)})
+
+
 @app.get("/sse")
 async def sse(request: Request):
     ctx = AppContext.get(request.app)

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -112,6 +112,13 @@ export class Backend {
     async kill(): Promise<BackendSuccessResponse | BackendExceptionResponse> {
         return this.fetchJson('/kill', 'POST');
     }
+
+    /**
+     * Clears the cache of the passed in node id
+     */
+    clearNodeCacheIndividual(id: string): Promise<BackendResult<null>> {
+        return this.fetchJson('/clearcache/individual', 'POST', { id });
+    }
 }
 
 const backendCache = new Map<number, Backend>();

--- a/src/renderer/hooks/useRunNode.ts
+++ b/src/renderer/hooks/useRunNode.ts
@@ -1,7 +1,8 @@
-import { useMemo, useRef } from 'react';
+import log from 'electron-log';
+import { useEffect, useMemo, useRef } from 'react';
 import { useContext } from 'use-context-selector';
 import { NodeData } from '../../common/common-types';
-import { delay, getInputValues } from '../../common/util';
+import { delay, getInputValues, isStartingNode } from '../../common/util';
 import { AlertBoxContext } from '../contexts/AlertBoxContext';
 import { BackendContext } from '../contexts/BackendContext';
 import { GlobalContext } from '../contexts/GlobalNodeState';
@@ -51,4 +52,18 @@ export const useRunNode = ({ inputData, id, schemaId }: NodeData, shouldRun: boo
         },
         [shouldRun, inputHash]
     );
+
+    useEffect(() => {
+        return () => {
+            // TODO: Change this if we ever make more than starting nodes run
+            if (isStartingNode(schema)) {
+                backend
+                    .clearNodeCacheIndividual(id)
+                    .then(() => {})
+                    .catch((error) => {
+                        log.error(error);
+                    });
+            }
+        };
+    }, []);
 };


### PR DESCRIPTION
Clears a node's cache when the component unmounts (pretty much just for deletions). Should fix part of the memory leak mentioned in #783 