### PR TITLE
Fixed black workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-    backend-lint:
+    backend-formatting:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
@@ -31,7 +31,19 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
             - name: Black
-              run: black backend/
+              run: black --check backend/
+    backend-lint:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Set up Python 3.9
+              uses: actions/setup-python@v1
+              with:
+                  python-version: 3.9
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install -r requirements.txt
             - name: pylint
               run: pylint backend/ --output-format=colorized --disable="C,R" --fail-under=10
             - name: pyright

--- a/backend/src/nodes/properties/inputs/image_dropdown_inputs.py
+++ b/backend/src/nodes/properties/inputs/image_dropdown_inputs.py
@@ -130,6 +130,7 @@ def ResizeToSideInput() -> DropDownInput:
         ],
     )
 
+
 def ResizeCondition() -> DropDownInput:
     """Upscale / Downscale condition dropdown"""
     return DropDownInput(
@@ -345,11 +346,11 @@ def CaptionPositionInput() -> DropDownInput:
         options=[
             {
                 "option": "Bottom",
-                "value": 'bottom',
+                "value": "bottom",
             },
             {
                 "option": "Top",
-                "value": 'top',
+                "value": "top",
             },
         ],
     )

--- a/backend/src/nodes/utils/clipboard/__init__.py
+++ b/backend/src/nodes/utils/clipboard/__init__.py
@@ -44,6 +44,7 @@ def copy_image(imageArray: np.ndarray):
         logger.error(err)
         raise err
 
+
 def copy_text(text: str):
     if DEFAULT_CLIPBOARD is None:
         logger.error(ERROR)

--- a/backend/src/nodes/utils/clipboard/clipboard_win32.py
+++ b/backend/src/nodes/utils/clipboard/clipboard_win32.py
@@ -203,7 +203,7 @@ class WindowsClipboard(ClipboardBase):
             raise Exception("win32clipboard is not avaiable!")
 
         if text.isdigit():
-            text = f"{text}\0" # Add null terminator. Without this, the clipboard will throw an error when the input is a number.
+            text = f"{text}\0"  # Add null terminator. Without this, the clipboard will throw an error when the input is a number.
 
         try:
             win32clipboard.OpenClipboard()


### PR DESCRIPTION
I noticed that our black workflow was broken. The problem is that `black backend/` does not check whether files need formatting, it reformats all backend files, which will always succeed. Since I would expect formatting to be a relatively common cause for CI errors, I also put it into its own job, to differentiate linting from formatting.