### PR TITLE
Added a class for ONNX models

### DIFF
--- a/backend/src/nodes/model_save_nodes.py
+++ b/backend/src/nodes/model_save_nodes.py
@@ -1,6 +1,5 @@
 # These sad files have to be all on their own :(
 from __future__ import annotations
-from typing import Any
 from sanic.log import logger
 
 from .node_base import NodeBase
@@ -11,6 +10,7 @@ from .properties.inputs import *
 from .properties.outputs import *
 
 from .utils.ncnn_model import NcnnModel
+from .utils.onnx_model import OnnxModel
 
 
 @NodeFactory.register("chainner:onnx:save_model")
@@ -34,13 +34,12 @@ class OnnxSaveModelNode(NodeBase):
         self.side_effects = True
 
     def run(
-        self, onnx_model: Tuple[Any, bytes], directory: str, model_name: str
+        self, model: OnnxModel, directory: str, model_name: str
     ) -> None:
         full_path = f"{os.path.join(directory, model_name)}.onnx"
         logger.info(f"Writing file to path: {full_path}")
         with open(full_path, "wb") as f:
-            _, onnx_model_bytes = onnx_model
-            f.write(onnx_model_bytes)
+            f.write(model.bytes)
 
 
 @NodeFactory.register("chainner:ncnn:save_model")

--- a/backend/src/nodes/utils/onnx_model.py
+++ b/backend/src/nodes/utils/onnx_model.py
@@ -1,0 +1,5 @@
+# This class defines an interface.
+# It is important that is does not contain types that depend on ONNX.
+class OnnxModel:
+    def __init__(self, model_as_bytes: bytes):
+        self.bytes = model_as_bytes

--- a/backend/src/nodes/utils/onnx_session.py
+++ b/backend/src/nodes/utils/onnx_session.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+import onnxruntime as ort
+from weakref import WeakKeyDictionary
+
+from .exec_options import ExecutionOptions
+from .onnx_model import OnnxModel
+
+
+def create_inference_session(
+    model: OnnxModel, exec_options: ExecutionOptions
+) -> ort.InferenceSession:
+    if exec_options.onnx_execution_provider == "TensorrtExecutionProvider":
+        providers = [
+            (
+                "TensorrtExecutionProvider",
+                {
+                    "device_id": exec_options.onnx_gpu_index,
+                },
+            ),
+            (
+                "CUDAExecutionProvider",
+                {
+                    "device_id": exec_options.onnx_gpu_index,
+                },
+            ),
+            "CPUExecutionProvider",
+        ]
+    elif exec_options.onnx_execution_provider == "CUDAExecutionProvider":
+        providers = [
+            (
+                "CUDAExecutionProvider",
+                {
+                    "device_id": exec_options.onnx_gpu_index,
+                },
+            ),
+            "CPUExecutionProvider",
+        ]
+    else:
+        providers = [exec_options.onnx_execution_provider, "CPUExecutionProvider"]
+
+    session = ort.InferenceSession(model.bytes, providers=providers)
+    return session
+
+
+__session_cache: WeakKeyDictionary[
+    OnnxModel, ort.InferenceSession
+] = WeakKeyDictionary()
+
+
+def get_onnx_session(
+    model: OnnxModel, exec_options: ExecutionOptions
+) -> ort.InferenceSession:
+    cached = __session_cache.get(model)
+    if cached is None:
+        cached = create_inference_session(model, exec_options)
+        __session_cache[model] = cached
+    return cached


### PR DESCRIPTION
Changes:
- ONNX models are now wrapped in a class that only contains the model bytes.
- The inference session is now lazily created using the `get_onnx_session` function. This function will create a new session if no existing session is associated with the model.
- Fixed that `ConvertOnnxToNcnnNode` still used the old type and crashed at runtime.

The divide between the model (bytes) and the inference session is necessary because the model class defines an interface that has to be usable even if the ONNX runtime package isn't present and no inference session can be created.

