### PR TITLE
Use `async` to pause executor

### DIFF
--- a/backend/src/nodes/image_iterator_nodes.py
+++ b/backend/src/nodes/image_iterator_nodes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 import os
 
 import numpy as np
@@ -104,8 +103,7 @@ class ImageFileIteratorNode(IteratorNodeBase):
         for root, _dirs, files in os.walk(
             directory, topdown=True, onerror=walk_error_handler
         ):
-            if context.executor.should_stop_running():
-                return
+            await context.progress.suspend()
 
             for name in sorted(files):
                 filepath = os.path.join(root, name)
@@ -114,40 +112,38 @@ class ImageFileIteratorNode(IteratorNodeBase):
                     just_image_files.append(filepath)
 
         file_len = len(just_image_files)
-        start_idx = math.ceil(float(context.percent) * file_len)
         errors = []
         for idx, filepath in enumerate(just_image_files):
-            if context.executor.should_stop_running():
-                return
-            if idx >= start_idx:
-                await context.queue.put(
-                    {
-                        "event": "iterator-progress-update",
-                        "data": {
-                            "percent": idx / file_len,
-                            "iteratorId": context.iterator_id,
-                            "running": child_nodes,
-                        },
-                    }
-                )
-                # Replace the input filepath with the filepath from the loop
-                context.nodes[img_path_node_id]["inputs"] = [filepath, directory, idx]
-                executor = context.create_iterator_executor()
-                try:
-                    await executor.run()
-                except Exception as e:
-                    logger.error(e)
-                    errors.append(str(e))
-                await context.queue.put(
-                    {
-                        "event": "iterator-progress-update",
-                        "data": {
-                            "percent": (idx + 1) / file_len,
-                            "iteratorId": context.iterator_id,
-                            "running": None,
-                        },
-                    }
-                )
+            await context.progress.suspend()
+            await context.queue.put(
+                {
+                    "event": "iterator-progress-update",
+                    "data": {
+                        "percent": idx / file_len,
+                        "iteratorId": context.iterator_id,
+                        "running": child_nodes,
+                    },
+                }
+            )
+            # Replace the input filepath with the filepath from the loop
+            context.nodes[img_path_node_id]["inputs"] = [filepath, directory, idx]
+            executor = context.create_iterator_executor()
+            try:
+                await executor.run()
+            except Exception as e:
+                logger.error(e)
+                errors.append(str(e))
+            await context.queue.put(
+                {
+                    "event": "iterator-progress-update",
+                    "data": {
+                        "percent": (idx + 1) / file_len,
+                        "iteratorId": context.iterator_id,
+                        "running": None,
+                    },
+                }
+            )
+
         if len(errors) > 0:
             raise Exception(
                 # pylint: disable=consider-using-f-string
@@ -210,8 +206,12 @@ class VideoFrameIteratorFrameWriterNode(NodeBase):
         writer,
         fps,
     ) -> None:
+        if video_type == "none":
+            return
+
         h, w, _ = get_h_w_c(img)
-        if writer["out"] is None and video_type != "none":
+
+        if writer["out"] is None:
             mp4_codec = "avc1"
             avi_codec = "divx"
             codec = mp4_codec if video_type == "mp4" else avi_codec
@@ -231,8 +231,8 @@ class VideoFrameIteratorFrameWriterNode(NodeBase):
                 logger.warning(
                     f"Failed to open video writer with codec: {codec} because: {e}"
                 )
-        if video_type != "none":
-            writer["out"].write((img * 255).astype(np.uint8))
+
+        writer["out"].write((img * 255).astype(np.uint8))
 
 
 @NodeFactory.register("chainner:image:video_frame_iterator")
@@ -282,25 +282,21 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
 
         # TODO: Open Video Buffer
         cap = cv2.VideoCapture(path)
-        fps = int(cap.get(cv2.CAP_PROP_FPS))
-
         writer = {"out": None}
