### PR TITLE
Executor rewrite

### DIFF
--- a/backend/src/base_types.py
+++ b/backend/src/base_types.py
@@ -1,0 +1,5 @@
+from typing import NewType
+
+NodeId = NewType("NodeId", str)
+InputId = NewType("InputId", int)
+OutputId = NewType("OutputId", int)

--- a/backend/src/chain/cache.py
+++ b/backend/src/chain/cache.py
@@ -1,0 +1,109 @@
+from typing import Any, Dict, Iterable, Optional, Set
+import gc
+from sanic.log import logger
+
+from .chain import NodeId, Chain
+
+
+class CacheStrategy:
+    STATIC_HITS_TO_LIVE = 1_000_000_000
+
+    def __init__(self, hits_to_live: int) -> None:
+        assert hits_to_live >= 0
+        self.hits_to_live = hits_to_live
+
+    @property
+    def static(self) -> bool:
+        return self.hits_to_live == CacheStrategy.STATIC_HITS_TO_LIVE
+
+    @property
+    def no_caching(self) -> bool:
+        return self.hits_to_live == 0
+
+
+StaticCaching = CacheStrategy(CacheStrategy.STATIC_HITS_TO_LIVE)
+"""The value is cached for the during of the execution of the chain."""
+
+
+def get_cache_strategies(chain: Chain) -> Dict[NodeId, CacheStrategy]:
+    """Create a map with the cache strategies for all nodes in the given chain."""
+
+    result: Dict[NodeId, CacheStrategy] = {}
+
+    for node in chain.nodes.values():
+        out_edges = chain.edges_from(node.id)
+        connected_to_child_node = any(
+            chain.nodes[e.target.id].parent for e in out_edges
+        )
+
+        strategy: CacheStrategy
+        if node.parent is None and connected_to_child_node:
+            # free nodes that are connected to child nodes need to live as the execution
+            strategy = StaticCaching
+        else:
+            strategy = CacheStrategy(len(out_edges))
+
+        result[node.id] = strategy
+
+    return result
+
+
+class _CacheEntry:
+    def __init__(self, value: Any, hits_to_live: int):
+        assert hits_to_live > 0
+        self.value = value
+        self.hits_to_live = hits_to_live
+
+
+class OutputCache:
+    def __init__(
+        self,
+        parent: Optional["OutputCache"] = None,
+        static_data: Optional[Dict[NodeId, Any]] = None,
+    ):
+        super().__init__()
+        self.__static: Dict[NodeId, Any] = static_data.copy() if static_data else {}
+        self.__counted: Dict[NodeId, _CacheEntry] = {}
+        self.parent: Optional[OutputCache] = parent
+
+    def keys(self) -> Iterable[NodeId]:
+        keys: Set[NodeId] = set()
+        keys.union(self.__static.keys(), self.__counted.keys())
+        if self.parent:
+            keys.union(self.parent.keys())
+        return keys
+
+    def has(self, node_id: NodeId) -> bool:
+        if node_id in self.__static or node_id in self.__counted:
+            return True
+        if self.parent:
+            return self.parent.has(node_id)
+        return False
+
+    def get(self, node_id: NodeId) -> Optional[Any]:
+        staticValue = self.__static.get(node_id, None)
+        if staticValue is not None:
+            return staticValue
+
+        counted = self.__counted.get(node_id, None)
+        if counted is not None:
+            value = counted.value
+            counted.hits_to_live -= 0
+            if counted.hits_to_live <= 0:
+                logger.debug(f"Hits to live reached 0 for {node_id}")
+                del self.__counted[node_id]
+                gc.collect()
+            return value
+
+        if self.parent is not None:
+            return self.parent.get(node_id)
+
+        return None
+
+    def set(self, node_id: NodeId, value: Any, strategy: CacheStrategy):
+        if strategy.no_caching:
+            return
+        elif strategy.static:
+            self.__static[node_id] = value
+        else:
+            self.__counted[node_id] = _CacheEntry(value, strategy.hits_to_live)

--- a/backend/src/chain/chain.py
+++ b/backend/src/chain/chain.py
@@ -1,0 +1,119 @@
+from typing import Callable, Dict, List, TypeVar, Union
+
+from base_types import NodeId, OutputId, InputId
+from nodes.node_base import NodeBase, IteratorNodeBase
+from nodes.node_factory import NodeFactory
+
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+def get_or_add(d: Dict[K, V], key: K, supplier: Callable[[], V]) -> V:
+    value = d.get(key)
+    if value is None:
+        value = supplier()
+        d[key] = value
+    return value
+
+
+class FunctionNode:
+    def __init__(self, node_id: NodeId, schema_id: str):
+        self.id: NodeId = node_id
+        self.schema_id: str = schema_id
+        self.parent: Union[NodeId, None] = None
+        self.is_helper: bool = False
+
+    def get_node(self) -> NodeBase:
+        return NodeFactory.get_node(self.schema_id)
+
+    def has_side_effects(self) -> bool:
+        return self.get_node().side_effects
+
+
+class IteratorNode:
+    def __init__(self, node_id: NodeId, schema_id: str):
+        self.id: NodeId = node_id
+        self.schema_id: str = schema_id
+        self.parent: None = None
+        self.__node = None
+
+    def get_node(self) -> IteratorNodeBase:
+        if self.__node is None:
+            node = NodeFactory.get_node(self.schema_id)
+            assert isinstance(node, IteratorNodeBase), "Invalid iterator node"
+            self.__node = node
+        return self.__node
+
+
+Node = Union[FunctionNode, IteratorNode]
+
+
+class EdgeSource:
+    def __init__(self, node_id: NodeId, output_id: OutputId):
+        self.id: NodeId = node_id
+        self.output_id: OutputId = output_id
+
+
+class EdgeTarget:
+    def __init__(self, node_id: NodeId, input_id: InputId):
+        self.id: NodeId = node_id
+        self.input_id: InputId = input_id
+
+
+class Edge:
+    def __init__(self, source: EdgeSource, target: EdgeTarget):
+        self.source = source
+        self.target = target
+
+
+class Chain:
+    def __init__(self):
+        self.nodes: Dict[NodeId, Node] = {}
+        self.__edges_by_source: Dict[NodeId, List[Edge]] = {}
+        self.__edges_by_target: Dict[NodeId, List[Edge]] = {}
+
+    def add_node(self, node: Node):
+        assert node.id not in self.nodes, f"Duplicate node id {node.id}"
+        self.nodes[node.id] = node
+
+    def add_edge(self, edge: Edge):
+        get_or_add(self.__edges_by_source, edge.source.id, list).append(edge)
+        get_or_add(self.__edges_by_target, edge.target.id, list).append(edge)
+
+    def edges_from(self, source: NodeId) -> List[Edge]:
+        return self.__edges_by_source.get(source, [])
+
+    def edges_to(self, target: NodeId) -> List[Edge]:
+        return self.__edges_by_target.get(target, [])
+
+    def remove_node(self, node_id: NodeId):
+        """
+        Removes the node with the given id.
+        If the node is an iterator node, then all of its children will also be removed.
+        """
+
+        node = self.nodes.pop(node_id, None)
+        if node is None:
+            return
+
+        for e in self.__edges_by_source.pop(node_id, []):
+            self.__edges_by_target[e.target.id].remove(e)
+        for e in self.__edges_by_target.pop(node_id, []):
+            self.__edges_by_source[e.source.id].remove(e)
+
+        if isinstance(node, IteratorNode):
+            # remove all child nodes
+            for n in list(self.nodes.values()):
+                if n.parent == node_id:
+                    self.remove_node(n.id)
+
+
+class SubChain:
+    def __init__(self, chain: Chain, iterator_id: NodeId):
+        self.nodes: Dict[NodeId, FunctionNode] = {}
+        self.iterator_id = iterator_id
+
+        for node in chain.nodes.values():
+            if node.parent is not None and node.parent == iterator_id:
+                self.nodes[node.id] = node

