### PR TITLE
Add ONNX execution options to settings

### DIFF
--- a/backend/src/nodes/pytorch_nodes.py
+++ b/backend/src/nodes/pytorch_nodes.py
@@ -38,6 +38,8 @@ def to_pytorch_execution_options(options: ExecutionOptions):
         fp16=options.fp16,
         pytorch_gpu_index=options.pytorch_gpu_index,
         ncnn_gpu_index=options.ncnn_gpu_index,
+        onnx_gpu_index=options.onnx_gpu_index,
+        onnx_execution_provider=options.onnx_execution_provider,
     )
 
 

--- a/backend/src/nodes/utils/exec_options.py
+++ b/backend/src/nodes/utils/exec_options.py
@@ -8,11 +8,15 @@ class ExecutionOptions:
         fp16: bool,
         pytorch_gpu_index: int,
         ncnn_gpu_index: int,
+        onnx_gpu_index: int,
+        onnx_execution_provider: str,
     ) -> None:
         self.__device = device
         self.__fp16 = fp16
         self.__pytorch_gpu_index = pytorch_gpu_index
         self.__ncnn_gpu_index = ncnn_gpu_index
+        self.__onnx_gpu_index = onnx_gpu_index
+        self.__onnx_execution_provider = onnx_execution_provider
 
     @property
     def device(self) -> str:
@@ -32,8 +36,16 @@ class ExecutionOptions:
     def ncnn_gpu_index(self):
         return self.__ncnn_gpu_index
 
+    @property
+    def onnx_gpu_index(self):
+        return self.__onnx_gpu_index
 
-__global_exec_options = ExecutionOptions("cpu", False, 0, 0)
+    @property
+    def onnx_execution_provider(self):
+        return self.__onnx_execution_provider
+
+
+__global_exec_options = ExecutionOptions("cpu", False, 0, 0, 0, "CPUExecutionProvider")
 
 
 def get_execution_options() -> ExecutionOptions:

--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -171,6 +171,8 @@ class RunRequest(TypedDict):
     isFp16: bool
     pytorchGPU: int
     ncnnGPU: int
+    onnxGPU: int
+    onnxExecutionProvider: str
 
 
 @app.route("/run", methods=["POST"])
@@ -198,6 +200,8 @@ async def run(request: Request):
                 fp16=full_data["isFp16"],
                 pytorch_gpu_index=full_data["pytorchGPU"],
                 ncnn_gpu_index=full_data["ncnnGPU"],
+                onnx_gpu_index=full_data["onnxGPU"],
+                onnx_execution_provider=full_data["onnxExecutionProvider"],
             )
             set_execution_options(exec_opts)
             logger.info(f"Using device: {exec_opts.device}")
@@ -248,6 +252,8 @@ class RunIndividualRequest(TypedDict):
     isFp16: bool
     pytorchGPU: int
     ncnnGPU: int
+    onnxGPU: int
+    onnxExecutionProvider: str
     schemaId: str
 
 
@@ -265,6 +271,8 @@ async def run_individual(request: Request):
             fp16=full_data["isFp16"],
             pytorch_gpu_index=full_data["pytorchGPU"],
             ncnn_gpu_index=full_data["ncnnGPU"],
