### PR TITLE
Navi: Added `invStrSet` function

### DIFF
--- a/tests/common/types/__snapshots__/evaluate.test.ts.snap
+++ b/tests/common/types/__snapshots__/evaluate.test.ts.snap
@@ -838,6 +838,20 @@ floor(never) => never
 floor(any) => Error: Incompatible argument type: The supplied argument type any is not compatible with the definition type."
 `;
 
+exports[`Builtin functions invStrSet 1`] = `
+"invStrSet(string) => never
+invStrSet(\\"\\") => invStrSet(\\"\\")
+invStrSet(\\"foo\\") => invStrSet(\\"foo\\")
+invStrSet(\\"bar\\") => invStrSet(\\"bar\\")
+invStrSet(\\"bar\\" | \\"foo\\") => invStrSet(\\"bar\\" | \\"foo\\")
+invStrSet(\\"baz\\" | \\"foo\\") => invStrSet(\\"baz\\" | \\"foo\\")
+invStrSet(invStrSet(\\"foo\\")) => \\"foo\\"
+invStrSet(invStrSet(\\"bar\\" | \\"foo\\")) => \\"bar\\" | \\"foo\\"
+invStrSet(invStrSet(\\"bar\\")) => \\"bar\\"
+invStrSet(never) => string
+invStrSet(any) => Error: Incompatible argument type: The supplied argument type any is not compatible with the definition type."
+`;
+
 exports[`Builtin functions log 1`] = `
 "log(number) => number
 log(-3.14) => never

--- a/tests/common/types/evaluate.test.ts
+++ b/tests/common/types/evaluate.test.ts
@@ -30,6 +30,7 @@ import {
     orderedPairs,
     potentiallyInvalidExpressions,
     sets,
+    strings,
     types,
     unorderedPairs,
 } from './data';
@@ -213,6 +214,23 @@ describe('Builtin functions', () => {
             expect(actual).toMatchSnapshot();
         });
     };
+    const testUnaryString = (name: string) => {
+        test(name, () => {
+            const actual = [...strings, ...sets]
+                .map((e) => new FunctionCallExpression(name, [e]))
+                .map((e) => {
+                    let result;
+                    try {
+                        result = evaluate(e, scope).toString();
+                    } catch (error) {
+                        result = String(error);
+                    }
+                    return `${e.toString()} => ${result}`;
+                })
+                .join('\n');
+            expect(actual).toMatchSnapshot();
+        });
+    };
     const testBinaryNumber = (
         name: string,
         properties: { commutative: boolean; reflexive: boolean; associative: boolean }
@@ -300,6 +318,8 @@ describe('Builtin functions', () => {
     testBinaryNumber('multiply', { commutative: true, reflexive: false, associative: false });
     testBinaryNumber('mod', { commutative: false, reflexive: false, associative: false });
     testBinaryNumber('pow', { commutative: false, reflexive: false, associative: false });
+
+    testUnaryString('invStrSet');
 });
 
 describe('Match', () => {


### PR DESCRIPTION
Test snapshots might look a bit funny, but that's okay. Inverted string sets are represented using the `invStrSet` function, so it comes up a lot.