--- a/backend/src/chain/input.py
+++ b/backend/src/chain/input.py
@@ -1,0 +1,47 @@
+from typing import Any, Dict, List, Optional, Union
+
+from base_types import NodeId
+
+
+class EdgeInput:
+    def __init__(self, node_id: NodeId, index: int) -> None:
+        self.id = node_id
+        self.index = index
+
+
+class ValueInput:
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+
+Input = Union[EdgeInput, ValueInput]
+
+
+class InputMap:
+    def __init__(self, parent: Optional["InputMap"] = None) -> None:
+        self.__data: Dict[NodeId, List[Input]] = {}
+        self.parent: Optional[InputMap] = parent
+
+    def get(self, node_id: NodeId) -> List[Input]:
+        values = self.__data.get(node_id, None)
+        if values is not None:
+            return values
+
+        if self.parent:
+            return self.parent.get(node_id)
+
+        assert False, f"Unknown node id {node_id}"
+
+    def set(self, node_id: NodeId, values: List[Input]):
+        self.__data[node_id] = values
+
+    def set_values(self, node_id: NodeId, values: List[Any]):
+        self.__data[node_id] = [ValueInput(x) for x in values]
+
+    def set_append(self, node_id: NodeId, values: List[Input]):
+        inputs = [*self.get(node_id), *values]
+        self.set(node_id, inputs)
+
+    def set_append_values(self, node_id: NodeId, values: List[Any]):
+        inputs = [*self.get(node_id), *[ValueInput(x) for x in values]]
+        self.set(node_id, inputs)

--- a/backend/src/chain/json.py
+++ b/backend/src/chain/json.py
@@ -1,0 +1,82 @@
+from typing import Any, List, Literal, Optional, Tuple, TypedDict, Union
+
+from base_types import NodeId
+
+from .chain import Chain, IteratorNode, FunctionNode, Edge, EdgeSource, EdgeTarget
+from .input import InputMap, EdgeInput, ValueInput, Input
+
+
+class JsonEdgeInput(TypedDict):
+    type: Literal["edge"]
+    id: NodeId
+    index: int
+
+
+class JsonValueInput(TypedDict):
+    type: Literal["value"]
+    value: Any
+
+
+JsonInput = Union[JsonEdgeInput, JsonValueInput]
+
+
+class JsonNode(TypedDict):
+    id: NodeId
+    schemaId: str
+    inputs: List[JsonInput]
+    parent: Optional[NodeId]
+    nodeType: str
+
+
+class IndexEdge:
+    def __init__(
+        self, from_id: NodeId, from_index: int, to_id: NodeId, to_index: int
+    ) -> None:
+        self.from_id = from_id
+        self.from_index = from_index
+        self.to_id = to_id
+        self.to_index = to_index
+
+
+def parse_json(json: List[JsonNode]) -> Tuple[Chain, InputMap]:
+    chain = Chain()
+    input_map = InputMap()
+
+    index_edges: List[IndexEdge] = []
+
+    for json_node in json:
+        if json_node["nodeType"] == "iterator":
+            node = IteratorNode(json_node["id"], json_node["schemaId"])
+        else:
+            node = FunctionNode(json_node["id"], json_node["schemaId"])
+            node.parent = json_node["parent"]
+            node.is_helper = json_node["nodeType"] == "iteratorHelper"
+        chain.add_node(node)
+
+        inputs: List[Input] = []
+        for index, i in enumerate(json_node["inputs"]):
+            if i["type"] == "edge":
+                inputs.append(EdgeInput(i["id"], i["index"]))
+                index_edges.append(IndexEdge(i["id"], i["index"], node.id, index))
+            else:
+                inputs.append(ValueInput(i["value"]))
+        input_map.set(node.id, inputs)
+
+    for index_edge in index_edges:
+        source_node = chain.nodes[index_edge.from_id].get_node()
+        target_node = chain.nodes[index_edge.to_id].get_node()
+
+        chain.add_edge(
+            Edge(
+                EdgeSource(
+                    index_edge.from_id,
+                    source_node.outputs[index_edge.from_index].id,
+                ),
+                EdgeTarget(
+                    index_edge.to_id,
+                    target_node.inputs[index_edge.to_index].id,
+                ),
+            )
+        )
+
+    return chain, input_map

--- a/backend/src/chain/optimize.py
+++ b/backend/src/chain/optimize.py
@@ -1,0 +1,59 @@
+from sanic.log import logger
+from .chain import Chain, IteratorNode, Node, EdgeSource
+
+
+def __has_side_effects(node: Node) -> bool:
+    if isinstance(node, IteratorNode) or node.is_helper:
+        # we assume that both iterators and their helper nodes always have side effects
+        return True
+    return node.has_side_effects()
+
+
+def __outline_child_nodes(chain: Chain) -> bool:
+    """
+    If a child node of an iterator is not downstream of any iterator helper node,
+    then this child node can be lifted out of the iterator (outlined) to be a free node.
+    """
+    changed = False
+
+    for node in chain.nodes.values():
+        # we try to outline child nodes that are not iterator helper nodes
+        if node.parent is not None and not node.is_helper:
+
+            def has_no_parent(source: EdgeSource) -> bool:
+                n = chain.nodes.get(source.id)
+                assert n is not None
+                return n.parent is None
+
+            # we can only outline if all of its inputs are independent of the iterator
+            can_outline = all(has_no_parent(n.source) for n in chain.edges_to(node.id))
+            if can_outline:
+                node.parent = None
+                changed = True
+                logger.info(
+                    f"Chain optimization: Outlined {node.schema_id} node {node.id}"
+                )
+
+    return changed
+
+
+def __removed_dead_nodes(chain: Chain) -> bool:
+    """
+    If a node does not have side effects and has no downstream nodes, then it can be removed.
+    """
+    changed = False
+
+    for node in list(chain.nodes.values()):
+        is_dead = len(chain.edges_from(node.id)) == 0 and not __has_side_effects(node)
+        if is_dead:
+            chain.remove_node(node.id)
+            changed = True
+            logger.info(f"Chain optimization: Removed {node.schema_id} node {node.id}")
+
+    return changed
+
+
+def optimize(chain: Chain):
+    changed = True
+    while changed:
+        changed = __removed_dead_nodes(chain) or __outline_child_nodes(chain)

