### PR TITLE
Report all type mismatches

### DIFF
--- a/src/renderer/components/node/NodeFooter/ValidityIndicator.tsx
+++ b/src/renderer/components/node/NodeFooter/ValidityIndicator.tsx
@@ -1,6 +1,7 @@
 import { Center, Icon, Spinner, Tooltip } from '@chakra-ui/react';
 import { memo } from 'react';
 import { BsCheck, BsExclamation } from 'react-icons/bs';
+import ReactMarkdown from 'react-markdown';
 import { Validity } from '../../../helpers/checkNodeValidity';
 
 interface ValidityIndicatorProps {
@@ -29,7 +30,9 @@ export const ValidityIndicator = memo(({ validity, animated }: ValidityIndicator
             borderRadius={8}
             closeOnClick={false}
             gutter={24}
-            label={validity.isValid ? 'Node valid' : validity.reason}
+            label={
+                <ReactMarkdown>{validity.isValid ? 'Node valid' : validity.reason}</ReactMarkdown>
+            }
             px={2}
             textAlign="center"
         >


### PR DESCRIPTION
Fixes https://github.com/joeyballentine/chaiNNer/issues/928

---

As discussed on discord.

All input type error will now be reported. Even if a nicely formatted error message is not available, an error message will be generated.

Since type errors are quite technical in nature, I expect that we will likely tweak the `printErrorTrace` method in the future to further improve user-friendliness.

Example: Here is the same error, once with a generated error trace and once with a nice error message.

![image](https://user-images.githubusercontent.com/20878432/189753977-7430e58d-bd75-4296-b812-21344c86eafa.png)
![image](https://user-images.githubusercontent.com/20878432/189754137-994c9038-5da9-44df-a21b-df342cf2d15c.png)
