### PR TITLE
Increase max VRAM when estimating (PyTorch)

### DIFF
--- a/backend/src/nodes/pytorch_nodes.py
+++ b/backend/src/nodes/pytorch_nodes.py
@@ -163,7 +163,7 @@ class ImageUpscaleNode(NodeBase):
                     f"Estimating memory required: {required_mem} GB, {free_mem} GB free, {total_mem} GB total. Estimated Split depth: {split_estimation}"
                 )
                 # Attempt to avoid using too much vram at once
-                if float(required_mem) > float(free_mem) / 2:
+                if float(required_mem) > float(free_mem) * 0.85:
                     split_estimation += 1
 
             t_out, depth = auto_split_process(


### PR DESCRIPTION
I originally made it split one more time when the usage was calculated to be more than half of the usable VRAM. This was to account for any inaccuracies in the estimation. 

However, I'm pretty sure this can be increased now, especially since we now allow it to OOM & split again once before truly erroring. 