--- a/backend/src/events.py
+++ b/backend/src/events.py
@@ -9,6 +9,8 @@ from typing import (
     Union,
 )
 
+from base_types import NodeId, InputId, OutputId
+
 
 class FinishData(TypedDict):
     message: str
@@ -20,11 +22,11 @@ class ImageInputInfo(TypedDict):
     channels: int
 
 
-InputsDict = Dict[int, Union[str, int, float, ImageInputInfo, None]]
+InputsDict = Dict[InputId, Union[str, int, float, ImageInputInfo, None]]
 
 
 class ExecutionErrorSource(TypedDict):
-    nodeId: str
+    nodeId: NodeId
     schemaId: str
     inputs: InputsDict
 
@@ -36,16 +38,16 @@ class ExecutionErrorData(TypedDict):
 
 
 class NodeFinishData(TypedDict):
-    finished: List[str]
-    nodeId: str
+    finished: List[NodeId]
+    nodeId: NodeId
     executionTime: Optional[float]
-    data: Optional[Dict[int, Any]]
+    data: Optional[Dict[OutputId, Any]]
 
 
 class IteratorProgressUpdateData(TypedDict):
     percent: float
-    iteratorId: str
-    running: Optional[List[str]]
+    iteratorId: NodeId
+    running: Optional[List[NodeId]]
 
 
 class FinishEvent(TypedDict):

--- a/backend/src/nodes/image_iterator_nodes.py
+++ b/backend/src/nodes/image_iterator_nodes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 import numpy as np
-from process import ExecutionContext
+from process import IteratorContext
 from sanic.log import logger
 
 from .categories import ImageCategory
@@ -77,20 +77,10 @@ class ImageFileIteratorNode(IteratorNodeBase):
         ]
 
     # pylint: disable=invalid-overridden-method
-    async def run(self, directory: str, context: ExecutionContext) -> None:
+    async def run(self, directory: str, context: IteratorContext) -> None:
         logger.info(f"Iterating over images in directory: {directory}")
-        logger.info(context.nodes)
 
-        img_path_node_id = None
-        child_nodes: List[str] = []
-        for k, v in context.nodes.items():
-            if v["schemaId"] == IMAGE_ITERATOR_NODE_ID:
-                img_path_node_id = v["id"]
-            if context.nodes[k]["child"]:
-                child_nodes.append(v["id"])
-            # Set this to false to actually allow processing to happen
-            context.nodes[k]["child"] = False
-        assert img_path_node_id is not None, "Unable to find image iterator helper node"
+        img_path_node_id = context.get_helper(IMAGE_ITERATOR_NODE_ID).id
 
         supported_filetypes = get_available_image_formats()
 
@@ -114,35 +104,13 @@ class ImageFileIteratorNode(IteratorNodeBase):
         file_len = len(just_image_files)
         errors = []
         for idx, filepath in enumerate(just_image_files):
-            await context.progress.suspend()
-            await context.queue.put(
-                {
-                    "event": "iterator-progress-update",
-                    "data": {
-                        "percent": idx / file_len,
-                        "iteratorId": context.iterator_id,
-                        "running": child_nodes,
-                    },
-                }
-            )
             # Replace the input filepath with the filepath from the loop
-            context.nodes[img_path_node_id]["inputs"] = [filepath, directory, idx]
-            executor = context.create_iterator_executor()
+            context.inputs.set_values(img_path_node_id, [filepath, directory, idx])
             try:
-                await executor.run()
+                await context.run_iteration(idx, file_len)
             except Exception as e:
                 logger.error(e)
                 errors.append(str(e))
