### PR TITLE
Moved checkNodeValidity into common

### DIFF
--- a/src/renderer/components/node/NodeFooter/NodeFooter.tsx
+++ b/src/renderer/components/node/NodeFooter/NodeFooter.tsx
@@ -1,8 +1,8 @@
 import { Center, SimpleGrid } from '@chakra-ui/react';
 import { memo } from 'react';
 import { useContextSelector } from 'use-context-selector';
+import { Validity } from '../../../../common/checkNodeValidity';
 import { GlobalVolatileContext } from '../../../contexts/GlobalNodeState';
-import { Validity } from '../../../helpers/checkNodeValidity';
 import { UseDisabled } from '../../../hooks/useDisabled';
 import { DisableToggle } from './DisableToggle';
 import { Timer } from './Timer';

--- a/src/renderer/components/node/NodeFooter/ValidityIndicator.tsx
+++ b/src/renderer/components/node/NodeFooter/ValidityIndicator.tsx
@@ -4,8 +4,8 @@ import { BsCheck, BsExclamation } from 'react-icons/bs';
 import { IoIosPause } from 'react-icons/io';
 import ReactMarkdown from 'react-markdown';
 import { useContext } from 'use-context-selector';
+import { Validity } from '../../../../common/checkNodeValidity';
 import { ExecutionStatusContext } from '../../../contexts/ExecutionContext';
-import { Validity } from '../../../helpers/checkNodeValidity';
 
 interface ValidityIndicatorProps {
     validity: Validity;

--- a/src/renderer/contexts/ExecutionContext.tsx
+++ b/src/renderer/contexts/ExecutionContext.tsx
@@ -3,6 +3,7 @@ import { Edge, Node, useReactFlow } from 'react-flow-renderer';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { createContext, useContext, useContextSelector } from 'use-context-selector';
 import { useThrottledCallback } from 'use-debounce';
+import { checkNodeValidity } from '../../common/checkNodeValidity';
 import {
     EdgeData,
     InputId,
@@ -21,7 +22,7 @@ import {
     parseSourceHandle,
     parseTargetHandle,
 } from '../../common/util';
-import { checkNodeValidity } from '../helpers/checkNodeValidity';
+import { getConnectedInputs } from '../helpers/connectedInputs';
 import { getEffectivelyDisabledNodes } from '../helpers/disabled';
 import { getNodesWithSideEffects } from '../helpers/sideEffect';
 import { useAsyncEffect } from '../hooks/useAsyncEffect';
@@ -390,9 +391,8 @@ export const ExecutionProvider = memo(({ children }: React.PropsWithChildren<{}>
             const schema = schemata.get(node.data.schemaId);
             const { category, name } = schema;
             const validity = checkNodeValidity({
-                id: node.id,
                 inputData: node.data.inputData,
-                edges,
+                connectedInputs: getConnectedInputs(node.id, edges),
                 schema,
                 functionInstance,
             });

--- a/src/renderer/helpers/connectedInputs.ts
+++ b/src/renderer/helpers/connectedInputs.ts
@@ -1,0 +1,13 @@
+import { Edge } from 'react-flow-renderer';
+import { EdgeData, InputId } from '../../common/common-types';
+import { parseTargetHandle } from '../../common/util';
+
+export const getConnectedInputs = (
+    nodeId: string,
+    edges: readonly Edge<EdgeData>[]
+): Set<InputId> => {
+    const targetedInputs = edges
+        .filter((e) => e.target === nodeId && e.targetHandle)
+        .map((e) => parseTargetHandle(e.targetHandle!).inOutId);
+    return new Set(targetedInputs);
+};

--- a/src/renderer/hooks/useValidity.ts
+++ b/src/renderer/hooks/useValidity.ts
@@ -1,14 +1,15 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useReactFlow } from 'react-flow-renderer';
 import { useContextSelector } from 'use-context-selector';
-import { EdgeData, InputData, NodeData, NodeSchema } from '../../common/common-types';
-import { GlobalVolatileContext } from '../contexts/GlobalNodeState';
 import {
     VALID,
     Validity,
     checkNodeValidity,
     checkRequiredInputs,
-} from '../helpers/checkNodeValidity';
+} from '../../common/checkNodeValidity';
+import { EdgeData, InputData, NodeData, NodeSchema } from '../../common/common-types';
+import { GlobalVolatileContext } from '../contexts/GlobalNodeState';
+import { getConnectedInputs } from '../helpers/connectedInputs';
 
 const STARTING_VALIDITY: Validity = {
     isValid: false,
@@ -38,10 +39,9 @@ export const useValidity = (id: string, schema: NodeSchema, inputData: InputData
         if (!alwaysValid) {
             setValidity(
                 checkNodeValidity({
-                    id,
                     schema,
                     inputData,
-                    edges: getEdges(),
+                    connectedInputs: getConnectedInputs(id, getEdges()),
                     functionInstance,
                 })
             );


### PR DESCRIPTION
No functional changes.

I moved the `checkNodeValidity` function into `src/common`. I'll need this function to implement a CLI mode for chainner, so this PR is preparation for that.