+            onnx_gpu_index=full_data["onnxGPU"],
+            onnx_execution_provider=full_data["onnxExecutionProvider"],
         )
         set_execution_options(exec_opts)
         logger.info(f"Using device: {exec_opts.device}")

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -30,6 +30,8 @@ export interface BackendRunRequest {
     isFp16: boolean;
     pytorchGPU: number;
     ncnnGPU: number;
+    onnxGPU: number;
+    onnxExecutionProvider: string;
 }
 export interface BackendRunIndividualRequest {
     id: string;
@@ -38,6 +40,8 @@ export interface BackendRunIndividualRequest {
     isFp16: boolean;
     pytorchGPU: number;
     ncnnGPU: number;
+    onnxGPU: number;
+    onnxExecutionProvider: string;
     schemaId: SchemaId;
 }
 

--- a/src/common/env.ts
+++ b/src/common/env.ts
@@ -5,6 +5,21 @@ export const isM1 = isMac && (os.cpus()[0]?.model.includes('Apple M1') ?? false)
 
 export const isRenderer = typeof process !== 'undefined' && process.type === 'renderer';
 
+export const pathVar = process.env.path?.split(os.platform() === 'win32' ? ';' : ':');
+export const altPathVarLinux = process.env.LD_LIBRARY_PATH?.split(':');
+export const hasTensorRtWindows =
+    // lib env var
+    pathVar?.some((p) => p.includes('TensorRT') && p.includes('lib') && !p.includes('cudnn')) &&
+    // cudnn lib env var
+    pathVar.some((p) => p.includes('TensorRT') && p.includes('lib') && p.includes('cudnn'));
+
+export const hasTensorRtLinux =
+    // lib env var
+    pathVar?.some((p) => p.includes('TensorRT') && p.includes('lib')) ||
+    altPathVarLinux?.some((p) => p.includes('TensorRT') && p.includes('lib'));
+
+export const hasTensorRt = !isMac && (hasTensorRtWindows || hasTensorRtLinux);
+
 const env = { ...process.env };
 delete env.PYTHONHOME;
 export const sanitizedEnv = env;

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -355,7 +355,7 @@ const PythonSettings = memo(() => {
                 label: 'CPU',
                 value: 'CPUExecutionProvider',
             },
-            ...(hasTensorRt
+            ...(hasTensorRt && nvidiaGpuList.length > 0
                 ? [
                       {
                           label: 'TensorRT',

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -247,7 +247,8 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
         getInputHash,
     } = useContext(GlobalContext);
     const { schemata, port, backend } = useContext(BackendContext);
-    const { useIsCpu, useIsFp16, usePyTorchGPU, useNcnnGPU } = useContext(SettingsContext);
+    const { useIsCpu, useIsFp16, usePyTorchGPU, useNcnnGPU, useOnnxGPU, useOnnxExecutionProvider } =
+        useContext(SettingsContext);
     const { sendAlert, sendToast } = useContext(AlertBoxContext);
     const { nodeChanges, edgeChanges } = useContextSelector(GlobalVolatileContext, (c) => ({
         nodeChanges: c.nodeChanges,
@@ -258,6 +259,8 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
     const [isFp16] = useIsFp16;
     const [pytorchGPU] = usePyTorchGPU;
     const [ncnnGPU] = useNcnnGPU;
+    const [onnxGPU] = useOnnxGPU;
+    const [onnxExecutionProvider] = useOnnxExecutionProvider;
 
     const { getNodes, getEdges } = useReactFlow<NodeData, EdgeData>();
 
@@ -480,6 +483,8 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
                 isFp16,
                 pytorchGPU,
                 ncnnGPU,
+                onnxGPU,
+                onnxExecutionProvider,
             });
             if (response.exception) {
                 // no need to alert here, because the error has already been handled by the queue

--- a/src/renderer/contexts/SettingsContext.tsx
+++ b/src/renderer/contexts/SettingsContext.tsx
@@ -14,6 +14,8 @@ interface Settings {
     useIsFp16: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
     usePyTorchGPU: readonly [number, React.Dispatch<React.SetStateAction<number>>];
     useNcnnGPU: readonly [number, React.Dispatch<React.SetStateAction<number>>];
+    useOnnxGPU: readonly [number, React.Dispatch<React.SetStateAction<number>>];
+    useOnnxExecutionProvider: readonly [string, React.Dispatch<React.SetStateAction<string>>];
     useIsSystemPython: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
     useDisHwAccel: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
     useCheckUpdOnStrtUp: readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>];
@@ -45,6 +47,10 @@ export const SettingsProvider = memo(({ children }: React.PropsWithChildren<unkn
     const useIsFp16 = useMemoArray(useLocalStorage('is-fp16', false));
     const usePyTorchGPU = useMemoArray(useLocalStorage('pytorch-gpu', 0));
     const useNcnnGPU = useMemoArray(useLocalStorage('ncnn-gpu', 0));
+    const useOnnxGPU = useMemoArray(useLocalStorage('onnx-gpu', 0));
+    const useOnnxExecutionProvider = useMemoArray(
+        useLocalStorage('onnx-execution-provider', 'CUDAExecutionProvider')
+    );
 
     const useIsSystemPython = useMemoArray(useLocalStorage('use-system-python', false));
     const useDisHwAccel = useMemoArray(useLocalStorage('disable-hw-accel', false));
@@ -87,11 +93,15 @@ export const SettingsProvider = memo(({ children }: React.PropsWithChildren<unkn
     );
 
     const contextValue = useMemoObject<Settings>({
-        // Globals
+        // GPU Stuff
         useIsCpu,
         useIsFp16,
         usePyTorchGPU,
         useNcnnGPU,
+        useOnnxGPU,
+        useOnnxExecutionProvider,
+
+        // Globals
         useIsSystemPython,
         useSnapToGrid,
         useDisHwAccel,

--- a/src/renderer/hooks/useRunNode.ts
+++ b/src/renderer/hooks/useRunNode.ts
@@ -13,12 +13,15 @@ export const useRunNode = ({ inputData, id, schemaId }: NodeData, shouldRun: boo
     const { sendToast } = useContext(AlertBoxContext);
     const { animate, unAnimate } = useContext(GlobalContext);
     const { schemata, backend } = useContext(BackendContext);
-    const { useIsCpu, useIsFp16, usePyTorchGPU, useNcnnGPU } = useContext(SettingsContext);
+    const { useIsCpu, useIsFp16, usePyTorchGPU, useNcnnGPU, useOnnxGPU, useOnnxExecutionProvider } =
+        useContext(SettingsContext);
 
     const [isCpu] = useIsCpu;
     const [isFp16] = useIsFp16;
     const [pytorchGPU] = usePyTorchGPU;
     const [ncnnGPU] = useNcnnGPU;
+    const [onnxGPU] = useOnnxGPU;
+    const [onnxExecutionProvider] = useOnnxExecutionProvider;
 
     const schema = schemata.get(schemaId);
 
@@ -46,6 +49,8 @@ export const useRunNode = ({ inputData, id, schemaId }: NodeData, shouldRun: boo
                     isFp16,
                     pytorchGPU,
                     ncnnGPU,
+                    onnxGPU,
+                    onnxExecutionProvider,
                 });
 
                 if (!result.success) {


### PR DESCRIPTION
This adds GPU selection as well as provider selection to ONNX in settings.

This also adds the ability to select TensorRT as the provider, if you have the path variables set up for it. However, using TensorRT does not work properly right now as it converts the model every time you upscale rather than sharing the model across all upscale, meaning it's slower than even CPU. I will fix this in an upcoming PR.