-            await context.queue.put(
-                {
-                    "event": "iterator-progress-update",
-                    "data": {
-                        "percent": (idx + 1) / file_len,
-                        "iteratorId": context.iterator_id,
-                        "running": None,
-                    },
-                }
-            )
 
         if len(errors) > 0:
             raise Exception(
@@ -261,24 +229,11 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
         self.icon = "MdVideoCameraBack"
 
     # pylint: disable=invalid-overridden-method
-    async def run(self, path: str, context: ExecutionContext) -> None:
+    async def run(self, path: str, context: IteratorContext) -> None:
         logger.info(f"Iterating over frames in video file: {path}")
-        logger.info(context.nodes)
 
-        input_node_id = None
-        output_node_id = None
-        child_nodes: List[str] = []
-        for k, v in context.nodes.items():
-            if v["schemaId"] == VIDEO_ITERATOR_INPUT_NODE_ID:
-                input_node_id = v["id"]
-            elif v["schemaId"] == VIDEO_ITERATOR_OUTPUT_NODE_ID:
-                output_node_id = v["id"]
-            if context.nodes[k]["child"]:
-                child_nodes.append(v["id"])
-            # Set this to false to actually allow processing to happen
-            context.nodes[k]["child"] = False
-        assert input_node_id is not None, "Unable to find video frame load helper node"
-        assert output_node_id is not None, "Unable to find video frame save helper node"
+        input_node_id = context.get_helper(VIDEO_ITERATOR_INPUT_NODE_ID).id
+        output_node_id = context.get_helper(VIDEO_ITERATOR_OUTPUT_NODE_ID).id
 
         # TODO: Open Video Buffer
         cap = cv2.VideoCapture(path)
@@ -287,7 +242,7 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
         try:
             fps = float(cap.get(cv2.CAP_PROP_FPS))
             frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-            context.nodes[output_node_id]["inputs"].extend((writer, fps))
+            context.inputs.set_append_values(output_node_id, [writer, fps])
             errors = []
             for idx in range(frame_count):
                 await context.progress.suspend()
@@ -298,33 +253,12 @@ class SimpleVideoFrameIteratorNode(IteratorNodeBase):
                     print("Can't receive frame (stream end?). Exiting ...")
                     break
 
-                await context.queue.put(
-                    {
-                        "event": "iterator-progress-update",
-                        "data": {
-                            "percent": idx / frame_count,
-                            "iteratorId": context.iterator_id,
-                            "running": child_nodes,
-                        },
-                    }
-                )
-                context.nodes[input_node_id]["inputs"] = [frame, idx]
-                executor = context.create_iterator_executor()
+                context.inputs.set_values(input_node_id, [frame, idx])
                 try:
-                    await executor.run()
+                    await context.run_iteration(idx, frame_count)
                 except Exception as e:
                     logger.error(e)
                     errors.append(str(e))
-                await context.queue.put(
-                    {
-                        "event": "iterator-progress-update",
-                        "data": {
-                            "percent": (idx + 1) / frame_count,
-                            "iteratorId": context.iterator_id,
-                            "running": None,
-                        },
-                    }
-                )
 
             if len(errors) > 0:
                 raise Exception(
@@ -420,7 +354,7 @@ class ImageSpriteSheetIteratorNode(IteratorNodeBase):
         sprite_sheet: np.ndarray,
         rows: int,
         columns: int,
-        context: ExecutionContext,
+        context: IteratorContext,
     ) -> np.ndarray:
         h, w, _ = get_h_w_c(sprite_sheet)
         assert (
@@ -430,24 +364,8 @@ class ImageSpriteSheetIteratorNode(IteratorNodeBase):
             w % columns == 0
         ), "Width of sprite sheet must be a multiple of the number of columns"
 
-        img_loader_node_id = None
-        output_node_id = None
-        child_nodes: List[str] = []
-        for k, v in context.nodes.items():
-            if v["schemaId"] == SPRITESHEET_ITERATOR_INPUT_NODE_ID:
-                img_loader_node_id = v["id"]
-            elif v["schemaId"] == SPRITESHEET_ITERATOR_OUTPUT_NODE_ID:
-                output_node_id = v["id"]
-            if context.nodes[k]["child"]:
-                child_nodes.append(v["id"])
-            # Set this to false to actually allow processing to happen
-            context.nodes[k]["child"] = False
-        assert (
-            img_loader_node_id is not None
-        ), "Unable to find sprite sheet load helper node"
-        assert (
-            output_node_id is not None
-        ), "Unable to find sprite sheet append helper node"
+        img_loader_node_id = context.get_helper(SPRITESHEET_ITERATOR_INPUT_NODE_ID).id
+        output_node_id = context.get_helper(SPRITESHEET_ITERATOR_OUTPUT_NODE_ID).id
 
         individual_h = h // rows
         individual_w = w // columns
@@ -467,39 +385,16 @@ class ImageSpriteSheetIteratorNode(IteratorNodeBase):
         length = len(img_list)
 
         results = []
-        context.nodes[output_node_id]["inputs"].append(results)
+        context.inputs.set_append_values(output_node_id, [results])
         errors = []
         for idx, img in enumerate(img_list):
-            await context.progress.suspend()
-            await context.queue.put(
-                {
-                    "event": "iterator-progress-update",
-                    "data": {
-                        "percent": idx / length,
-                        "iteratorId": context.iterator_id,
-                        "running": child_nodes,
-                    },
-                }
-            )
             # Replace the input filepath with the filepath from the loop
-            context.nodes[img_loader_node_id]["inputs"] = [img, idx]
-            # logger.info(nodes[output_node_id]["inputs"])
-            executor = context.create_iterator_executor()
+            context.inputs.set_values(img_loader_node_id, [img, idx])
             try:
-                await executor.run()
+                await context.run_iteration(idx, length)
             except Exception as e:
                 logger.error(e)
                 errors.append(str(e))
-            await context.queue.put(
-                {
-                    "event": "iterator-progress-update",
-                    "data": {
-                        "percent": (idx + 1) / length,
-                        "iteratorId": context.iterator_id,
-                        "running": None,
-                    },
-                }
-            )
         result_rows = []
         for i in range(rows):
             row = np.concatenate(results[i * columns : (i + 1) * columns], axis=1)

--- a/backend/src/nodes/model_save_nodes.py
+++ b/backend/src/nodes/model_save_nodes.py
@@ -33,9 +33,7 @@ class OnnxSaveModelNode(NodeBase):
 
         self.side_effects = True
 
-    def run(
-        self, model: OnnxModel, directory: str, model_name: str
-    ) -> None:
+    def run(self, model: OnnxModel, directory: str, model_name: str) -> None:
         full_path = f"{os.path.join(directory, model_name)}.onnx"
         logger.info(f"Writing file to path: {full_path}")
         with open(full_path, "wb") as f:

--- a/backend/src/nodes/node_base.py
+++ b/backend/src/nodes/node_base.py
@@ -1,16 +1,12 @@
 from abc import ABCMeta, abstractmethod
-from typing import Any, List, Literal, Union
+from typing import Any, List, Literal
+
+from base_types import InputId, OutputId
 
 from .categories import Category
 
 from .properties.inputs.base_input import BaseInput
 from .properties.outputs.base_output import BaseOutput
-
-
-def assign_implicit_ids(l: Union[List[BaseInput], List[BaseOutput]]):
-    for i, inout in enumerate(l):
-        if inout.id is None:
-            inout.id = i
 
 
 NodeType = Literal["regularNode", "iterator", "iteratorHelper"]
@@ -20,8 +16,8 @@ class NodeBase(metaclass=ABCMeta):
     """Base class for a node"""
 
     def __init__(self):
-        self.inputs: List[BaseInput] = []
-        self.outputs: List[BaseOutput] = []
+        self.__inputs: List[BaseInput] = []
+        self.__outputs: List[BaseOutput] = []
         self.description: str = ""
 
         self.category: Category = Category(
@@ -35,20 +31,32 @@ class NodeBase(metaclass=ABCMeta):
         self.side_effects: bool = False
         self.deprecated: bool = False
 
+    @property
+    def inputs(self) -> List[BaseInput]:
+        return self.__inputs
+
+    @inputs.setter
+    def inputs(self, value: List[BaseInput]):
+        for i, input_value in enumerate(value):
+            if input_value.id == -1:
+                input_value.id = InputId(i)
+        self.__inputs = value
+
+    @property
+    def outputs(self) -> List[BaseOutput]:
+        return self.__outputs
+
+    @outputs.setter
+    def outputs(self, value: List[BaseOutput]):
+        for i, output_value in enumerate(value):
+            if output_value.id == -1:
+                output_value.id = OutputId(i)
+        self.__outputs = value
+
     @abstractmethod
     def run(self) -> Any:
         """Abstract method to run a node's logic"""
         return
-
-    def get_inputs(self, with_implicit_ids=False):
-        if with_implicit_ids:
-            assign_implicit_ids(self.inputs)
-        return self.inputs
-
-    def get_outputs(self, with_implicit_ids=False):
-        if with_implicit_ids:
-            assign_implicit_ids(self.outputs)
-        return self.outputs
 
 
 # pylint: disable=abstract-method

--- a/backend/src/nodes/properties/inputs/base_input.py
+++ b/backend/src/nodes/properties/inputs/base_input.py
@@ -1,4 +1,5 @@
 from typing import Union, Literal
+from base_types import InputId
 from .. import expression
 
 InputKind = Literal[
@@ -27,7 +28,7 @@ class BaseInput:
         self.label: str = label
         self.optional: bool = False
         self.has_handle: bool = has_handle
-        self.id: Union[int, None] = None
+        self.id: InputId = InputId(-1)
 
     # This is the method that should be created by each input
     def enforce(self, value):
@@ -56,8 +57,8 @@ class BaseInput:
             "hasHandle": self.has_handle,
         }
 
-    def with_id(self, input_id: int):
-        self.id = input_id
+    def with_id(self, input_id: Union[InputId, int]):
+        self.id = InputId(input_id)
         return self
 
     def make_optional(self):

--- a/backend/src/nodes/properties/outputs/base_output.py
+++ b/backend/src/nodes/properties/outputs/base_output.py
@@ -1,4 +1,5 @@
 from typing import Union, Literal
+from base_types import OutputId
 from .. import expression
 
 OutputKind = Literal["image", "large-image", "text", "directory", "pytorch", "generic"]
@@ -14,7 +15,7 @@ class BaseOutput:
     ):
         self.output_type: expression.ExpressionJson = output_type
         self.label: str = label
-        self.id = None
+        self.id: OutputId = OutputId(-1)
         self.never_reason: Union[str, None] = None
         self.kind: OutputKind = kind
         self.has_handle: bool = has_handle
@@ -29,8 +30,8 @@ class BaseOutput:
             "hasHandle": self.has_handle,
         }
 