-        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-        start_idx = math.ceil(float(context.percent) * frame_count)
-        context.nodes[output_node_id]["inputs"].extend((writer, fps))
-        errors = []
-        for idx in range(frame_count):
-            if context.executor.should_stop_running():
-                cap.release()
-                if writer["out"] is not None:
-                    writer["out"].release()
-                return
-            ret, frame = cap.read()
-            # if frame is read correctly ret is True
-            if not ret:
-                print("Can't receive frame (stream end?). Exiting ...")
-                break
-            if idx >= start_idx:
+        try:
+            fps = int(cap.get(cv2.CAP_PROP_FPS))
+            frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+            context.nodes[output_node_id]["inputs"].extend((writer, fps))
+            errors = []
+            for idx in range(frame_count):
+                await context.progress.suspend()
+
+                ret, frame = cap.read()
+                # if frame is read correctly ret is True
+                if not ret:
+                    print("Can't receive frame (stream end?). Exiting ...")
+                    break
+
                 await context.queue.put(
                     {
                         "event": "iterator-progress-update",
@@ -329,14 +325,17 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
                     }
                 )
 
-        cap.release()
-        if writer["out"] is not None:
-            writer["out"].release()
-        if len(errors) > 0:
-            raise Exception(
-                # pylint: disable=consider-using-f-string
-                "Errors occurred during iteration: \n• {}".format("\n• ".join(errors))
-            )
+            if len(errors) > 0:
+                raise Exception(
+                    # pylint: disable=consider-using-f-string
+                    "Errors occurred during iteration: \n• {}".format(
+                        "\n• ".join(errors)
+                    )
+                )
+        finally:
+            cap.release()
+            if writer["out"] is not None:
+                writer["out"].release()
 
 
 @NodeFactory.register(SPRITESHEET_ITERATOR_INPUT_NODE_ID)
@@ -470,8 +469,7 @@ class ImageSpriteSheetIteratorNode(IteratorNodeBase):
         context.nodes[output_node_id]["inputs"].append(results)
         errors = []
         for idx, img in enumerate(img_list):
