### PR TITLE
Fixed starting nodes not running after clearing

### DIFF
--- a/src/renderer/hooks/useRunNode.ts
+++ b/src/renderer/hooks/useRunNode.ts
@@ -33,12 +33,16 @@ export const useRunNode = ({ inputData, id, schemaId }: NodeData, shouldRun: boo
     const lastRunInputHash = useRef<string>();
     useAsyncEffect(
         async (token) => {
-            if (shouldRun && inputHash !== lastRunInputHash.current) {
-                // give it some time for other effects to settle in
-                await delay(50);
-                token.checkCanceled();
+            if (inputHash === lastRunInputHash.current) {
+                return;
+            }
+            // give it some time for other effects to settle in
+            await delay(50);
+            token.checkCanceled();
 
-                lastRunInputHash.current = inputHash;
+            lastRunInputHash.current = inputHash;
+
+            if (shouldRun) {
                 animate([id], false);
 
                 const result = await backend.runIndividual({

--- a/src/renderer/hooks/useRunNode.ts
+++ b/src/renderer/hooks/useRunNode.ts
@@ -30,17 +30,17 @@ export const useRunNode = ({ inputData, id, schemaId }: NodeData, shouldRun: boo
         [inputData]
     );
     const inputHash = useMemo(() => JSON.stringify(inputs), [inputData]);
-    const lastRunInputHash = useRef<string>();
+    const lastInputHash = useRef<string>();
     useAsyncEffect(
         async (token) => {
-            if (inputHash === lastRunInputHash.current) {
+            if (inputHash === lastInputHash.current) {
                 return;
             }
             // give it some time for other effects to settle in
             await delay(50);
             token.checkCanceled();
 
-            lastRunInputHash.current = inputHash;
+            lastInputHash.current = inputHash;
 
             if (shouldRun) {
                 animate([id], false);


### PR DESCRIPTION
If you cleared a Load Image node with a selected image and then selected the same image again, then the node wouldn't run again and display no image preview.

This was because the lastInputHash was only updated when running a node. Since nodes without all required inputs can't be run, the `runRunNode` hook basically ignored that the node was cleared.

The fix is pretty simple. We just always update lastInputHash, even if we aren't going to run the node.