-    def with_id(self, output_id: int):
-        self.id = output_id
+    def with_id(self, output_id: Union[OutputId, int]):
+        self.id = OutputId(output_id)
         return self
 
     def with_never_reason(self, reason: str):

--- a/backend/src/process.py
+++ b/backend/src/process.py
@@ -6,79 +6,93 @@ import functools
 import gc
 import uuid
 import time
+from typing import Any, Callable, Dict, List, Optional, Tuple
 import numpy as np
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict
 
 from sanic.log import logger
-from progress import ProgressToken
+from progress import ProgressToken, Aborted, ProgressController
 from events import EventQueue, Event, InputsDict
+from base_types import NodeId, OutputId
+
+from chain.chain import Chain, Node, FunctionNode, IteratorNode, SubChain
+from chain.cache import OutputCache, CacheStrategy, get_cache_strategies
+from chain.input import InputMap, EdgeInput
 
 from nodes.node_base import NodeBase
-from nodes.node_factory import NodeFactory
 from nodes.utils.image_utils import get_h_w_c
-from progress import Aborted, ProgressController
-
-
-class CacheOptions(TypedDict):
-    shouldCache: bool
-    maxCacheHits: int
-    clearImmediately: bool
-
-
-class UsableData(TypedDict):
-    id: str
-    schemaId: str
-    inputs: list
-    child: bool
-    children: List[str]
-    nodeType: str
-    hasSideEffects: bool
-    cacheOptions: CacheOptions
 
 
 class NodeExecutionError(Exception):
     def __init__(
         self,
-        node: UsableData,
+        node: Node,
         cause: str,
         inputs: InputsDict,
     ):
         super().__init__(cause)
-        self.node: UsableData = node
+        self.node: Node = node
         self.inputs: InputsDict = inputs
 
 
-class ExecutionContext:
+class IteratorContext:
     def __init__(
         self,
-        nodes: Dict[str, UsableData],
-        loop: asyncio.AbstractEventLoop,
-        queue: EventQueue,
-        pool: ThreadPoolExecutor,
-        cache: Dict[str, Any],
-        iterator_id: str,
         executor: Executor,
+        iterator_id: NodeId,
     ):
-        self.nodes: Dict[str, UsableData] = nodes
-
-        self.loop: asyncio.AbstractEventLoop = loop
-        self.queue: EventQueue = queue
-        self.pool: ThreadPoolExecutor = pool
-
-        self.cache: Dict[str, Any] = cache
-        self.iterator_id: str = iterator_id
         self.executor: Executor = executor
         self.progress: ProgressToken = executor.progress
 
-    def create_iterator_executor(self) -> Executor:
+        self.iterator_id: NodeId = iterator_id
+        self.chain = SubChain(executor.chain, iterator_id)
+        self.inputs = InputMap(parent=executor.inputs)
+
+    def get_helper(self, schema_id: str) -> FunctionNode:
+        for node in self.chain.nodes.values():
+            if node.schema_id == schema_id:
+                return node
+        assert (
+            False
+        ), f"Unable to find {schema_id} helper node for iterator {self.iterator_id}"
+
+    def __create_iterator_executor(self) -> Executor:
         return Executor(
-            self.nodes,
-            self.loop,
-            self.queue,
-            self.pool,
-            self.cache.copy(),
-            self.executor,
+            self.executor.chain,
+            self.inputs,
+            self.executor.loop,
+            self.executor.queue,
+            self.executor.pool,
+            parent_executor=self.executor,
         )
+
+    async def run_iteration(self, index: int, total: int):
+        executor = self.__create_iterator_executor()
+
+        await self.progress.suspend()
+        await self.executor.queue.put(
+            {
+                "event": "iterator-progress-update",
+                "data": {
+                    "percent": index / total,
+                    "iteratorId": self.iterator_id,
+                    "running": list(self.chain.nodes.keys()),
+                },
+            }
+        )
+
+        try:
+            await executor.run_iteration(self.chain)
+        finally:
+            await self.executor.queue.put(
+                {
+                    "event": "iterator-progress-update",
+                    "data": {
+                        "percent": (index + 1) / total,
+                        "iteratorId": self.iterator_id,
+                        "running": None,
+                    },
+                }
+            )
 
 
 def timed_supplier(supplier: Callable[[], Any]) -> Callable[[], Tuple[Any, float]]:
@@ -98,20 +112,29 @@ class Executor:
 
     def __init__(
         self,
-        nodes: Dict[str, UsableData],
+        chain: Chain,
+        inputs: InputMap,
         loop: asyncio.AbstractEventLoop,
         queue: EventQueue,
         pool: ThreadPoolExecutor,
-        existing_cache: Dict[str, Any],
+        parent_cache: Optional[OutputCache] = None,
         parent_executor: Optional[Executor] = None,
     ):
-        self.execution_id: str = uuid.uuid4().hex
-        self.nodes: Dict[str, UsableData] = nodes
-        self.output_cache: Dict[str, Any] = existing_cache
-        self.__broadcast_tasks: List[asyncio.Task[None]] = []
-        self.cache_hit_state = {node["id"]: 0 for node in self.nodes.values()}
+        assert not (
+            parent_cache and parent_executor
+        ), "Providing both a parent executor and a parent cache is not supported."
 
-        self.progress = ProgressController() if not parent_executor else parent_executor.progress
+        self.execution_id: str = uuid.uuid4().hex
+        self.chain = chain
+        self.inputs = inputs
+        self.cache: OutputCache = OutputCache(
+            parent=parent_executor.cache if parent_executor else parent_cache
+        )
+        self.__broadcast_tasks: List[asyncio.Task[None]] = []
+
+        self.progress = (
+            ProgressController() if not parent_executor else parent_executor.progress
+        )
 
         self.loop: asyncio.AbstractEventLoop = loop
         self.queue: EventQueue = queue
@@ -119,7 +142,14 @@ class Executor:
 
         self.parent_executor = parent_executor
 
-    async def process(self, node: UsableData) -> Any:
+        self.cache_strategy: Dict[NodeId, CacheStrategy] = (
+            parent_executor.cache_strategy
+            if parent_executor
+            else get_cache_strategies(chain)
+        )
+
+    async def process(self, node_id: NodeId) -> Any:
+        node = self.chain.nodes[node_id]
         try:
             return await self.__process(node)
         except Aborted:
@@ -129,111 +159,56 @@ class Executor:
         except Exception as e:
             raise NodeExecutionError(node, str(e), {}) from e
 
-    async def __process(self, node: UsableData) -> Any:
+    async def __process(self, node: Node) -> Any:
         """Process a single node"""
 
         logger.debug(f"node: {node}")
-        node_id = node["id"]
-        logger.debug(f"Running node {node_id}")
+        logger.debug(f"Running node {node.id}")
+
         # Return cached output value from an already-run node if that cached output exists
-        if self.output_cache.get(node_id, None) is not None:
-            await self.queue.put(self.__create_node_finish(node_id))
-            temp = self.output_cache[node_id]
-            self.cache_hit_state[node_id] += 1
-            logger.debug(
-                f"Cache hit for node {node_id}: {self.cache_hit_state[node_id]} | max: {node['cacheOptions']['maxCacheHits']}"
-            )
-            if (
-                self.cache_hit_state[node_id] is not None
-                and node["cacheOptions"]["maxCacheHits"] is not None
-                and node["cacheOptions"]["maxCacheHits"] != "None"
-                and self.cache_hit_state[node_id]
-                >= node["cacheOptions"]["maxCacheHits"]
-            ):
-                logger.debug(
-                    f"number of cache hits exceeded: max: {node['cacheOptions']['maxCacheHits']}, current: {self.cache_hit_state[node_id]}"
-                )
-                logger.debug(f"deleting cache entry for node: {node_id}")
-                del self.output_cache[node_id]
-                gc.collect()
-            return temp
+        cached = self.cache.get(node.id)
+        if cached is not None:
+            await self.queue.put(self.__create_node_finish(node.id))
+            return cached
 
         inputs = []
-        for node_input in node["inputs"]:
+        for node_input in self.inputs.get(node.id):
             await self.progress.suspend()
 
             # If input is a dict indicating another node, use that node's output value
-            if isinstance(node_input, dict) and node_input.get("id", None):
-                # Get the next node by id
-                next_node_id = str(node_input["id"])
-                next_input = self.nodes[next_node_id]
-                next_index = int(node_input["index"])
+            if isinstance(node_input, EdgeInput):
                 # Recursively get the value of the input
-                processed_input = await self.process(next_input)
+                processed_input = await self.process(node_input.id)
                 # Split the output if necessary and grab the right index from the output
                 if type(processed_input) in [list, tuple]:
-                    index = next_index
-                    processed_input = processed_input[index]
+                    processed_input = processed_input[node_input.index]
                 inputs.append(processed_input)
-                if next_input["cacheOptions"]["clearImmediately"]:
-                    del self.output_cache[next_node_id]
-                    gc.collect()
                 await self.progress.suspend()
             # Otherwise, just use the given input (number, string, etc)
             else:
-                inputs.append(node_input)
+                inputs.append(node_input.value)
+
         await self.progress.suspend()
+
         # Create node based on given category/name information
-        node_instance = NodeFactory.get_node(node["schemaId"])
+        node_instance = node.get_node()
 
         # Enforce that all inputs match the expected input schema
         enforced_inputs = []
-        if node["nodeType"] == "iteratorHelper":
+        if node_instance.type == "iteratorHelper":
             enforced_inputs = inputs
         else:
-            node_inputs = node_instance.get_inputs()
+            node_inputs = node_instance.inputs
             for idx, node_input in enumerate(inputs):
                 enforced_inputs.append(node_inputs[idx].enforce_(node_input))
 
-        if node["nodeType"] == "iterator":
-            logger.info("this is where an iterator would run")
-            sub_nodes: Dict[str, UsableData] = {}
-            for child in node["children"]:  # type: ignore
-                sub_nodes[child] = self.nodes[child]
-            sub_nodes_ids = sub_nodes.keys()
-            for v in sub_nodes.copy().values():
-                # TODO: this might be something to do in the frontend before processing instead
-                for node_input in v["inputs"]:
-                    logger.info(f"node_input, {node_input}")
-                    if isinstance(node_input, dict) and node_input.get("id", None):
-                        next_node_id = str(node_input["id"])
-                        logger.info(f"next_node_id, {next_node_id}")
-                        # Run all the connected nodes that are outside the iterator and cache the outputs
-                        if next_node_id not in sub_nodes_ids:
-                            logger.debug(f"not in sub_node_ids, caching {next_node_id}")
-                            output = await self.process(self.nodes[next_node_id])
-                            self.output_cache[next_node_id] = output
-                            # Add this to the sub node dict as well so it knows it exists
-                            sub_nodes[next_node_id] = self.nodes[next_node_id]
-            context = ExecutionContext(
-                sub_nodes,
-                self.loop,
-                self.queue,
-                self.pool,
-                self.output_cache,
-                node["id"],
-                self,
-            )
+        if node_instance.type == "iterator":
+            context = IteratorContext(self, node.id)
             output = await node_instance.run(
                 *enforced_inputs,
                 context=context,  # type: ignore
             )
-            # Cache the output of the node
-            self.output_cache[node_id] = output
-            await self.queue.put(self.__create_node_finish(node_id))
-            del node_instance
-            gc.collect()
-            return output
+            await self.queue.put(self.__create_node_finish(node.id))
         else:
             try:
                 # Run the node and pass in inputs as args
@@ -241,12 +216,15 @@ class Executor:
                 output, execution_time = await self.loop.run_in_executor(
                     self.pool, timed_supplier(run_func)
                 )
+                del run_func
+            except Aborted:
+                raise
             except NodeExecutionError:
                 raise
             except Exception as e:
                 input_dict: InputsDict = {}
-                for index, node_input in enumerate(node_instance.get_inputs()):
-                    input_id = index if node_input.id is None else node_input.id
+                for index, node_input in enumerate(node_instance.inputs):
+                    input_id = node_input.id
                     input_value = enforced_inputs[index]
                     if input_value is None:
                         input_dict[input_id] = None
@@ -257,33 +235,41 @@ class Executor:
                         input_dict[input_id] = {"width": w, "height": h, "channels": c}
                 raise NodeExecutionError(node, str(e), input_dict) from e
 
-            await self.__broadcast_data(node_instance, node_id, execution_time, output)
-            # Cache the output of the node
-            if node["cacheOptions"]["shouldCache"]:
-                self.output_cache[node_id] = output
-            del node_instance, run_func
-            gc.collect()
-            return output
+            await self.__broadcast_data(node_instance, node.id, execution_time, output)
+
+        del node_instance
+
+        # Cache the output of the node
+        # If we are executing a free node from within an iterator,
+        # we want to store the result in the cache of the parent executor
+        write_cache = (
+            self.parent_executor.cache
+            if self.parent_executor and node.parent is None
+            else self.cache
+        )
+        write_cache.set(node.id, output, self.cache_strategy[node.id])
+
+        gc.collect()
+        return output
 
     async def __broadcast_data(
         self,
         node_instance: NodeBase,
-        node_id: str,
+        node_id: NodeId,
         execution_time: float,
         output: Any,
     ):
