### PR TITLE
Various improvements to Crop nodes

### DIFF
--- a/backend/src/nodes/image_dim_nodes.py
+++ b/backend/src/nodes/image_dim_nodes.py
@@ -329,8 +329,8 @@ class CropNode(NodeBase):
             ImageInput(),
             NumberInput("Top Offset", unit="px"),
             NumberInput("Left Offset", unit="px"),
-            NumberInput("Height", unit="px", default=1),
-            NumberInput("Width", unit="px", default=1),
+            NumberInput("Height", unit="px", minimum=1, default=1),
+            NumberInput("Width", unit="px", minimum=1, default=1),
         ]
         self.outputs = [
             ImageOutput(

--- a/backend/src/nodes/image_dim_nodes.py
+++ b/backend/src/nodes/image_dim_nodes.py
@@ -203,12 +203,19 @@ class ImResizeToSide(NodeBase):
                     channels: Input0.channels
                 }
                 """
-                )
+            )
         ]
         self.icon = "MdOutlinePhotoSizeSelectLarge"
         self.sub = "Resize"
 
-    def run(self, img: np.ndarray, target: int, side: str, interpolation: int, condition: str) -> np.ndarray:
+    def run(
+        self,
+        img: np.ndarray,
+        target: int,
+        side: str,
+        interpolation: int,
+        condition: str,
+    ) -> np.ndarray:
         """Takes an image and resizes it"""
 
         logger.info(f"Resizing image to {side} via {interpolation}")
@@ -240,7 +247,6 @@ class ImResizeToSide(NodeBase):
             out_dims = resize_to_side_conditional(w, h, target, side, condition)
 
         return resize(img, out_dims, interpolation)
-
 
 
 @NodeFactory.register("chainner:image:resize_resolution")
@@ -323,14 +329,18 @@ class CropNode(NodeBase):
             ImageInput(),
             NumberInput("Top Offset", unit="px"),
             NumberInput("Left Offset", unit="px"),
-            NumberInput("Height", unit="px"),
-            NumberInput("Width", unit="px"),
+            NumberInput("Height", unit="px", default=1),
+            NumberInput("Width", unit="px", default=1),
         ]
         self.outputs = [
             ImageOutput(
                 image_type=expression.Image(
-                    width="Input4", height="Input3", channels_as="Input0"
+                    width="min(Input4, Input0.width - Input2) & int(1..)",
+                    height="min(Input3, Input0.height - Input1) & int(1..)",
+                    channels_as="Input0",
                 )
+            ).with_never_reason(
+                "The cropped area would result in an image with no width or no height."
             )
         ]
         self.category = ImageDimensionCategory
@@ -341,12 +351,10 @@ class CropNode(NodeBase):
     def run(
         self, img: np.ndarray, top: int, left: int, height: int, width: int
     ) -> np.ndarray:
-        """Crop an image"""
-
         h, w, _ = get_h_w_c(img)
 
-        assert top < h, "Cropped area would result in image with no height"
-        assert left < w, "Cropped area would result in image with no width"
+        assert top < h, "Cropped area would result in an image with no height"
+        assert left < w, "Cropped area would result in an image with no width"
 
         result = img[top : top + height, left : left + width]
 
@@ -372,7 +380,7 @@ class BorderCropNode(NodeBase):
                     channels_as="Input0",
                 )
             ).with_never_reason(
-                "The cropped area would result in image with no width or no height."
+                "The cropped area would result in an image with no width or no height."
             )
         ]
         self.category = ImageDimensionCategory
@@ -381,12 +389,10 @@ class BorderCropNode(NodeBase):
         self.sub = "Crop"
 
     def run(self, img: np.ndarray, amount: int) -> np.ndarray:
-        """Crop an image"""
-
         h, w, _ = get_h_w_c(img)
 
-        assert 2 * amount < h, "Cropped area would result in image with no height"
-        assert 2 * amount < w, "Cropped area would result in image with no width"
+        assert 2 * amount < h, "Cropped area would result in an image with no height"
+        assert 2 * amount < w, "Cropped area would result in an image with no width"
 
         result = img[amount : h - amount, amount : w - amount]
 
@@ -413,7 +419,7 @@ class EdgeCropNode(NodeBase):
                     channels_as="Input0",
                 )
             ).with_never_reason(
-                "The cropped area would result in image with no width or no height."
+                "The cropped area would result in an image with no width or no height."
             )
         ]
         self.category = ImageDimensionCategory
@@ -424,12 +430,10 @@ class EdgeCropNode(NodeBase):
     def run(
         self, img: np.ndarray, top: int, left: int, right: int, bottom: int
     ) -> np.ndarray:
-        """Crop an image"""
-
         h, w, _ = get_h_w_c(img)
 
-        assert top + bottom < h, "Cropped area would result in image with no height"
-        assert left + right < w, "Cropped area would result in image with no width"
+        assert top + bottom < h, "Cropped area would result in an image with no height"
+        assert left + right < w, "Cropped area would result in an image with no width"
 
         result = img[top : h - bottom, left : w - right]
 
@@ -454,15 +458,22 @@ class ContentCropNode(NodeBase):
                 default=0,
             ),
         ]
-        self.outputs = [ImageOutput(image_type=expression.Image(channels_as="Input0"))]
+        self.outputs = [
+            ImageOutput(
+                image_type="""
+                match Input0.channels {
+                    ..3 => Input0,
+                    _ => Image { channels: Input0.channels }
+                }
+                """
+            )
+        ]
         self.category = ImageDimensionCategory
         self.name = "Crop (Content)"
         self.icon = "MdCrop"
         self.sub = "Crop"
 
     def run(self, img: np.ndarray, thresh_val: float) -> np.ndarray:
-        """Crop an image"""
-
         c = get_h_w_c(img)[2]
         if c < 4:
             return img


### PR DESCRIPTION
I initially just wanted to fix a typo, but it snowballed into this...

Changes:
- Fixed a small grammatical error in error messages and never reason.
- Improved the output type of Crop (Content). When the input image does not have an alpha channel, then the input will be returned as is. The output type now reflects this behaviour.
- Added never reason to Crop (Offsets).
- Fixed output type of Crop (Offsets).
- Changed the default and minimum value of "Width" and "Height" inputs in Crop (Offsets) to 1. A width/height of 0 is always invalid. This is now consistent with the Resize (Resolution) node.

I'm sorry about the formatting changes. I just ran black and this happened.