### PR TITLE
Fixed iterators not stopping correctly

### DIFF
--- a/backend/src/nodes/pytorch_iterators.py
+++ b/backend/src/nodes/pytorch_iterators.py
@@ -93,19 +93,7 @@ class ModelFileIteratorNode(IteratorNodeBase):
                 if ext.lower() in supported_filetypes:
                     just_model_files.append(filepath)
 
-        file_len = len(just_model_files)
-        errors = []
-        for idx, filepath in enumerate(just_model_files):
-            # Replace the input filepath with the filepath from the loop
-            context.inputs.set_values(model_path_node_id, [filepath, directory, idx])
-            try:
-                await context.run_iteration(idx, file_len)
-            except Exception as e:
-                logger.error(e)
-                errors.append(str(e))
+        def before(filepath: str, index: int):
+            context.inputs.set_values(model_path_node_id, [filepath, directory, index])
 
-        if len(errors) > 0:
-            raise Exception(
-                # pylint: disable=consider-using-f-string
-                "Errors occurred during iteration: \n• {}".format("\n• ".join(errors))
-            )
+        await context.run(just_model_files, before)


### PR DESCRIPTION
When the executor is killed, the progress token will raise an `Aborted` exception. Iterators caught this exception, which led to the behavior described by @theflyingzamboni.

![image](https://user-images.githubusercontent.com/20878432/191741372-62b690d2-0d38-44da-9c36-dcfe1e3c733d.png)

So the simple fix would have been to catch `Aborted` in each iterator. However, I didn't like that. The error handling logic is already copy-pasted across the iterators, so I took this chance to unify it.

The iterator context now has a `run` method. This method takes an iterable and a method to run before each iteration. The `before` method is used for passing values into the helper nodes. The `run` method allows all iterators to share the same error handling logic.