-        node_outputs = node_instance.get_outputs()
-        finished = [key for key in self.output_cache.keys()]
+        node_outputs = node_instance.outputs
+        finished = list(self.cache.keys())
         if not node_id in finished:
             finished.append(node_id)
 
         def compute_broadcast_data():
-            broadcast_data: Dict[int, Any] = dict()
+            broadcast_data: Dict[OutputId, Any] = dict()
             output_list: List[Any] = [output] if len(node_outputs) == 1 else output
             for index, node_output in enumerate(node_outputs):
                 try:
-                    output_id = node_output.id if node_output.id is not None else index
-                    broadcast_data[output_id] = node_output.get_broadcast_data(
+                    broadcast_data[node_output.id] = node_output.get_broadcast_data(
                         output_list[index]
                     )
                 except Exception as e:
@@ -305,7 +291,7 @@ class Executor:
             )
 
         # Only broadcast the output if the node has outputs and the output is not cached
-        if len(node_outputs) > 0 and self.output_cache.get(node_id, None) is None:
+        if len(node_outputs) > 0 and not self.cache.has(node_id):
             # broadcasts are done is parallel, so don't wait
             self.__broadcast_tasks.append(self.loop.create_task(send_broadcast()))
         else:
@@ -321,8 +307,8 @@ class Executor:
                 }
             )
 
-    def __create_node_finish(self, node_id: str) -> Event:
-        finished = [key for key in self.output_cache.keys()]
+    def __create_node_finish(self, node_id: NodeId) -> Event:
+        finished = list(self.cache.keys())
         if not node_id in finished:
             finished.append(node_id)
 
@@ -336,22 +322,31 @@ class Executor:
             },
         }
 
-    def get_output_nodes(self) -> List[UsableData]:
-        output_nodes: List[UsableData] = []
-        for node in self.nodes.values():
-            if (node["hasSideEffects"]) and not node["child"]:
-                output_nodes.append(node)
+    def __get_output_nodes(self) -> List[NodeId]:
+        output_nodes: List[NodeId] = []
+        for node in self.chain.nodes.values():
+            # we assume that iterator node always have side effects
+            side_effects = isinstance(node, IteratorNode) or node.has_side_effects()
+            if node.parent is None and side_effects:
+                output_nodes.append(node.id)
         return output_nodes
 
-    async def process_nodes(self):
+    def __get_iterator_output_nodes(self, sub: SubChain) -> List[NodeId]:
+        output_nodes: List[NodeId] = []
+        for node in sub.nodes.values():
+            if node.has_side_effects():
+                output_nodes.append(node.id)
+        return output_nodes
+
+    async def __process_nodes(self, nodes: List[NodeId]):
         await self.progress.suspend()
 
         # Run each of the output nodes through processing
-        for output_node in self.get_output_nodes():
+        for output_node in nodes:
             await self.progress.suspend()
             await self.process(output_node)
 
-        logger.debug(self.output_cache.keys())
+        logger.debug(self.cache.keys())
 
         # await all broadcasts
         tasks = self.__broadcast_tasks
@@ -361,7 +356,11 @@ class Executor:
 
     async def run(self):
         logger.debug(f"Running executor {self.execution_id}")
-        await self.process_nodes()
+        await self.__process_nodes(self.__get_output_nodes())
+
+    async def run_iteration(self, sub: SubChain):
+        logger.debug(f"Running executor {self.execution_id}")
+        await self.__process_nodes(self.__get_iterator_output_nodes(sub))
 
     def resume(self):
         logger.info(f"Resuming executor {self.execution_id}")
@@ -374,7 +373,3 @@ class Executor:
     def kill(self):
         logger.info(f"Killing executor {self.execution_id}")
         self.progress.abort()
-
-    def set_nodes_list(self, nodes: Dict[str, UsableData]):
-        """Set the list of nodes to run"""
-        self.nodes = nodes

