### PR TITLE
Blend images optimizations

### DIFF
--- a/backend/src/nodes/image_util_nodes.py
+++ b/backend/src/nodes/image_util_nodes.py
@@ -68,51 +68,49 @@ class ImBlend(NodeBase):
 
         if (b_w, b_h) == (o_w, o_h):
             # we don't have to do any size adjustments
-            result = blend_images(ov, base, blend_mode)
-        else:
-            # Pad base image with transparency if necessary to match size with overlay
-            top = bottom = left = right = 0
-            if b_h < max_h:
-                top = (max_h - b_h) // 2
-                bottom = max_h - b_h - top
-            if b_w < max_w:
-                left = (max_w - b_w) // 2
-                right = max_w - b_w - left
-            if any((top, bottom, left, right)):
-                # copyMakeBorder will create black border if base not converted to RGBA first
-                base = convert_to_BGRA(base, b_c)
-                base = cv2.copyMakeBorder(
-                    base, top, bottom, left, right, cv2.BORDER_CONSTANT, value=0
-                )
-            else:  # Make sure cached image not being worked on regardless
-                base = base.copy()
+            return blend_images(ov, base, blend_mode)
 
-            # Center overlay
-            center_x = base.shape[1] // 2
-            center_y = base.shape[0] // 2
-            x_offset = center_x - (o_w // 2)
-            y_offset = center_y - (o_h // 2)
-
-            blended_img = blend_images(
-                ov,
-                base[y_offset : y_offset + o_h, x_offset : x_offset + o_w],
-                blend_mode,
+        # Pad base image with transparency if necessary to match size with overlay
+        top = bottom = left = right = 0
+        if b_h < max_h:
+            top = (max_h - b_h) // 2
+            bottom = max_h - b_h - top
+        if b_w < max_w:
+            left = (max_w - b_w) // 2
+            right = max_w - b_w - left
+        if any((top, bottom, left, right)):
+            # copyMakeBorder will create black border if base not converted to RGBA first
+            base = convert_to_BGRA(base, b_c)
+            base = cv2.copyMakeBorder(
+                base, top, bottom, left, right, cv2.BORDER_CONSTANT, value=0
             )
+        else:  # Make sure cached image not being worked on regardless
+            base = base.copy()
 
-            result = base  # Just so the names make sense
-            result_c = get_h_w_c(result)[2]
-            blend_c = get_h_w_c(blended_img)[2]
+        # Center overlay
+        center_x = base.shape[1] // 2
+        center_y = base.shape[0] // 2
+        x_offset = center_x - (o_w // 2)
+        y_offset = center_y - (o_h // 2)
 
-            # Have to ensure blend and result have same shape
-            if result_c < blend_c:
-                if blend_c == 4:
-                    result = convert_to_BGRA(result, result_c)
-                else:
-                    result = as_2d_grayscale(result)
-                    result = np.dstack((result, result, result))
-            result[y_offset : y_offset + o_h, x_offset : x_offset + o_w] = blended_img
+        blended_img = blend_images(
+            ov,
+            base[y_offset : y_offset + o_h, x_offset : x_offset + o_w],
+            blend_mode,
+        )
 
-        result = np.clip(result, 0, 1)
+        result = base  # Just so the names make sense
+        result_c = get_h_w_c(result)[2]
+        blend_c = get_h_w_c(blended_img)[2]
+
+        # Have to ensure blend and result have same shape
+        if result_c < blend_c:
+            if blend_c == 4:
+                result = convert_to_BGRA(result, result_c)
+            else:
+                result = as_2d_grayscale(result)
+                result = np.dstack((result, result, result))
+        result[y_offset : y_offset + o_h, x_offset : x_offset + o_w] = blended_img
 
         return result
 

--- a/backend/src/nodes/utils/blend_modes.py
+++ b/backend/src/nodes/utils/blend_modes.py
@@ -25,6 +25,35 @@ class BlendModes:
     SOFT_LIGHT = 17
 
 
+__normalized = {
+    BlendModes.NORMAL: True,
+    BlendModes.MULTIPLY: True,
+    BlendModes.DARKEN: True,
+    BlendModes.LIGHTEN: True,
+    BlendModes.ADD: False,
+    BlendModes.COLOR_BURN: False,
+    BlendModes.COLOR_DODGE: False,
+    BlendModes.REFLECT: False,
+    BlendModes.GLOW: False,
+    BlendModes.OVERLAY: True,
+    BlendModes.DIFFERENCE: True,
+    BlendModes.NEGATION: True,
+    BlendModes.SCREEN: True,
+    BlendModes.XOR: True,
+    BlendModes.SUBTRACT: False,
+    BlendModes.DIVIDE: False,
+    BlendModes.EXCLUSION: True,
+    BlendModes.SOFT_LIGHT: True,
+}
+
+
+def blend_mode_normalized(blend_mode: int) -> bool:
+    """
+    Returns whether the given blend mode is guaranteed to produce normalized results (value between 0 and 1).
+    """
+    return __normalized.get(blend_mode, False)
+
+
 class ImageBlender:
     """Class for compositing images using different blending modes."""
 

--- a/backend/src/nodes/utils/image_utils.py
+++ b/backend/src/nodes/utils/image_utils.py
@@ -5,7 +5,7 @@ import cv2
 import numpy as np
 from sanic.log import logger
 
-from .blend_modes import ImageBlender
+from .blend_modes import ImageBlender, blend_mode_normalized
 from .utils import get_h_w_c
 
 
@@ -216,7 +216,9 @@ def blend_images(overlay: np.ndarray, base: np.ndarray, blend_mode: int):
     """
     Changes the given image to the background overlayed with the image.
 
-    The 2 given images must be the same size.
+    The 2 given images must be the same size and their values must be between 0 and 1.
+
+    The returned image is guaranteed to have values between 0 and 1.
 
     If the 2 given images have a different number of channels, then the returned image
     will have maximum of the two.
@@ -234,17 +236,39 @@ def blend_images(overlay: np.ndarray, base: np.ndarray, blend_mode: int):
         sane = c in (1, 3, 4)
         assert sane, f"The {name} has to be a grayscale, RGB, or RGBA image"
 
-    assert_sane(o_shape[2], "overlay layer")
-    assert_sane(b_shape[2], "base layer")
+    o_channels = o_shape[2]
+    b_channels = b_shape[2]
+
+    assert_sane(o_channels, "overlay layer")
+    assert_sane(b_channels, "base layer")
 
     blender = ImageBlender()
-    target_c = max(o_shape[2], b_shape[2])
+    target_c = max(o_channels, b_channels)
+    needs_clipping = not blend_mode_normalized(blend_mode)
+
+    if target_c == 4 and b_channels < 4:
+        base = as_target_channels(base, 3)
+
+        # The general algorithm below can be optimized because we know that b_a is 1
+        o_a = np.dstack((overlay[:, :, 3],) * 3)
+        o_rgb = overlay[:, :, :3]
+
+        blend_rgb = blender.apply_blend(o_rgb, base, blend_mode)
+        final_rgb = o_a * blend_rgb + (1 - o_a) * base
+        if needs_clipping:
+            final_rgb = np.clip(final_rgb, 0, 1)
+
+        return as_target_channels(final_rgb, 4)
+
     overlay = as_target_channels(overlay, target_c)
     base = as_target_channels(base, target_c)
 
     if target_c in (1, 3):
         # We don't need to do any alpha blending, so the images can blended directly
-        return blender.apply_blend(overlay, base, blend_mode)
+        result = blender.apply_blend(overlay, base, blend_mode)
+        if needs_clipping:
+            result = np.clip(result, 0, 1)
+        return result
 
     # do the alpha blending for RGBA
     o_a = overlay[:, :, 3]
@@ -266,8 +290,12 @@ def blend_images(overlay: np.ndarray, base: np.ndarray, blend_mode: int):
         + (np.dstack((blend_strength,) * 3) * blend_rgb)
     )
     final_rgb /= np.maximum(np.dstack((final_a,) * 3), 0.0001)  # type: ignore
+    final_rgb = np.clip(final_rgb, 0, 1)
 
-    return np.concatenate([final_rgb, np.expand_dims(final_a, axis=2)], axis=2)
+    result = np.concatenate([final_rgb, np.expand_dims(final_a, axis=2)], axis=2)
+    if needs_clipping:
+        result = np.clip(result, 0, 1)
+    return result
 
 
 def calculate_ssim(img1: np.ndarray, img2: np.ndarray) -> float:


### PR DESCRIPTION
This addresses the performance problems [mentioned here](https://github.com/joeyballentine/chaiNNer/issues/984#issuecomment-1250332852).

This PR includes 2 optimizations:
1. Clipping. Most blend mode always produce normalized images (values between 0 and 1). We don't need to call `np.clip` for those blend modes, which is a quite expensive function, as it turns out. In my tests, this saves about 140ms.
2. RGB base. If the base image is an RGB image, then the alpha blending becomes A LOT simpler. In my tests, this saves about 240ms.

In my tests, these 2 optimization together reduced the time it took to blend an RGB base image with an RGBA overlay of the same size from 500ms to 120ms. That's 4x faster.

I also changed the guarantees of the `blend_images` function. It now guarantees to return a normalized image. This not only enables the clipping optimization, it also makes for a cleaner API.