### PR TITLE
Clear manual output type

### DIFF
--- a/src/renderer/contexts/GlobalNodeState.tsx
+++ b/src/renderer/contexts/GlobalNodeState.tsx
@@ -206,6 +206,15 @@ export const GlobalProvider = memo(
             },
             [setManualOutputTypes]
         );
+        const clearManualOutputTypes = useCallback(
+            (nodeId: string): void => {
+                setManualOutputTypes(({ map }) => {
+                    map.delete(nodeId);
+                    return { map };
+                });
+            },
+            [setManualOutputTypes]
+        );
 
         const [typeState, setTypeState] = useState(TypeState.empty);
         const typeStateRef = useRef(typeState);
@@ -1027,9 +1036,10 @@ export const GlobalProvider = memo(
                     return newNode;
                 });
                 outputDataActions.delete(id);
+                clearManualOutputTypes(id);
                 addInputDataChanges();
             },
-            [modifyNode, addInputDataChanges, outputDataActions]
+            [modifyNode, addInputDataChanges, outputDataActions, clearManualOutputTypes]
         );
 
         const setNodeDisabled = useCallback(


### PR DESCRIPTION
Fixes #927.

While I say that this fixes the linked issue, I wasn't actually able to see any issues caused by the output type not being cleared. This is because the output elements (`renderer/components/outputs/*`) that set the manual output type also clear it again when their stored output data is reset. Since `clearNode` already resets the output data, I'm not sure why clearing the output type is also necessary. What was the reason you opened #927 @joeyballentine?