--- a/backend/src/response.py
+++ b/backend/src/response.py
@@ -37,8 +37,8 @@ def errorResponse(
 ) -> ErrorResponse:
     if source is None and isinstance(exception, NodeExecutionError):
         source = {
-            "nodeId": exception.node["id"],
-            "schemaId": exception.node["schemaId"],
+            "nodeId": exception.node.id,
+            "schemaId": exception.node.schema_id,
             "inputs": exception.inputs,
         }
     return {

--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -73,8 +73,12 @@ except Exception as e:
 # pylint: disable=unused-import
 from nodes import utility_nodes  # type: ignore
 from nodes.node_factory import NodeFactory
+from base_types import NodeId, InputId, OutputId
+from chain.cache import OutputCache
+from chain.json import parse_json, JsonNode
+from chain.optimize import optimize
 from events import EventQueue, ExecutionErrorData
-from process import Executor, NodeExecutionError, UsableData, timed_supplier
+from process import Executor, NodeExecutionError, timed_supplier
 from progress import Aborted
 from response import (
     errorResponse,
@@ -88,7 +92,7 @@ from nodes.utils.exec_options import set_execution_options, ExecutionOptions
 class AppContext:
     def __init__(self):
         self.executor: Optional[Executor] = None
-        self.cache: Dict[str, Any] = dict()
+        self.cache: Dict[NodeId, Any] = dict()
         # This will be initialized by setup_queue.
         # This is necessary because we don't know Sanic's event loop yet.
         self.queue: EventQueue = None  # type: ignore
@@ -153,12 +157,8 @@ async def nodes(_):
             "schemaId": schema_id,
             "name": node_object.name,
             "category": node_object.category.name,
-            "inputs": [
-                x.toDict() for x in node_object.get_inputs(with_implicit_ids=True)
-            ],
-            "outputs": [
-                x.toDict() for x in node_object.get_outputs(with_implicit_ids=True)
-            ],
+            "inputs": [x.toDict() for x in node_object.inputs],
+            "outputs": [x.toDict() for x in node_object.outputs],
             "description": node_object.description,
             "icon": node_object.icon,
             "subcategory": node_object.sub,
@@ -173,7 +173,7 @@ async def nodes(_):
 
 
 class RunRequest(TypedDict):
-    data: Dict[str, UsableData]
+    data: List[JsonNode]
     isCpu: bool
     isFp16: bool
     pytorchGPU: int
@@ -198,7 +198,8 @@ async def run(request: Request):
 
         full_data: RunRequest = dict(request.json)  # type: ignore
         logger.info(full_data)
-        nodes_list = full_data["data"]
+        chain, inputs = parse_json(full_data["data"])
+        optimize(chain)
 
         logger.info("Running new executor...")
         exec_opts = ExecutionOptions(
@@ -212,11 +213,12 @@ async def run(request: Request):
         set_execution_options(exec_opts)
         logger.info(f"Using device: {exec_opts.device}")
         executor = Executor(
-            nodes_list,
+            chain,
+            inputs,
             app.loop,
             ctx.queue,
             ctx.pool,
-            ctx.cache.copy(),
+            parent_cache=OutputCache(static_data=ctx.cache.copy()),
         )
         try:
             ctx.executor = executor
@@ -242,8 +244,8 @@ async def run(request: Request):
         }
         if isinstance(exception, NodeExecutionError):
             error["source"] = {
-                "nodeId": exception.node["id"],
-                "schemaId": exception.node["schemaId"],
+                "nodeId": exception.node.id,
+                "schemaId": exception.node.schema_id,
                 "inputs": exception.inputs,
             }
 
@@ -252,7 +254,7 @@ async def run(request: Request):
 
 
 class RunIndividualRequest(TypedDict):
-    id: str
+    id: NodeId
     inputs: List[Any]
     isCpu: bool
     isFp16: bool
@@ -290,7 +292,7 @@ async def run_individual(request: Request):
         if node_instance.type == "iteratorHelper":
             enforced_inputs = full_data["inputs"]
         else:
-            node_inputs = node_instance.get_inputs(with_implicit_ids=True)
+            node_inputs = node_instance.inputs
             for idx, node_input in enumerate(full_data["inputs"]):
                 enforced_inputs.append(node_inputs[idx].enforce_(node_input))
 
@@ -305,14 +307,13 @@ async def run_individual(request: Request):
             ctx.cache[full_data["id"]] = output
 
         # Broadcast the output from the individual run
-        broadcast_data: Dict[int, Any] = dict()
-        node_outputs = node_instance.get_outputs(with_implicit_ids=True)
+        broadcast_data: Dict[OutputId, Any] = dict()
+        node_outputs = node_instance.outputs
         if len(node_outputs) > 0:
             output_idxable = [output] if len(node_outputs) == 1 else output
             for idx, node_output in enumerate(node_outputs):
                 try:
-                    output_id = node_output.id if node_output.id is not None else idx
-                    broadcast_data[output_id] = node_output.get_broadcast_data(
+                    broadcast_data[node_output.id] = node_output.get_broadcast_data(
                         output_idxable[idx]
                     )
                 except Exception as error:
@@ -352,7 +353,6 @@ async def clear_cache_individual(request: Request):
 @app.get("/sse")
 async def sse(request: Request):
     ctx = AppContext.get(request.app)
-    logger.info(f"Size of ctx.cache: {sys.getsizeof(ctx.cache)}")
     headers = {"Cache-Control": "no-cache"}
     response = await request.respond(headers=headers, content_type="text/event-stream")
     while True:

--- a/src/common/Backend.ts
+++ b/src/common/Backend.ts
@@ -1,5 +1,5 @@
 import fetch from 'cross-fetch';
-import { Category, InputId, InputValue, NodeSchema, SchemaId, UsableData } from './common-types';
+import { Category, InputId, InputValue, JsonNode, NodeSchema, SchemaId } from './common-types';
 
 export interface BackendSuccessResponse {
     type: 'success';
@@ -38,7 +38,7 @@ export interface BackendNodesResponse {
     categories: Category[];
 }
 export interface BackendRunRequest {
-    data: Record<string, UsableData>;
+    data: JsonNode[];
     isCpu: boolean;
     isFp16: boolean;
     pytorchGPU: number;

--- a/src/common/common-types.ts
+++ b/src/common/common-types.ts
@@ -132,24 +132,22 @@ export interface FileOpenError {
     error: string;
 }
 
-export interface EdgeHandle {
+export interface JsonEdgeInput {
+    type: 'edge';
     id: string;
     index: number;
 }
-
-export interface CacheOptions {
-    readonly shouldCache: boolean;
-    readonly maxCacheHits: number;
+export interface JsonValueInput {
+    type: 'value';
+    value: InputValue | null;
 }
-export interface UsableData {
+export type JsonInput = JsonEdgeInput | JsonValueInput;
+export interface JsonNode {
     id: string;
     schemaId: SchemaId;
-    inputs: (InputValue | EdgeHandle | null)[];
-    child: boolean;
-    children?: string[];
+    inputs: JsonInput[];
     nodeType: string;
-    hasSideEffects: boolean;
-    cacheOptions: CacheOptions;
+    parent: string | null;
 }
 
 export interface WindowSize {

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -2,7 +2,7 @@ import { constants } from 'fs';
 import fs from 'fs/promises';
 import { LocalStorage } from 'node-localstorage';
 import { v4 as uuid4, v5 as uuid5 } from 'uuid';
-import type { EdgeHandle, InputId, InputValue, NodeSchema, OutputId } from './common-types';
+import type { InputId, NodeSchema, OutputId } from './common-types';
 
 export const EMPTY_ARRAY: readonly never[] = [];
 export const EMPTY_SET: ReadonlySet<never> = new Set<never>();
@@ -194,7 +194,5 @@ export const delay = (ms: number): Promise<void> => {
     });
 };
 
-export const getInputValues = <T extends InputValue | EdgeHandle | null>(
-    schema: NodeSchema,
-    getValue: (inputId: InputId) => T
-): T[] => schema.inputs.map((input) => getValue(input.id));
+export const getInputValues = <T>(schema: NodeSchema, getValue: (inputId: InputId) => T): T[] =>
+    schema.inputs.map((input) => getValue(input.id));


### PR DESCRIPTION
This is the executor "rewrite" I mentioned on Discord.

Major changes:
- The `/run` API is now a lot simpler. The frontend only has to submit the current chain. No caching stuff. The shape of the JSON also changed.
- `NewType` for node ids and input/output ids. This allows us to verify that the implementation is correct using types.
- Simpler API for `NodeBase` inputs. I removed `get_inputs` and made `.inputs` a getter/setter pair instead. The setter will automatically fill in any missing input ids. This makes it way easier to use the input ids of inputs. Same for outputs.
- `Chain` is the new Python class to describe the whole graph of the chain. Notably, this does not include inputs, they are separate. Since we now have the full graph in a convenient representation on the python side, I also implemented a simple chain optimizer. It only removes useless nodes and outlines child nodes right now, but we can add more in the future.
- New input system. Inputs are now their own data structure and not part of the nodes anymore. This allows iterators to set inputs without modifying the chain itself. Further, inputs can inherit from a parent input map. This makes the input maps for iterators very cheap.
- New caching system. Everything related to caching is now in `chain.cache`. The basic data structure is a multi-level cache where each level can lookup but not modify parent caches. This makes it quite easy to implement iterators and how they cache stuff. 
   Iterators also cache more efficiently now. Previously, all child node outputs were cached until the end of the current iteration. They are now reference-counted and will be cleared from cache ASAP. I didn't explicitly add this, btw. This just naturally emerged from the new caching system.
- Iterators got simpler. With the new cache and input system, iterators got a lot simpler, both in their `Executor` code and their `run` methods. The executor doesn't have to preemptively execute required free nodes anymore, and most of the shared code between iterators either became unnecessary or was moved into `IteratorContext` (formerly `ExecutorContext`).

I did some basic testing, and it worked well so far. 