### PR TITLE
Fixed infinite pip loop

### DIFF
--- a/src/renderer/hooks/useAsyncEffect.ts
+++ b/src/renderer/hooks/useAsyncEffect.ts
@@ -93,7 +93,7 @@ interface ObjectUseAsyncEffectOptions<T> {
  */
 export const useAsyncEffect = <T>(
     options: UseAsyncEffectOptions<T>,
-    dependencies?: readonly unknown[]
+    dependencies: readonly unknown[]
 ) => {
     const objOptions: ObjectUseAsyncEffectOptions<T> =
         typeof options === 'function' ? { supplier: options, successEffect: noop } : options;

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -143,10 +143,13 @@ export const Main = memo(({ port }: MainProps) => {
     );
 
     const [pythonInfo, setPythonInfo] = useState<PythonInfo>();
-    useAsyncEffect({
-        supplier: () => ipcRenderer.invoke('get-python'),
-        successEffect: setPythonInfo,
-    });
+    useAsyncEffect(
+        {
+            supplier: () => ipcRenderer.invoke('get-python'),
+            successEffect: setPythonInfo,
+        },
+        []
+    );
 
     if (error) return null;
 


### PR DESCRIPTION
The problem was that I forgot the deps array on the async effect that got the python info.

To prevent this problem for occurring in the future, I made the deps array a mandatory parameter. All our current uses have one anyway.