### PR TITLE
Remove Linux qt variable check and removal as it is unneeded (since a long time ago)

### DIFF
--- a/backend/src/run.py
+++ b/backend/src/run.py
@@ -3,8 +3,6 @@ from concurrent.futures import ThreadPoolExecutor
 import functools
 import gc
 import logging
-import os
-import platform
 import sys
 import traceback
 from json import dumps as stringify
@@ -19,10 +17,6 @@ from sanic.response import json
 from sanic_cors import CORS
 
 from nodes.categories import categories, category_order
-
-# Remove broken QT env var
-if platform.system() == "Linux":
-    os.environ.pop("QT_QPA_PLATFORM_PLUGIN_PATH")
 
 # pylint: disable=ungrouped-imports,wrong-import-position
 from nodes import image_adj_nodes  # type: ignore


### PR DESCRIPTION
This was needed back when we used cv2.imshow for previewing images. This hasn't been in chaiNNer for quite a while now, so this bit of code is no longer needed, and actually caused an issue for @xpscyho 