-            if context.executor.should_stop_running():
-                break
+            await context.progress.suspend()
             await context.queue.put(
                 {
                     "event": "iterator-progress-update",

--- a/backend/src/nodes/node_factory.py
+++ b/backend/src/nodes/node_factory.py
@@ -1,36 +1,42 @@
-from typing import Callable, Dict
+from typing import Callable, Dict, TypeVar
 
 from sanic.log import logger
 
 from .node_base import NodeBase
 
+T = TypeVar("T", bound=NodeBase)
 
 # Implementation based on https://medium.com/@geoffreykoh/implementing-the-factory-pattern-via-dynamic-registry-and-python-decorators-479fc1537bbe
 class NodeFactory:
     """The factory class for creating nodes"""
 
-    registry = {}
+    registry: Dict[str, Callable[[], NodeBase]] = {}
     """ Internal registry for available nodes """
 
+    __node_cache: Dict[str, NodeBase] = {}
+
     @classmethod
-    def create_node(cls, schema_id: str) -> NodeBase:
+    def get_node(cls, schema_id: str) -> NodeBase:
         """Factory command to create the node"""
 
-        node_class = cls.registry[schema_id]
-        node = node_class()
+        node = cls.__node_cache.get(schema_id)
+        if node is None:
+            node_class = cls.registry[schema_id]
+            node = node_class()
+            cls.__node_cache[schema_id] = node
         return node
 
     @classmethod
-    def register(cls, schema_id: str) -> Callable:
-        def inner_wrapper(wrapped_class: NodeBase) -> Callable:
+    def register(cls, schema_id: str):
+        def inner_wrapper(wrapped_class: Callable[[], T]) -> Callable[[], T]:
             if schema_id not in cls.registry:
                 cls.registry[schema_id] = wrapped_class
             else:
                 logger.warning(f"Node {schema_id} already exists. Will replace it")
-            return wrapped_class  # type: ignore
+            return wrapped_class
 
         return inner_wrapper
 
     @classmethod
-    def get_registry(cls) -> Dict:
+    def get_registry(cls):
         return cls.registry

--- a/backend/src/nodes/pytorch_iterators.py
+++ b/backend/src/nodes/pytorch_iterators.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 import os
 
 from sanic.log import logger
@@ -97,8 +96,7 @@ class ModelFileIteratorNode(IteratorNodeBase):
         for root, _dirs, files in os.walk(
             directory, topdown=True, onerror=walk_error_handler
         ):
-            if context.executor.should_stop_running():
-                return
+            await context.progress.suspend()
 
             for name in sorted(files):
                 filepath = os.path.join(root, name)
@@ -107,40 +105,39 @@ class ModelFileIteratorNode(IteratorNodeBase):
                     just_model_files.append(filepath)
 
         file_len = len(just_model_files)
-        start_idx = math.ceil(float(context.percent) * file_len)
         errors = []
         for idx, filepath in enumerate(just_model_files):
-            if context.executor.should_stop_running():
-                return
-            if idx >= start_idx:
-                await context.queue.put(
-                    {
-                        "event": "iterator-progress-update",
-                        "data": {
-                            "percent": idx / file_len,
-                            "iteratorId": context.iterator_id,
-                            "running": child_nodes,
-                        },
-                    }
-                )
-                # Replace the input filepath with the filepath from the loop
-                context.nodes[model_path_node_id]["inputs"] = [filepath, directory, idx]
-                executor = context.create_iterator_executor()
-                try:
-                    await executor.run()
-                except Exception as e:
-                    logger.error(e)
-                    errors.append(str(e))
-                await context.queue.put(
-                    {
-                        "event": "iterator-progress-update",
-                        "data": {
-                            "percent": (idx + 1) / file_len,
-                            "iteratorId": context.iterator_id,
-                            "running": None,
-                        },
-                    }
-                )
+            await context.progress.suspend()
+
+            await context.queue.put(
+                {
+                    "event": "iterator-progress-update",
+                    "data": {
+                        "percent": idx / file_len,
+                        "iteratorId": context.iterator_id,
+                        "running": child_nodes,
+                    },
+                }
+            )
+            # Replace the input filepath with the filepath from the loop
+            context.nodes[model_path_node_id]["inputs"] = [filepath, directory, idx]
+            executor = context.create_iterator_executor()
+            try:
+                await executor.run()
+            except Exception as e:
+                logger.error(e)
+                errors.append(str(e))
+            await context.queue.put(
+                {
+                    "event": "iterator-progress-update",
+                    "data": {
+                        "percent": (idx + 1) / file_len,
+                        "iteratorId": context.iterator_id,
+                        "running": None,
+                    },
+                }
+            )
+
         if len(errors) > 0:
             raise Exception(
                 # pylint: disable=consider-using-f-string

--- a/backend/src/progress.py
+++ b/backend/src/progress.py
@@ -1,0 +1,57 @@
+from abc import ABC, abstractmethod
+import asyncio
+
+
+class Aborted(Exception):
+    pass
+
+
+class ProgressToken(ABC):
+    @property
+    @abstractmethod
+    def paused(self) -> bool:
+        pass
+
+    @property
+    @abstractmethod
+    def aborted(self) -> bool:
+        pass
+
+    @abstractmethod
+    async def suspend(self) -> None:
+        """
+        If the operation was aborted, this method will throw an `Aborted` exception.
+        If the operation is paused, this method will wait until the operation is resumed or aborted.
+        """
+
+
+class ProgressController(ProgressToken):
+    def __init__(self):
+        self.__paused: bool = False
+        self.__aborted: bool = False
+
+    @property
+    def paused(self) -> bool:
+        return self.__paused
+
+    @property
+    def aborted(self) -> bool:
+        return self.__aborted
+
+    def pause(self):
+        self.__paused = True
+
+    def resume(self):
+        self.__paused = False
+
+    def abort(self):
+        self.__aborted = True
+
+    async def suspend(self) -> None:
+        if self.aborted:
+            raise Aborted()
+
+        while self.paused:
+            await asyncio.sleep(0.1)
+            if self.aborted:
+                raise Aborted()

--- a/backend/src/response.py
+++ b/backend/src/response.py
@@ -1,0 +1,57 @@
+from typing import Literal, Optional, TypedDict, Union
+
+from process import NodeExecutionError
+from events import ExecutionErrorSource
+
+
+class SuccessResponse(TypedDict):
+    type: Literal["success"]
+    message: str
+
+
+class ErrorResponse(TypedDict):
+    type: Literal["error"]
+    message: str
+    exception: str
+    source: Optional[ExecutionErrorSource]
+
+
+class NoExecutorResponse(TypedDict):
+    type: Literal["no-executor"]
+    message: str
+
+
+class AlreadyRunningResponse(TypedDict):
+    type: Literal["already-running"]
+    message: str
+
+
+def successResponse(message: str) -> SuccessResponse:
+    return {"type": "success", "message": message}
+
+
+def errorResponse(
+    message: str,
+    exception: Union[str, Exception],
+    source: Optional[ExecutionErrorSource] = None,
+) -> ErrorResponse:
+    if source is None and isinstance(exception, NodeExecutionError):
+        source = {
+            "nodeId": exception.node["id"],
+            "schemaId": exception.node["schemaId"],
+            "inputs": exception.inputs,
+        }
+    return {
+        "type": "error",
+        "message": message,
+        "exception": str(exception),
+        "source": source,
+    }
+
+
+def noExecutorResponse(message: str) -> NoExecutorResponse:
+    return {"type": "no-executor", "message": message}
+
+
+def alreadyRunningResponse(message: str) -> AlreadyRunningResponse:
+    return {"type": "already-running", "message": message}

--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -367,8 +367,9 @@ async def pause(request: Request):
     ctx = AppContext.get(request.app)
 
     if not ctx.executor:
-        logger.info("No executor to pause")
-        return json({"message": "No executor to pause!"}, status=200)
+        message = "No executor to pause"
+        logger.warning(message)
+        return json({"message": message, "exception": message}, status=400)
 
     try:
         logger.info("Executor found. Attempting to pause...")
@@ -388,8 +389,9 @@ async def resume(request: Request):
     ctx = AppContext.get(request.app)
 
     if not ctx.executor:
-        logger.info("No executor to resume")
-        return json({"message": "No executor to resume!"}, status=200)
+        message = "No executor to resume"
+        logger.warning(message)
+        return json({"message": message, "exception": message}, status=400)
 
     try:
         logger.info("Executor found. Attempting to resume...")
@@ -409,8 +411,9 @@ async def kill(request: Request):
     ctx = AppContext.get(request.app)
 
     if not ctx.executor:
-        logger.info("No executor to kill")
-        return json({"message": "No executor to kill!"}, status=200)
+        message = "No executor to kill"
+        logger.warning(message)
+        return json({"message": message, "exception": message}, status=400)
 
     try:
         logger.info("Executor found. Attempting to kill...")

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -107,17 +107,15 @@ export class Backend {
         return this.fetchJson('/run/individual', 'POST', data);
     }
 
-    /**
-     * Pauses the current execution
-     */
     pause(): Promise<BackendSuccessResponse | BackendExceptionResponse> {
         return this.fetchJson('/pause', 'POST');
     }
 
-    /**
-     * Kills the current execution
-     */
-    async kill(): Promise<BackendSuccessResponse | BackendExceptionResponse> {
+    resume(): Promise<BackendSuccessResponse | BackendExceptionResponse> {
+        return this.fetchJson('/resume', 'POST');
+    }
+
+    kill(): Promise<BackendSuccessResponse | BackendExceptionResponse> {
         return this.fetchJson('/kill', 'POST');
     }
 

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -2,8 +2,8 @@ import fetch from 'cross-fetch';
 import { Category, InputId, InputValue, NodeSchema, SchemaId, UsableData } from './common-types';
 
 export interface BackendSuccessResponse {
+    type: 'success';
     message: string;
-    exception?: never;
 }
 export interface BackendExceptionSource {
     nodeId: string;
@@ -16,10 +16,23 @@ export interface BackendExceptionSource {
     >;
 }
 export interface BackendExceptionResponse {
+    type: 'error';
     message: string;
     source?: BackendExceptionSource | null;
     exception: string;
 }
+export interface BackendNoExecutorResponse {
+    type: 'no-executor';
+    message: string;
+}
+export interface BackendAlreadyRunningResponse {
+    type: 'already-running';
+    message: string;
+}
+export type BackendExecutorActionResponse =
+    | BackendSuccessResponse
+    | BackendExceptionResponse
+    | BackendNoExecutorResponse;
 export interface BackendNodesResponse {
     nodes: NodeSchema[];
     categories: Category[];
@@ -96,7 +109,9 @@ export class Backend {
     /**
      * Runs the provided nodes
      */
-    run(data: BackendRunRequest): Promise<BackendSuccessResponse | BackendExceptionResponse> {
+    run(
+        data: BackendRunRequest
+    ): Promise<BackendSuccessResponse | BackendExceptionResponse | BackendAlreadyRunningResponse> {
         return this.fetchJson('/run', 'POST', data);
     }
 
@@ -107,15 +122,15 @@ export class Backend {
         return this.fetchJson('/run/individual', 'POST', data);
     }
 
-    pause(): Promise<BackendSuccessResponse | BackendExceptionResponse> {
+    pause(): Promise<BackendExecutorActionResponse> {
         return this.fetchJson('/pause', 'POST');
     }
 
-    resume(): Promise<BackendSuccessResponse | BackendExceptionResponse> {
+    resume(): Promise<BackendExecutorActionResponse> {
         return this.fetchJson('/resume', 'POST');
     }
 
-    kill(): Promise<BackendSuccessResponse | BackendExceptionResponse> {
+    kill(): Promise<BackendExecutorActionResponse> {
         return this.fetchJson('/kill', 'POST');
     }
 

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -148,7 +148,6 @@ export interface UsableData {
     child: boolean;
     children?: string[];
     nodeType: string;
-    percent?: number;
     hasSideEffects: boolean;
     cacheOptions: CacheOptions;
 }

--- a/src/renderer/components/CustomEdge.tsx
+++ b/src/renderer/components/CustomEdge.tsx
@@ -7,6 +7,7 @@ import { useDebouncedCallback } from 'use-debounce';
 import { EdgeData, NodeData } from '../../common/common-types';
 import { parseSourceHandle } from '../../common/util';
 import { BackendContext } from '../contexts/BackendContext';
+import { ExecutionStatusContext } from '../contexts/ExecutionContext';
 import { GlobalContext, GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import { SettingsContext } from '../contexts/SettingsContext';
 import { shadeColor } from '../helpers/colorTools';
@@ -32,6 +33,7 @@ export const CustomEdge = memo(
             (c) => c.effectivelyDisabledNodes
         );
         const { useAnimateChain } = useContext(SettingsContext);
+        const { paused } = useContext(ExecutionStatusContext);
         const [animateChain] = useAnimateChain;
 
         const edgePath = useMemo(
@@ -75,6 +77,8 @@ export const CustomEdge = memo(
         const hoverTimeout = useDebouncedCallback(() => {
             setIsHovered(false);
         }, 7500);
+
+        const showRunning = animated && !paused;
 
         return (
             <g
@@ -122,10 +126,10 @@ export const CustomEdge = memo(
                         transitionTimingFunction: 'ease-in-out',
                         cursor: 'pointer',
                         animation:
-                            animated && animateChain
+                            showRunning && animateChain
                                 ? 'dashdraw-chain 0.5s linear infinite'
                                 : 'none',
-                        opacity: animated ? 1 : 0,
+                        opacity: showRunning ? 1 : 0,
                     }}
                 />
                 <path
@@ -145,10 +149,10 @@ export const CustomEdge = memo(
                         transitionTimingFunction: 'ease-in-out',
                         cursor: 'pointer',
                         animation:
-                            animated && animateChain
+                            showRunning && animateChain
                                 ? 'dashdraw-chain 0.5s linear infinite'
                                 : 'none',
-                        opacity: animated ? 1 : 0,
+                        opacity: showRunning ? 1 : 0,
                     }}
                 />
                 <path

--- a/src/renderer/components/node/NodeFooter/ValidityIndicator.tsx
+++ b/src/renderer/components/node/NodeFooter/ValidityIndicator.tsx
@@ -1,7 +1,10 @@
 import { Center, Icon, Spinner, Tooltip } from '@chakra-ui/react';
 import { memo } from 'react';
 import { BsCheck, BsExclamation } from 'react-icons/bs';
+import { IoIosPause } from 'react-icons/io';
 import ReactMarkdown from 'react-markdown';
+import { useContext } from 'use-context-selector';
+import { ExecutionStatusContext } from '../../../contexts/ExecutionContext';
 import { Validity } from '../../../helpers/checkNodeValidity';
 
 interface ValidityIndicatorProps {
@@ -10,20 +13,52 @@ interface ValidityIndicatorProps {
 }
 
 export const ValidityIndicator = memo(({ validity, animated }: ValidityIndicatorProps) => {
+    const { paused } = useContext(ExecutionStatusContext);
+
+    // eslint-disable-next-line no-nested-ternary
     return animated ? (
-        <Tooltip
-            hasArrow
-            borderRadius={8}
-            closeOnClick={false}
-            gutter={24}
-            label="This node is currently running..."
-            px={2}
-            textAlign="center"
-        >
-            <Center className="nodrag">
-                <Spinner size="xs" />
-            </Center>
-        </Tooltip>
+        paused ? (
+            <Tooltip
+                hasArrow
+                borderRadius={8}
+                closeOnClick={false}
+                gutter={24}
+                label="This node is currently paused"
+                px={2}
+                textAlign="center"
+            >
+                <Center className="nodrag">
+                    <Center
+                        bgColor="var(--node-valid-bg)"
+                        borderRadius={100}
+                        h="auto"
+                        w="auto"
+                    >
+                        <Icon
+                            as={IoIosPause}
+                            boxSize="1rem"
+                            color="var(--node-valid-fg)"
+                            cursor="default"
+                            m="auto"
+                        />
+                    </Center>
+                </Center>
+            </Tooltip>
+        ) : (
+            <Tooltip
+                hasArrow
+                borderRadius={8}
+                closeOnClick={false}
+                gutter={24}
+                label="This node is currently running..."
+                px={2}
+                textAlign="center"
+            >
+                <Center className="nodrag">
+                    <Spinner size="xs" />
+                </Center>
+            </Tooltip>
+        )
     ) : (
         <Tooltip
             hasArrow


### PR DESCRIPTION
The basic idea for this PR is quite simple: Python's `async def` are pausable functions, so why not use that for pausing?

This makes pausing very easy as function only have to call `await progress.suspend()`. The `suspend` method of the progress token will sleep until the executor is unpaused, and will throw an error if the executor was killed. I said, "executor", but a progress token is actually associated with a progress controller. This controller represents an operation that can be paused, resumed, and aborted (see `progress.py` for details). Executors simply own such a controller.

This makes the implementation of iterators easier as well. Since the iterator's `run` method itself is paused, we don't need the ugly `percent` parameter to resume progress anymore. This makes the code easier and is more efficient.

I also changed the backend API. Instead of implicitly resuming paused executors, `run` will now throw if another executor is currently present. To resume the current executor, a new `resume` end point was added. `run` also changed in that it will not return during pauses anymore. So `run` will only return after the executor finished, failed, or as killed/aborted. This actually makes the API easier to implement and use...

The frontend also changed. Aside from the necessary changes to accommodate the new backend API, I also changed how nodes animate. Nodes are not unanimated during pauses anymore. They stay animated the whole time, but the components displaying the animation check whether the chain is currently paused. I also added an icon to indicate currently paused nodes.

![image](https://user-images.githubusercontent.com/20878432/190913095-2d59f077-78a4-4d6b-b9f5-6ed90a9df8e8.png)

Going forward, we can now easily add support for pausing nodes mid processing as well. This will be especially useful for upscaling nodes. Using the new progress API, it should be easy to make all upscaling nodes pausable and abortable. Finally, we'll be able to abort upscaling tasks that take way too long.
However, this is something for later, so it won't be part of this PR.

---

Changes:
- Use new progress API to pause the executor and iterators.
- Display pause indicator for paused nodes.
- Fixed that the sprite sheet iterator couldn't be paused.
- Changed NodeFactory API. `create_node` is now called `get_node` and the `register` decorator is now correctly typed. The factory now assumes that all nodes have no mutable state (to enable caching). This is currently the case and has to be enforced going forward.
    This change has nothing to do with the async progress stuff. I was doing my rewrite when I thought that these changes are large enough to be their own PR.