### PR TITLE
Added proper output type for Text Pattern node

### DIFF
--- a/backend/src/nodes/utility_nodes.py
+++ b/backend/src/nodes/utility_nodes.py
@@ -169,7 +169,30 @@ class TextPatternNode(NodeBase):
             TextInput("{3}").make_optional(),
             TextInput("{4}").make_optional(),
         ]
-        self.outputs = [TextOutput("Output Text")]
+        self.outputs = [
+            TextOutput(
+                "Output Text",
+                output_type="""
+                def convert(value: string | number | null) {
+                    match value {
+                        number as n => toString(n),
+                        _ as v => v
+                    }
+                }
+
+                formatPattern(
+                    toString(Input0),
+                    convert(Input1),
+                    convert(Input2),
+                    convert(Input3),
+                    convert(Input4)
+                )
+                """,
+            ).with_never_reason(
+                "The pattern is either syntactically invalid or contains replacements that do not have a value."
+                '\n\nHint: Use "{{" to escape a single "{" inside the pattern.'
+            )
+        ]
 
         self.category = UtilityCategory
         self.name = "Text Pattern"

--- a/src/common/types/chainner-format.ts
+++ b/src/common/types/chainner-format.ts
@@ -1,0 +1,137 @@
+import { concat } from './builtin';
+import { intersect } from './intersection';
+import {
+    NeverType,
+    StringLiteralType,
+    StringPrimitive,
+    StringType,
+    StructType,
+    UnionType,
+    ValueType,
+} from './types';
+
+type ReplacementToken =
+    | { type: 'literal'; value: string }
+    | { type: 'interpolation'; name: string };
+
+class ReplacementString {
+    readonly tokens: readonly ReplacementToken[];
+
+    readonly names: ReadonlySet<string>;
+
+    constructor(pattern: string) {
+        const tokens: ReplacementToken[] = [];
+        const names = new Set<string>();
+
+        const contentPattern = /^\w+$/;
+
+        const tokenPattern = /(\{\{)|\{([^{}]*)\}/g;
+        let lastIndex = 0;
+        let lastStr = '';
+        let m;
+        // eslint-disable-next-line no-cond-assign
+        while ((m = tokenPattern.exec(pattern))) {
+            lastStr += pattern.slice(lastIndex, m.index);
+            lastIndex = m.index + m[0].length;
+
+            const interpolation = m[2] as string | undefined;
+            if (interpolation !== undefined) {
+                if (interpolation === '') {
+                    throw new Error(
+                        'Invalid replacement pattern. {} is not a valid replacement.' +
+                            ` Either specify a name or id number, or escape a single "{" as "{{".` +
+                            ` Full pattern: ${pattern}`
+                    );
+                }
+                if (!contentPattern.test(interpolation)) {
+                    throw new Error(
+                        'Invalid replacement pattern.' +
+                            ` "{${interpolation}}" is not a valid replacement.` +
+                            ' Names and ids only allow letters and digits.' +
+                            ` Full pattern: ${pattern}`
+                    );
+                }
+
+                tokens.push({ type: 'literal', value: lastStr });
+                lastStr = '';
+                tokens.push({ type: 'interpolation', name: interpolation });
+                names.add(interpolation);
+            } else {
+                lastStr += '{';
+            }
+        }
+        lastStr += pattern.slice(lastIndex);
+        tokens.push({ type: 'literal', value: lastStr });
+
+        this.tokens = tokens;
+        this.names = names;
+    }
+
+    replace(replacements: ReadonlyMap<string, string>): string {
+        let result = '';
+
+        for (const token of this.tokens) {
+            if (token.type === 'literal') {
+                result += token.value;
+            } else {
+                const replacement = replacements.get(token.name);
+                if (replacement !== undefined) {
+                    result += replacement;
+                } else {
+                    throw new Error(
+                        'Unknown replacement.' +
+                            ` There is no replacement with the name or id ${token.name}.` +
+                            ` Available replacements: ${[...replacements.keys()].join(', ')}.`
+                    );
+                }
+            }
+        }
+
+        return result;
+    }
+}
+
+type Arg<T extends ValueType> = T | UnionType<T> | NeverType;
+export const formatTextPattern = (
+    pattern: Arg<StringPrimitive>,
+    ...args: Arg<StringPrimitive | StructType>[]
+): Arg<StringPrimitive> => {
+    if (pattern.type === 'never') return NeverType.instance;
+
+    const argsMap = new Map<string, Arg<StringPrimitive>>();
+    for (const [arg, name] of args.map((a, i) => [a, String(i + 1)] as const)) {
+        if (arg.type === 'never') {
+            return NeverType.instance;
+        }
+        const stringType = intersect(arg, StringType.instance);
+        if (stringType.type !== 'never') {
+            argsMap.set(name, stringType as Arg<StringPrimitive>);
+        }
+    }
+
+    if (pattern.type !== 'literal') return StringType.instance;
+
+    let parsed;
+    try {
+        parsed = new ReplacementString(pattern.value);
+    } catch {
+        // Invalid pattern
+        return NeverType.instance;
+    }
+
+    const concatArgs: Arg<StringPrimitive>[] = [];
+    for (const token of parsed.tokens) {
+        if (token.type === 'literal') {
+            concatArgs.push(new StringLiteralType(token.value));
+        } else {
+            const arg = argsMap.get(token.name);
+            if (arg === undefined) {
+                // invalid reference
+                return NeverType.instance;
+            }
+            concatArgs.push(arg);
+        }
+    }
+
+    return concat(...concatArgs);
+};

--- a/src/common/types/chainner-scope.ts
+++ b/src/common/types/chainner-scope.ts
@@ -1,8 +1,11 @@
 import { lazy } from '../util';
+import { formatTextPattern } from './chainner-format';
 import { globalScope } from './global-scope';
 import { parseDefinitions } from './parse';
-import { Scope, ScopeBuilder } from './scope';
+import { BuiltinFunctionDefinition, Scope, ScopeBuilder } from './scope';
 import { SourceDocument } from './source';
+import { StringType, StructType, Type } from './types';
+import { union } from './union';
 
 const code = `
 struct null;
@@ -91,6 +94,15 @@ export const getChainnerScope = lazy((): Scope => {
     for (const d of definitions) {
         builder.add(d);
     }
+
+    builder.add(
+        new BuiltinFunctionDefinition(
+            'formatPattern',
+            formatTextPattern as (..._: Type[]) => Type,
+            [StringType.instance],
+            union(StringType.instance, new StructType('null'))
+        )
+    );
 
     return builder.createScope();
 });


### PR DESCRIPTION
I added a function called `formatPattern` that does the whole parse+replace of the Text Pattern node with types. Since this function is highly specific to chainner, I added it to chainner's scope instead of the global scope. I even gave the implementation of the function its own file.

As with all types, the output not only shows results, it also shows errors. If the pattern is syntactically invalid or references an invalid replacement, an error will be shown.

![image](https://user-images.githubusercontent.com/20878432/191596459-8125a239-ce7f-463c-84f9-adf4994af213.png)
![image](https://user-images.githubusercontent.com/20878432/191596503-a9c86f80-180f-4103-9820-6bd9192d873c.png)
