### PR TITLE
Ncnn load net refactor

### DIFF
--- a/backend/src/nodes/utils/ncnn_auto_split.py
+++ b/backend/src/nodes/utils/ncnn_auto_split.py
@@ -32,7 +32,7 @@ def ncnn_auto_split_process(
     overlap: int = 16,
     max_depth: Union[int, None] = None,
     current_depth: int = 1,
-    input_name: str = "data",
+    input_name: str = "input",
     output_name: str = "output",
     blob_vkallocator=None,
     staging_vkallocator=None,
@@ -129,6 +129,8 @@ def ncnn_auto_split_process(
         overlap=overlap,
         max_depth=max_depth,
         current_depth=current_depth + 1,
+        input_name=input_name,
+        output_name=output_name,
         blob_vkallocator=blob_vkallocator,
         staging_vkallocator=staging_vkallocator,
     )
@@ -138,6 +140,8 @@ def ncnn_auto_split_process(
         overlap=overlap,
         max_depth=depth,
         current_depth=current_depth + 1,
+        input_name=input_name,
+        output_name=output_name,
         blob_vkallocator=blob_vkallocator,
         staging_vkallocator=staging_vkallocator,
     )
@@ -147,6 +151,8 @@ def ncnn_auto_split_process(
         overlap=overlap,
         max_depth=depth,
         current_depth=current_depth + 1,
+        input_name=input_name,
+        output_name=output_name,
         blob_vkallocator=blob_vkallocator,
         staging_vkallocator=staging_vkallocator,
     )
@@ -156,6 +162,8 @@ def ncnn_auto_split_process(
         overlap=overlap,
         max_depth=depth,
         current_depth=current_depth + 1,
+        input_name=input_name,
+        output_name=output_name,
         blob_vkallocator=blob_vkallocator,
         staging_vkallocator=staging_vkallocator,
     )

--- a/backend/src/nodes/utils/ncnn_session.py
+++ b/backend/src/nodes/utils/ncnn_session.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+from ncnn_vulkan import ncnn
+from weakref import WeakKeyDictionary
+
+from .exec_options import ExecutionOptions
+from .ncnn_model import NcnnModel
+
+
+def create_ncnn_net(model: NcnnModel, exec_options: ExecutionOptions) -> ncnn.Net:
+    net = ncnn.Net()
+
+    # Use vulkan compute
+    net.opt.use_vulkan_compute = True
+    net.set_vulkan_device(exec_options.ncnn_gpu_index)
+
+    # Load model param and bin
+    net.load_param_mem(model.write_param())
+    net.load_model_mem(model.weights_bin)
+
+    # Attribute not needed anymore, save memory
+    model.weights_bin = b""
+
+    return net
+
+
+__session_cache: WeakKeyDictionary[NcnnModel, ncnn.Net] = WeakKeyDictionary()
+
+
+def get_ncnn_net(model: NcnnModel, exec_options: ExecutionOptions) -> ncnn.Net:
+    cached = __session_cache.get(model)
+    if cached is None:
+        cached = create_ncnn_net(model, exec_options)
+        __session_cache[model] = cached
+    return cached


### PR DESCRIPTION
As with the ONNX sessions, we were loading the NCNN model weights from cache to the Net object every time the upscale node was run. This refactor just reuses the ONNX pattern to cache the Net the first time it is loaded, and use that afterwards. I've been getting iterator run times 60-75% as long as pre-fix for smaller images. Also removes the CPU spikes from loading weights to the Net, though does not change high CPU usage for very fast iterator processing with small image/small model combinations.

Also fixed a bug with ncnn_auto_split_process not passing the input and output names when recursing.