### PR TITLE
Removed starting node assumption in `useRunNode`

### DIFF
--- a/src/renderer/hooks/useRunNode.ts
+++ b/src/renderer/hooks/useRunNode.ts
@@ -2,7 +2,7 @@ import log from 'electron-log';
 import { useEffect, useMemo, useRef } from 'react';
 import { useContext } from 'use-context-selector';
 import { NodeData } from '../../common/common-types';
-import { delay, getInputValues, isStartingNode } from '../../common/util';
+import { delay, getInputValues } from '../../common/util';
 import { AlertBoxContext } from '../contexts/AlertBoxContext';
 import { BackendContext } from '../contexts/BackendContext';
 import { GlobalContext } from '../contexts/GlobalNodeState';
@@ -25,6 +25,8 @@ export const useRunNode = ({ inputData, id, schemaId }: NodeData, shouldRun: boo
 
     const schema = schemata.get(schemaId);
 
+    const didEverRun = useRef(false);
+
     const inputs = useMemo(
         () => getInputValues(schema, (inputId) => inputData[inputId] ?? null),
         [inputData]
@@ -43,6 +45,7 @@ export const useRunNode = ({ inputData, id, schemaId }: NodeData, shouldRun: boo
             lastInputHash.current = inputHash;
 
             if (shouldRun) {
+                didEverRun.current = true;
                 animate([id], false);
 
                 const result = await backend.runIndividual({
@@ -74,14 +77,8 @@ export const useRunNode = ({ inputData, id, schemaId }: NodeData, shouldRun: boo
 
     useEffect(() => {
         return () => {
-            // TODO: Change this if we ever make more than starting nodes run
-            if (isStartingNode(schema)) {
-                backend
-                    .clearNodeCacheIndividual(id)
-                    .then(() => {})
-                    .catch((error) => {
-                        log.error(error);
-                    });
+            if (didEverRun.current) {
+                backend.clearNodeCacheIndividual(id).catch((error) => log.error(error));
             }
         };
     }, []);


### PR DESCRIPTION
[I said that I don't like the assumption that only starting nodes get executed](https://github.com/joeyballentine/chaiNNer/pull/978/files#r973292312), so I removed this assumption from `useRunNode`. I did this by adding a ref that tracks whether we ever executed the node. If we didn't, then we don't need to clear the cache.