### PR TITLE
Add output scale input for Face Upscale (GFPGAN)

### DIFF
--- a/backend/src/nodes/properties/inputs/generic_inputs.py
+++ b/backend/src/nodes/properties/inputs/generic_inputs.py
@@ -344,16 +344,3 @@ def TileModeDropdown(has_auto=True, label="Number of Tiles") -> DropDownInput:
         label=label,
         options=options,
     )
-
-
-def FaceUpscaleDropdown() -> DropDownInput:
-    return DropDownInput(
-        input_type="FaceUpscaleModel",
-        label="Face Restoration Model",
-        options=[
-            {"option": "GFPGANv1.2", "value": "GFPGANv1.2"},
-            {"option": "GFPGANv1.3", "value": "GFPGANv1.3"},
-            {"option": "GFPGANv1.4", "value": "GFPGANv1.4"},
-            {"option": "RestoreFormer", "value": "RestoreFormer"},
-        ],
-    )

--- a/backend/src/nodes/pytorch_alt_nodes.py
+++ b/backend/src/nodes/pytorch_alt_nodes.py
@@ -37,14 +37,17 @@ class FaceUpscaleNode(NodeBase):
             ),
             ImageInput(),
             ImageInput("Upscaled Background").make_optional(),
+            NumberInput(
+                label="Output Scale", default=8, minimum=1, maximum=8, unit="x"
+            ),
         ]
         self.outputs = [
             ImageOutput(
                 "Upscaled Image",
                 image_type="""
                 Image {
-                    width: Input0.scale * Input1.width,
-                    height: Input0.scale * Input1.height,
+                    width: Input3 * Input1.width,
+                    height: Input3 * Input1.height,
                     channels: 3
                 }
                 """,
@@ -72,10 +75,10 @@ class FaceUpscaleNode(NodeBase):
         face_helper: FaceRestoreHelper,
         face_model: PyTorchModel,
         weight: float,
+        upscale: int,
     ):
         exec_options = to_pytorch_execution_options(get_execution_options())
         device = torch.device(exec_options.device)
-        upscale = face_model.scale
         face_helper.clean_all()
 
         face_helper.read_image(img)
@@ -107,26 +110,14 @@ class FaceUpscaleNode(NodeBase):
             restored_face = restored_face.astype("uint8")  # type: ignore
             face_helper.add_restored_face(restored_face)
 
-        h, w, _ = get_h_w_c(img)
-        upsample_h = int(h * upscale)
-        upsample_w = int(w * upscale)
-
         if background_img is not None:
             # upsample the background
             background_img = self.denormalize(background_img)
 
-            d_size = (upsample_h, upsample_w)
-            interp = cv2.INTER_LANCZOS4
-            background_upscale = cv2.resize(
-                background_img,
-                d_size,
-                interpolation=interp,
-            )
-
             face_helper.get_inverse_affine(None)
             # paste each restored face to the input image
             restored_img = face_helper.paste_faces_to_input_image(
-                upsample_img=background_upscale
+                upsample_img=background_img
             )
         else:
             face_helper.get_inverse_affine(None)
@@ -141,6 +132,7 @@ class FaceUpscaleNode(NodeBase):
         face_model: PyTorchModel,
         img: np.ndarray,
         background_img: Union[np.ndarray, None],
+        upscale: int,
     ) -> np.ndarray:
         """Upscales an image with a pretrained model"""
         face_helper = None
@@ -151,7 +143,6 @@ class FaceUpscaleNode(NodeBase):
             device = torch.device(exec_options.device)
             should_use_fp16 = exec_options.fp16 and face_model.supports_fp16
 
-            upscale = face_model.scale
             weight = 0.5
 
             with torch.no_grad():
@@ -182,6 +173,7 @@ class FaceUpscaleNode(NodeBase):
                             face_helper,
                             face_model,
                             weight,
+                            upscale,
                         )
                 else:
                     result = self.upscale(
@@ -190,6 +182,7 @@ class FaceUpscaleNode(NodeBase):
                         face_helper,
                         face_model,
                         weight,
+                        upscale,
                     )
 
                 return result

--- a/backend/src/nodes/pytorch_alt_nodes.py
+++ b/backend/src/nodes/pytorch_alt_nodes.py
@@ -75,7 +75,6 @@ class FaceUpscaleNode(NodeBase):
         face_helper: FaceRestoreHelper,
         face_model: PyTorchModel,
         weight: float,
-        upscale: int,
     ):
         exec_options = to_pytorch_execution_options(get_execution_options())
         device = torch.device(exec_options.device)
@@ -173,7 +172,6 @@ class FaceUpscaleNode(NodeBase):
                             face_helper,
                             face_model,
                             weight,
-                            upscale,
                         )
                 else:
                     result = self.upscale(
@@ -182,7 +180,6 @@ class FaceUpscaleNode(NodeBase):
                         face_helper,
                         face_model,
                         weight,
-                        upscale,
                     )
 
                 return result


### PR DESCRIPTION
This was talked about on Discord. Basically, since regular GFPGAN allows you to define an output scale, we figure the majority of users familiar with existing implementations will find it odd that it doesn't allow different scales. Since the scaling is done internally via the `face_helper` stuff, we can just utilize that to do the scaling for us and it will be consistent with existing implementations.

![image](https://user-images.githubusercontent.com/34788790/191652317-fe0d7fb6-f0ff-406f-9b40-3dd8c986ab98.png)
